### PR TITLE
Don't link to a rendering of a partial template

### DIFF
--- a/pombola/hansard/templates/hansard/person_summary.html
+++ b/pombola/hansard/templates/hansard/person_summary.html
@@ -12,7 +12,7 @@
 
 <h2>Parliamentary appearances</h2>
 
-<p>{{ person.name }} has <a href='{% url "hansard:person_summary" slug=person.slug %}'>spoken {{ entry_count }} times</a> in Parliament.</p>
+<p>{{ person.name }} has spoken {{ entry_count }} times in Parliament.</p>
 
 <h3>Recent Appearances</h3>
 


### PR DESCRIPTION
It was the case that in Mzalendo, for example, there was a link from
the "has spoken N times" text on:

  /person/whoever/appearances/

... to:

  /hansard/person/whoever/summary/

But the latter just renders the partial template which was on the former
page anyway.  Ideally one would want to have that link to a page with
all appareances, but whether that's worth doing partly depends on how
imminently we will be replacing the hansard app with SayIt.

This commit just removes that link, since it doesn't add anything, and
links to a bad page, pending one of the two better solutions above being
done.  Fixes #1126.
