### PR TITLE
Fix broken links in breadcrumbs

### DIFF
--- a/pombola/core/templatetags/breadcrumbs.py
+++ b/pombola/core/templatetags/breadcrumbs.py
@@ -2,16 +2,17 @@
 
 from django.template import Library
 from django.utils.safestring import mark_safe
+from django.core.urlresolvers import resolve, Resolver404
 import re
 
 register = Library()
 
 url_name_mappings = {
-  'info'   : ('Information', '/info'),
-  'organisation' : ('Organisations', '/organisation/all'),
-  'person' : ('Politicians', '/person/all'),
-  'place' : ('Places', '/place/all'),
-  'search' : ('Search', '/search')
+  'info'   : ('Information', '/info/'),
+  'organisation' : ('Organisations', '/organisation/all/'),
+  'person' : ('Politicians', '/person/all/'),
+  'place' : ('Places', '/place/all/'),
+  'search' : ('Search', '/search/')
 }
 
 separator = ' <span class="sep">&raquo;</span> ';
@@ -57,9 +58,14 @@ def breadcrumbs(url):
                 else:
                     sub_link = re.sub('[_\-]', ' ', link).title()
                     sub_link = re.sub('\\bFaq\\b', 'FAQ', sub_link)
-                    this_url = "/".join(bread)
+                    this_url = "/{0}/".format("/".join(bread))
                 if not i == total:
-                    tlink = '<li><a href="%s/" title="Breadcrumb link to %s">%s</a> %s</li>' % (this_url, sub_link, sub_link, separator)
+                    try:
+                        resolve(this_url)
+                        tlink = '<li><a href="%s" title="Breadcrumb link to %s">%s</a> %s</li>' % (this_url, sub_link, sub_link, separator)
+                    except Resolver404:
+                        tlink = '<li>%s %s</li>' % (sub_link, separator)
+
                 else:
                     tlink = '<li>%s</li>' % sub_link
                 home.append(tlink)

--- a/pombola/core/tests/test_templatetags.py
+++ b/pombola/core/tests/test_templatetags.py
@@ -16,8 +16,14 @@ class BreadcrumbTest(TestCase):
         tests = (
             # input, expected output
             ( '/',        '<li>Home</li>'),
-            ( '/foo',     home_li + '<li>Foo</li>'),
-            ( '/foo/bar', home_li + '<li><a href="foo/" title="Breadcrumb link to Foo">Foo</a>  <span class="sep">&raquo;</span> </li><li>Bar</li>'),
+            ( '/organisation',     home_li + '<li>Organisations</li>'),
+            ( '/organisation/bar', home_li + '<li><a href="/organisation/all/" title="Breadcrumb link to Organisations">Organisations</a>  <span class="sep">&raquo;</span> </li><li>Bar</li>'),
+
+            # existing urls that aren't in the mapping should be linked to.
+            ( '/blog/first-post', home_li + '<li><a href="/blog/" title="Breadcrumb link to Blog">Blog</a>  <span class="sep">&raquo;</span> </li><li>First Post</li>'),
+
+            # urls that don't exist shouldn't be linked to.
+            ( '/foo/bar', home_li + '<li>Foo  <span class="sep">&raquo;</span> </li><li>Bar</li>'),
 
             # Test that coordinates are passed through correctly
             # (don't drop '-', put space after ',')


### PR DESCRIPTION
This adds some extra checks to see if the breadcrumb url can be resolved, if it can, then we generate the breadcrumbs as normal. If we can't resolve the url it then we still display the breadcrumb, but we don't make it a link. This fixes pages like http://za-pombola.staging.mysociety.org/place/latlon/-33.925,18.424/ where the **latlon** breadcrumb previously linked to `/place/latlon`, which doesn't exist.

This also solves the problem of some of the breadcrumbs being relative rather than absolute links, which cause 404 errors.

Closes #801 
