### PR TITLE
ZA use sayit functionality from master #1027

### DIFF
--- a/pombola/south_africa/templates/core/person_speech_list.html
+++ b/pombola/south_africa/templates/core/person_speech_list.html
@@ -19,7 +19,7 @@
     <li>
         <p>
             <span class="speech-title">
-                <a href="{% url section_url|default:'speeches:section-view' speech.section_id %}#s{{ speech.id }}">
+                <a href="{% url section_url|default:'speeches:section-view' speech.section.get_path %}#s{{ speech.id }}">
                     {% if parent_title %}
                         {{ speech.section.parent.title }}
                     {% else %}

--- a/pombola/south_africa/templates/south_africa/hansard_index.html
+++ b/pombola/south_africa/templates/south_africa/hansard_index.html
@@ -31,7 +31,7 @@
         <div class="js-hide-reveal hansard-section" id="{{ t.grouper|slugify }}">
             {% for item in t.list %}
             <p>
-                <a href="{% url 'speeches:section-view' item.section.id %}">{{ item.section.title }}</a>
+                <a href="{% url 'speeches:section-view' item.section.get_path %}">{{ item.section.title }}</a>
                 ({{ item.speech_count }})
             </p>
             {% endfor %}

--- a/pombola/south_africa/templates/speeches/_breadcrumbs.html
+++ b/pombola/south_africa/templates/speeches/_breadcrumbs.html
@@ -10,7 +10,7 @@
                 {% if forloop.counter == 1 %}
                     <li><a href="{% url 'speeches:section-list' %}">{{ n.title }}</a> 
                 {% else %}
-                    <li><a href="{% url 'speeches:section-view' n.id %}">{{ n.title }}</a> 
+                    <li><a href="{% url 'speeches:section-view' n.get_path %}">{{ n.title }}</a> 
                 {% endif %}
             {% endif %}
         {% endfor %}

--- a/pombola/south_africa/templates/speeches/section_detail.html
+++ b/pombola/south_africa/templates/speeches/section_detail.html
@@ -23,10 +23,10 @@
   {% if previous or next %}
     <ul class="pager">
       {% if previous %}
-        <li class="previous"><a href="{% url "speeches:section-view" previous.id %}">&larr; {{ previous.title }}</a>
+        <li class="previous"><a href="{% url "speeches:section-view" previous.get_path %}">&larr; {{ previous.title }}</a>
       {% endif %}
       {% if next %}
-        <li class="next"><a href="{% url "speeches:section-view" next.id %}">{{ next.title }} &rarr;</a>
+        <li class="next"><a href="{% url "speeches:section-view" next.get_path %}">{{ next.title }} &rarr;</a>
       {% endif %}
     </ul>
   {% endif %}
@@ -38,7 +38,7 @@
         <li id="s{{ node.id }}" class="speech speech-border"{% if node.speaker.colour %} style="border-left-color: #{{ node.speaker.colour }};"{% endif %}>
         {% include "speeches/speech.html" with speech=node nosection="1" noli=1 %}
       {% else %}
-        <li><span class="section-title"><a href="{% url 'speeches:section-view' node.id %}">{{ node.title }}</a></span>
+        <li><span class="section-title"><a href="{% url 'speeches:section-view' node.get_path %}">{{ node.title }}</a></span>
         {% if node.is_leaf_node %}({{ node.speech_count }}){% endif %}
       {% endif %}
       {% for level in structure.closed_levels %}</li></ul>{% endfor %}
@@ -48,10 +48,10 @@
   {% if previous or next %}
     <ul class="pager">
       {% if previous %}
-        <li class="previous"><a href="{% url "speeches:section-view" previous.id %}">&larr; {{ previous.title }}</a>
+        <li class="previous"><a href="{% url "speeches:section-view" previous.get_path %}">&larr; {{ previous.title }}</a>
       {% endif %}
       {% if next %}
-        <li class="next"><a href="{% url "speeches:section-view" next.id %}">{{ next.title }} &rarr;</a>
+        <li class="next"><a href="{% url "speeches:section-view" next.get_path %}">{{ next.title }} &rarr;</a>
       {% endif %}
     </ul>
   {% endif %}

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -61,36 +61,51 @@ urlpatterns += patterns('pombola.south_africa.views',
 sayit_patterns = patterns('',
 
     # Exposed endpoints
-    url(r'^(?P<pk>\d+)$',        SectionView.as_view(), name='section-view'),
+    url(r'^(?P<pk>\d+)$',        SectionView.as_view(), name='section-id-view'),
     url(r'^speech/(?P<pk>\d+)$', SpeechView.as_view(),  name='speech-view'),
 
     # Fake endpoint to redirect
+    # has to be added here for all of the sub-systems
     url(r'^speaker/(?P<pk>\d+)$', SASpeakerRedirectView.as_view(), name='speaker-view'),
+
+    # note that the full slug pattern is added later!
+)
+
+sayit_slug_pattern = patterns('',
+    url(r'^(?P<full_slug>.+)$', SectionView.as_view(), name='section-view'),
 )
 
 hansard_patterns = sayit_patterns + patterns('',
     # special Hansard index page that provides listing of the hansard sessions that contain speeches.
     url(r'^$', SAHansardIndex.as_view(), name='section-list'),
-)
+) + sayit_slug_pattern
 
 committee_patterns = patterns('',
     # Exposed endpoints
-    url(r'^(?P<pk>\d+)$',        SACommitteeSectionRedirectView.as_view(), name='section-view'),
     url(r'^speech/(?P<pk>\d+)$', SACommitteeSpeechRedirectView.as_view(),  name='speech-view'),
 
-    # Fake endpoint to redirect
-    url(r'^speaker/(?P<pk>\d+)$', SASpeakerRedirectView.as_view(), name='speaker-view'),
-
     url(r'^$', SACommitteeIndex.as_view(), name='section-list'),
+
+    # we don't include sayit_slug_pattern as we want to customize it
+    url(r'^(?P<full_slug>.+)$',  SACommitteeSectionRedirectView.as_view(), name='section-view'),
 )
 
 question_patterns = sayit_patterns + patterns('',
     # special Hansard index page that provides listing of the hansard sessions that contain speeches.
     url(r'^$', SAQuestionIndex.as_view(), name='section-list'),
-)
+) + sayit_slug_pattern
 
 urlpatterns += patterns('',
+
+    # these handle the top-level pages, and individual speeches
     url(r'^hansard/',   include(hansard_patterns,   namespace='hansard',   app_name='speeches')),
     url(r'^committee/', include(committee_patterns, namespace='committee', app_name='speeches')),
     url(r'^question/',  include(question_patterns,  namespace='question',  app_name='speeches')),
+
+    ## TODO: Would be nice to include slug patterns here at top level instead,
+    ##       but the following doesn't work? HC
+    # url(r'', include(
+    #    patterns('', 
+    #        url(r'^(?P<full_slug>/.+)$', SectionView.as_view(), name='section-view'),
+    #    ), namespace='hansard', app_name='speeches')),
 )

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -22,7 +22,7 @@ from haystack.forms import SearchForm
 
 from popit.models import Person as PopitPerson
 from speeches.models import Section, Speech, Speaker, Tag
-from speeches.views import NamespaceMixin
+from speeches.views import NamespaceMixin, SectionView
 
 from pombola.core import models
 from pombola.core.views import PlaceDetailView, PlaceDetailSub, \
@@ -428,12 +428,11 @@ class SACommitteeSpeechRedirectView(RedirectView):
 
         raise Http404("No source URL for this content")
 
-class SACommitteeSectionRedirectView(RedirectView):
+class SACommitteeSectionRedirectView(RedirectView, SectionView):
 
     def get_redirect_url(self, **kwargs):
         try:
-            id = int( kwargs['pk'] )
-            section = Section.objects.get( id=id )
+            section = self.get_object()
             for speech in section.speech_set.all():
                 source_url = speech.source_url
                 if source_url:

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ git+git://github.com/mysociety/mapit.git@master#egg=django-mapit
 # remain and take precedence over other install methods. Adding a 'rm' line to
 # the prepare_environment script in the same commit as changing the line here is
 # one possible approach.
--e git+git://github.com/mysociety/sayit.git@pombola#egg=django-sayit  # NOTE - when changing remember to remove the repo from virtualenv!
+-e git+git://github.com/mysociety/sayit.git@master#egg=django-sayit  # NOTE - when changing remember to remove the repo from virtualenv!
 -e git+git://github.com/mysociety/za-hansard.git@master#egg=za_hansard  # NOTE - when changing remember to remove the repo from virtualenv!
 -e git+git://github.com/mysociety/popit-resolver@master#egg=popit-resolver  # NOTE - when changing remember to remove the repo from virtualenv!
 -e git+git://github.com/mysociety/popit-django@master#egg=popit-django  # NOTE - when changing remember to remove the repo from virtualenv!


### PR DESCRIPTION
Point section-view urls to <full_slug> type ones.  This leads to urls
like

```
/hansard/hansard/2013/05/08/proceedings-of-the-national-assembly-wednesday-08/appropriation-bill
```

where the repetition of /hansard is a little jarring.  I've not been able to get this to work mounted at the top-level however.

The Committee-specific redirect now inherits from SectionView in order to take advantage of its .get_object() parsing.
