### PR TITLE
Don’t produce link on search page to geocoder search for any site other ...

### DIFF
--- a/pombola/search/templates/search/search_base.html
+++ b/pombola/search/templates/search/search_base.html
@@ -17,24 +17,35 @@
     {% endblock %}
 
     <form method="get" action="." class="search-wrap">
+      {% if settings.COUNTRY_APP == 'south_africa' or settings.ENABLED_FEATURES.hansard %}
         <p>
           Alternatively search
-          {% block alternative_search %}
-          <a href="{% url "core_geocoder_search" %}">for a location</a>
-          {% endblock %}
-          {% if settings.ENABLED_FEATURES.hansard %}
-            or <a href="{% url "hansard_search"  %}" id="search-hansard-instead">Hansard transcripts</a>
+
+          {% if settings.COUNTRY_APP == 'south_africa' %}
+            {% block alternative_search %}
+              <a href="{% url "core_geocoder_search" %}">for a location</a>
+            {% endblock %}
           {% endif %}
+
+          {% if settings.COUNTRY_APP == 'south_africa' and settings.ENABLED_FEATURES.hansard %}
+            or
+          {% endif %}
+
+          {% if settings.ENABLED_FEATURES.hansard %}
+            <a href="{% url "hansard_search"  %}" id="search-hansard-instead">Hansard transcripts</a>
+          {% endif %}
+
           instead.
         </p>
-        
+      {% endif %}
+
         <div class="search-box">
           {% block search_form %}
             {{ form.q }}
           {% endblock %}
             <input type="submit" value="Search" class="button">
         </div>
-        
+
         {% if query %}
 
             <h3>Results</h3>


### PR DESCRIPTION
...than south_africa.

This is rather inelegant as the core templates should not need to do logic on behalf of the contry specific installs, hopefully can be cleaned up later when a better structure for Pombola is decided on.
