### PR TITLE
Issues/965 za duplicates in org people list

### DIFF
--- a/pombola/south_africa/templates/core/organisation_people.html
+++ b/pombola/south_africa/templates/core/organisation_people.html
@@ -16,11 +16,6 @@
         <p><a href="?historic=" class="{% if not request.GET.historic and not request.GET.all %}active{% endif %}">Current members</a></p>
         <p><a href="?historic=1" class="{% if request.GET.historic %}active{% endif %}">Past members</a></p>
         <p><a href="?all=1" class="{% if request.GET.all %}active{% endif %}">All members</a></p>
-
-        <h3>Sort by</h3>
-        <p><a href="?order=name" class="{% if request.GET.order == "name" %}active{% endif %}">Alphabetical</a></p>
-        <p><a href="?order=party" class="{% if request.GET.order == "party" %}active{% endif %}">Party</a></p>
-        <p><a href="?order=place" class="{% if request.GET.order == "place" %}active{% endif %}">Location</a></p>
       </div>
     </div>
 


### PR DESCRIPTION
Closes #965 

Uses `regroup` to pick out the people attached to the positions and then lists the positions relevant to the org under the person's name. This mean that the changes are only at the template level and don't need to change the core code and risk breaking other sites.

Before:

![national_assembly_people____pombola_south_africa](https://f.cloud.github.com/assets/187630/1541317/422763dc-4d33-11e3-834c-c374db681dcb.png)

After:

![national_assembly_people____pombola_south_africa](https://f.cloud.github.com/assets/187630/1541309/1c29c42c-4d33-11e3-9096-f9b6ad8cee21.png)

Various other features of the page removed:
- count of people in each of the "Current members" etc links as they are now dependent on the regroup being done.
- removed sorting options as display may not show the thing being sorted on, and the sorts didn't really make any sense.
