### PR TITLE
Split org/people page into current and past

### DIFF
--- a/pombola/core/templates/core/organisation_people.html
+++ b/pombola/core/templates/core/organisation_people.html
@@ -8,6 +8,12 @@
 
   <h2>Related People</h2>
 
+  {% if historic %}
+    <p>Showing historic positions (switch to <a href="?historic=">current positions</a>).</p>    
+  {% else %}
+    <p>Showing current positions (switch to <a href="?historic=1">past positions</a>).</p>
+  {% endif %}
+
   <div>
 
     <ul class="listing">

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -264,7 +264,16 @@ class OrganisationDetailSub(DetailView):
         # of an organisation to be controlled with the 'order' query
         # parameter:
         if self.kwargs['sub_page'] == 'people':
-            positions = self.object.position_set.all()
+            all_positions = self.object.position_set.all()
+
+            # Limit to those currently active, or inactive
+            if self.request.GET.get('historic'):
+                context['historic'] = True
+                positions = all_positions.currently_inactive()
+            else:
+                context['historic'] = False
+                positions = all_positions.currently_active()
+
             if self.request.GET.get('order') == 'place':
                 context['sorted_positions'] = positions.order_by_place()
             else:


### PR DESCRIPTION
Closes #697, but with these caveats:
- The duplicate people in the list (see issue) has not been addressed, as the page is actually listing positions. Changing it to be a list of people (which is what it does look like) would need deeper changes.
- The way the query parameter `historic` is added to url will clobber other query parameters. Not an issue atm though.
