### PR TITLE
Don’t show the “All Blah Appearances” links if there are none.

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -94,7 +94,9 @@ pombola_settings.extra_js.push('js/tabs.js')
     <section class="person-appearances">
       <h3>Plenary appearances</h3>
 
-      <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='hansard' %}">All Plenary Appearances</a></p>
+      {% if hansard.count %}
+        <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='hansard' %}">All Plenary Appearances</a></p>
+      {% endif %}
 
       {% include "core/person_speech_list.html" with speechlist=hansard section_url='hansard:section-view' %}
     </section>
@@ -102,7 +104,9 @@ pombola_settings.extra_js.push('js/tabs.js')
     <section class="person-appearances">
       <h3>Committee appearances</h3>
 
-      <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='committee' %}">All Committee Appearances</a></p>
+      {% if committee.count %}
+        <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='committee' %}">All Committee Appearances</a></p>
+      {% endif %}
 
       {% include "core/person_speech_list.html" with speechlist=committee section_url='committee:section-view' %}
     </section>
@@ -110,7 +114,9 @@ pombola_settings.extra_js.push('js/tabs.js')
     <section class="person-appearances">
       <h3>Questions </h3>
 
-      <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='question' %}">All Questions and Answers</a></p>
+      {% if question.count %}
+        <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='question' %}">All Questions and Answers</a></p>
+      {% endif %}
 
       {% include "core/person_speech_list.html" with speechlist=question section_url='question:section-view' parent_title=1 %}
     </section>


### PR DESCRIPTION
Closes #992 

Rather than hide the whole section just hide the "All .... Appearances" link:

![agnes_noluthando_daphne_qikani____pombola_south_africa](https://f.cloud.github.com/assets/187630/1613958/2e045eac-55e2-11e3-9ca0-61c918361749.png)
