### PR TITLE
Issues/1041 reorder appearances

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -92,16 +92,6 @@ pombola_settings.extra_js.push('js/tabs.js')
     <h2>Appearances</h2>
 
     <section class="person-appearances">
-      <h3>Plenary appearances</h3>
-
-      {% if hansard.count %}
-        <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='hansard' %}">All Plenary Appearances</a></p>
-      {% endif %}
-
-      {% include "core/person_speech_list.html" with speechlist=hansard section_url='hansard:section-view' %}
-    </section>
-
-    <section class="person-appearances">
       <h3>Committee appearances</h3>
 
       {% if committee.count %}
@@ -109,6 +99,16 @@ pombola_settings.extra_js.push('js/tabs.js')
       {% endif %}
 
       {% include "core/person_speech_list.html" with speechlist=committee section_url='committee:section-view' %}
+    </section>
+
+    <section class="person-appearances">
+      <h3>Plenary appearances</h3>
+
+      {% if hansard.count %}
+        <p><a href="{% url 'sa-person-appearance' person_slug=object.slug speech_tag='hansard' %}">All Plenary Appearances</a></p>
+      {% endif %}
+
+      {% include "core/person_speech_list.html" with speechlist=hansard section_url='hansard:section-view' %}
     </section>
 
     <section class="person-appearances">


### PR DESCRIPTION
Fixes #1041 

Merges in @evdb's PR for #992 to hopefully preempt conflict resolution.

This simply reorders Committee appearances above Plenary (e.g. /hansard/) on the person detail page.
