### PR TITLE
Change blog categories list to be in ALL CAPS for ZA. Closes #1096

### DIFF
--- a/pombola/core/static/css/south-africa.css
+++ b/pombola/core/static/css/south-africa.css
@@ -4870,6 +4870,10 @@ ul.pager li.next {
   margin-bottom: 2em;
 }
 
+.sidebar .blog-categories li {
+  text-transform: uppercase;
+}
+
 /* Error and status pages */
 .error #page {
   padding: 0;

--- a/pombola/core/static/sass/_south-africa_overrides.scss
+++ b/pombola/core/static/sass/_south-africa_overrides.scss
@@ -1813,6 +1813,12 @@ ul.pager {
     }
 }
 
+.sidebar .blog-categories {
+  li {
+    text-transform:uppercase;
+  }
+}
+
 /* Error and status pages */
 
 .error {

--- a/pombola/south_africa/templates/info/_blog_sidebar.html
+++ b/pombola/south_africa/templates/info/_blog_sidebar.html
@@ -18,7 +18,7 @@
 
     <h3>Categories</h3>
 
-    <ul>
+    <ul class="blog-categories">
       {% for category in all_categories %}
         <li><a href="{% url 'info_blog_category' slug=category.slug %}">{{ category.name }}</a></li>
       {% empty %}


### PR DESCRIPTION
Closes #1096 

Produces a menu that looks like this:

![blog_posts____pombola_south_africa-4](https://f.cloud.github.com/assets/187630/1741865/ec891120-63ec-11e3-96ef-9eac89411b65.png)

As it happens it would also be possible to produce small caps using:

``` CSS
font-variant:small-caps;
```

![blog_posts____pombola_south_africa-3](https://f.cloud.github.com/assets/187630/1741863/d6dba22a-63ec-11e3-9d05-413639aa14dd.png)
