### PR TITLE
Don’t show places on these pages - redundant info

### DIFF
--- a/pombola/south_africa/templates/core/person_list_item.html
+++ b/pombola/south_africa/templates/core/person_list_item.html
@@ -10,18 +10,20 @@
     <span class="name">{{ object.name }}</span>
 </a>
 
-{% for position in object.position_set.all.currently_active %}
-{% if position.place %}
-<div class="position-place">
-    <a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>
+{% if not skip_positions %}
+  {% for position in object.position_set.all.currently_active %}
+    {% if position.place %}
+      <div class="position-place">
+        <a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>
 
-    {% if position.place.parent_place %}
-    <a href="{{ position.place.parent_place.get_absolute_url }}">{{ position.place.parent_place.name }}</a>
-    {{ position.place.parent_place.kind.name }}
+        {% if position.place.parent_place %}
+          <a href="{{ position.place.parent_place.get_absolute_url }}">{{ position.place.parent_place.name }}</a>
+          {{ position.place.parent_place.kind.name }}
+        {% endif %}
+      </div>
     {% endif %}
-</div>
+  {% endfor %}
 {% endif %}
-{% endfor %}
 
 {% if object.parties %}
 <div class="position-parties">

--- a/pombola/south_africa/templates/core/place_detail.html
+++ b/pombola/south_africa/templates/core/place_detail.html
@@ -43,30 +43,30 @@
     <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#national-assembly-people">Members of the National Assembly ({{ national_assembly_people_count }})</a>
 
     <div id="national-assembly-people" class="person-panel js-hide-reveal">
-        {% include "core/_people_listing.html" with people=national_assembly_people %}
+        {% include "core/_people_listing.html" with people=national_assembly_people skip_positions=1 %}
         {% if former_national_assembly_people %}
         <p>Former members</p>
-        {% include "core/_people_listing.html" with people=former_national_assembly_people %}
+        {% include "core/_people_listing.html" with people=former_national_assembly_people skip_positions=1 %}
         {% endif %}
     </div>
 
     <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#ncop-people">Members of the National Council of Provinces ({{ ncop_people_count }})</a>
 
     <div id="ncop-people" class="person-panel js-hide-reveal">
-        {% include "core/_people_listing.html" with people=ncop_people %}
+        {% include "core/_people_listing.html" with people=ncop_people skip_positions=1 %}
         {% if former_ncop_people %}
         <p>Former members</p>
-        {% include "core/_people_listing.html" with people=former_ncop_people %}
+        {% include "core/_people_listing.html" with people=former_ncop_people skip_positions=1 %}
         {% endif %}
     </div>
 
     <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#provinicial-legislature-people">Members of the Provincial Legislature ({{ legislature_people_count }})</a>
 
     <div id="provinicial-legislature-people" class="person-panel js-hide-reveal">
-        {% include "core/_people_listing.html" with people=legislature_people %}
+        {% include "core/_people_listing.html" with people=legislature_people skip_positions=1 %}
         {% if former_legislature_people %}
         <p>Former members</p>
-        {% include "core/_people_listing.html" with people=former_legislature_people %}
+        {% include "core/_people_listing.html" with people=former_legislature_people skip_positions=1 %}
         {% endif %}
     </div>
 
@@ -74,7 +74,7 @@
     <p><a class="js-hide-reveal-link" href="#other-people">Other people ({{ other_people.count }})</a></p>
 
     <div id="other-people" class="person-panel js-hide-reveal">
-        {% include "core/_people_listing.html" with people=other_people %}
+        {% include "core/_people_listing.html" with people=other_people skip_positions=1 %}
     </div>
     {% endif %}
 


### PR DESCRIPTION
Closes #976 

Approach is just to hide the place names as for this page they add no value (as page is for a place, and heading describes the position they hold). Problem was that for each person all current positions were being listed but only the place name displayed, which was misleading.
