### PR TITLE
Fix #1015 change nav bar blog link "Impressions"

### DIFF
--- a/pombola/south_africa/templates/menu_entries.html
+++ b/pombola/south_africa/templates/menu_entries.html
@@ -46,7 +46,7 @@
       <li><a href="{% url 'info_blog_list' %}">Recent Posts</a></li>
       <li><a href="{% url 'info_blog_category' slug='mp-corner' %}">MP Corner</a></li>
       <li><a href="{% url 'info_blog_category' slug='ngo-articles' %}">NGO articles</a></li>
-      <li><a href="{% url 'info_blog_category' slug='pmg-blog-monitor-snippets' %}">PMG Monitor Blog Snippets</a></li>
+      <li><a href="{% url 'info_blog_category' slug='impressions' %}">IMPRESSIONS</a></li>
       <li><a href="{% url 'info_blog_category' slug='week-parliament' %}">That Week In Parliament</a></li>
       <li><a href="{% url 'info_blog_category' slug='thought-pieces' %}">Thought Pieces/Commentary</a></li>
     </ul>


### PR DESCRIPTION
Have also changed the slug to 'impressions', which may require the
category to be created/renamed.
