### PR TITLE
Fix autocompletion on the admin's hansard alias page

### DIFF
--- a/pombola/admin_additions/templates/admin/base_site.html
+++ b/pombola/admin_additions/templates/admin/base_site.html
@@ -18,10 +18,22 @@
     {% endcomment %}
 
     {% comment %}
-      'jQuery' and '$' at this point are jQuery v2.0.3 which is loaded by the
-      markdown plugin. Django's own jQuery (v1.6.4) is available as
-      django.jQuery.
+      On pages that use the MarkItUpWidget from django-markitup,
+      'jQuery' and '$' at this point will be jQuery v2.0.3,
+      which is loaded by the markdown plugin. That version
+      doesn't work with the autocomplete plugin, however, which
+      needs an earlier version. Django's own jQuery (v1.6.4) is
+      available as django.jQuery, but that version is too old
+      for the AJAX libraries. So, this condition looks to see
+      whether the Javascript for MarkItUp! would have been
+      added, and if not, loads a version of jQuery that it known
+      to work with django-autocomplete-light and
+      django-ajax-selects.
     {% endcomment %}
+
+    {% if 'markitup' not in media|stringformat:"s" %}
+    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.js"></script>
+    {% endif %}
 
     <!-- for the admin autocomplete -->
     <script type="text/javascript">//<![CDATA[


### PR DESCRIPTION
In the Django admin, jQuery is loaded by default but renamed to
django.jQuery, a name that isn't expected by the autocomplete plugin.
jQuery (as its default names) is also loaded on any page that contains
a MarkItUpWidget, but there's no such widget on the page for editing
hansard alias, so autocompletion fails due to the absence of jQuery.

This commit changes the admin pages to include a working version of
jQuery if 'markitup' isn't contained in the string representation of
the media object in the template context.

An alternative fix would be to switch to using a Javascript library
such as RequireJS to load jQuery on demand if it wasn't already
loaded; it would be worth considering using such a system in the future
to make it easier to manage these complex dependencies and version
incompatabilities.

Fixes #1134.
