### PR TITLE
Change haystack INDEX_NAME when running tests

### DIFF
--- a/pombola/settings.py
+++ b/pombola/settings.py
@@ -340,6 +340,10 @@ HAYSTACK_CONNECTIONS = {
 }
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
+# Use a different elasticsearch index if running in test mode.
+if 'test' in sys.argv:
+    HAYSTACK_CONNECTIONS['default']['INDEX_NAME'] = config.get('POMBOLA_DB_NAME') + '_test'
+
 # Admin autocomplete
 AJAX_LOOKUP_CHANNELS = {
     'person_name'       : dict(model='core.person',        search_field='legal_name'),


### PR DESCRIPTION
This uses the [same technique sayit uses](https://github.com/mysociety/sayit/blob/master/spoke/settings/base.py#L231) for detecting when
we're running tests, however instead of switching to the SimpleEngine,
we're overriding the INDEX_NAME setting by appending '_test' to it.

Originally I did try using the SimpleEngine, but it [caused errors](https://gist.github.com/hecticjeff/11ed0b34b101f87cee3d)
when running the tests. Doing it this way also means our tests run
in an environment that's closer to production.

Closes #915 
