### PR TITLE
Change table padding and header colours

### DIFF
--- a/pombola/core/static/css/kenya.css
+++ b/pombola/core/static/css/kenya.css
@@ -3104,16 +3104,26 @@ h2 a.appearances-trigger.active {
   background: #009245;
   height: 2px;
 }
-.infopage th {
-  font-weight: bold;
+.infopage table {
+  border: 2px solid #e6e6e6;
 }
 .infopage th, .infopage td {
-  padding: 0.25em;
-  border-bottom: 1px solid #e6e6e6;
-  border-right: 1px solid #e6e6e6;
+  padding: 0.5em 1em;
+  border-width: 0;
+  border-right-width: 1px;
+  border-style: solid;
+  border-color: #e6e6e6;
 }
 .infopage th:last-child, .infopage td:last-child {
   border-right: none;
+}
+.infopage th {
+  font-weight: bold;
+  background-color: #f7f7f7;
+  border-bottom-width: 2px;
+}
+.infopage td {
+  border-bottom-width: 1px;
 }
 .infopage tr:last-child td {
   border-bottom: none;

--- a/pombola/core/static/css/libya.css
+++ b/pombola/core/static/css/libya.css
@@ -3068,16 +3068,26 @@ h2 a.appearances-trigger.active {
   background: #239e46;
   height: 2px;
 }
-.infopage th {
-  font-weight: bold;
+.infopage table {
+  border: 2px solid #e6e6e6;
 }
 .infopage th, .infopage td {
-  padding: 0.25em;
-  border-bottom: 1px solid #e6e6e6;
-  border-right: 1px solid #e6e6e6;
+  padding: 0.5em 1em;
+  border-width: 0;
+  border-right-width: 1px;
+  border-style: solid;
+  border-color: #e6e6e6;
 }
 .infopage th:last-child, .infopage td:last-child {
   border-right: none;
+}
+.infopage th {
+  font-weight: bold;
+  background-color: #f7f7f7;
+  border-bottom-width: 2px;
+}
+.infopage td {
+  border-bottom-width: 1px;
 }
 .infopage tr:last-child td {
   border-bottom: none;

--- a/pombola/core/static/css/nigeria.css
+++ b/pombola/core/static/css/nigeria.css
@@ -3068,16 +3068,26 @@ h2 a.appearances-trigger.active {
   background: #55a4da;
   height: 2px;
 }
-.infopage th {
-  font-weight: bold;
+.infopage table {
+  border: 2px solid #e6e6e6;
 }
 .infopage th, .infopage td {
-  padding: 0.25em;
-  border-bottom: 1px solid #e6e6e6;
-  border-right: 1px solid #e6e6e6;
+  padding: 0.5em 1em;
+  border-width: 0;
+  border-right-width: 1px;
+  border-style: solid;
+  border-color: #e6e6e6;
 }
 .infopage th:last-child, .infopage td:last-child {
   border-right: none;
+}
+.infopage th {
+  font-weight: bold;
+  background-color: #f7f7f7;
+  border-bottom-width: 2px;
+}
+.infopage td {
+  border-bottom-width: 1px;
 }
 .infopage tr:last-child td {
   border-bottom: none;

--- a/pombola/core/static/css/south-africa.css
+++ b/pombola/core/static/css/south-africa.css
@@ -3068,16 +3068,26 @@ h2 a.appearances-trigger.active {
   background: #e23d28;
   height: 2px;
 }
-.infopage th {
-  font-weight: bold;
+.infopage table {
+  border: 2px solid #e6e6e6;
 }
 .infopage th, .infopage td {
-  padding: 0.25em;
-  border-bottom: 1px solid #e6e6e6;
-  border-right: 1px solid #e6e6e6;
+  padding: 0.5em 1em;
+  border-width: 0;
+  border-right-width: 1px;
+  border-style: solid;
+  border-color: #e6e6e6;
 }
 .infopage th:last-child, .infopage td:last-child {
   border-right: none;
+}
+.infopage th {
+  font-weight: bold;
+  background-color: #f7f7f7;
+  border-bottom-width: 2px;
+}
+.infopage td {
+  border-bottom-width: 1px;
 }
 .infopage tr:last-child td {
   border-bottom: none;

--- a/pombola/core/static/css/zimbabwe.css
+++ b/pombola/core/static/css/zimbabwe.css
@@ -3068,16 +3068,26 @@ h2 a.appearances-trigger.active {
   background: #009245;
   height: 2px;
 }
-.infopage th {
-  font-weight: bold;
+.infopage table {
+  border: 2px solid #e6e6e6;
 }
 .infopage th, .infopage td {
-  padding: 0.25em;
-  border-bottom: 1px solid #e6e6e6;
-  border-right: 1px solid #e6e6e6;
+  padding: 0.5em 1em;
+  border-width: 0;
+  border-right-width: 1px;
+  border-style: solid;
+  border-color: #e6e6e6;
 }
 .infopage th:last-child, .infopage td:last-child {
   border-right: none;
+}
+.infopage th {
+  font-weight: bold;
+  background-color: #f7f7f7;
+  border-bottom-width: 2px;
+}
+.infopage td {
+  border-bottom-width: 1px;
 }
 .infopage tr:last-child td {
   border-bottom: none;

--- a/pombola/core/static/sass/_info_pages.scss
+++ b/pombola/core/static/sass/_info_pages.scss
@@ -18,14 +18,23 @@
     border: none;
     background: $colour_primary;
     height: 2px; }
-  th {
-    font-weight: bold; }
+  table {
+    border: 2px solid $colour_muted;
+  }
   th, td {
-    padding: 0.25em;
-    border-bottom: 1px solid $colour_muted;
-    border-right:  1px solid $colour_muted;
+    padding: 0.5em 1em;
+    border-width: 0;
+    border-right-width: 1px;
+    border-style:  solid;
+    border-color:  $colour_muted;
     &:last-child {
       border-right: none; } }
+  th {
+    font-weight: bold;
+    background-color: $colour_lighter_grey;
+    border-bottom-width: 2px; }
+  td {
+    border-bottom-width: 1px; }
   tr:last-child td {
     border-bottom: none; } }
 


### PR DESCRIPTION
Closes #1130 

Before:

![local_government_elections____shineyoureye-2](https://f.cloud.github.com/assets/187630/1940138/53f66d22-7f71-11e3-9aa0-d5f959e87b6a.png)

After:

![table_test____shineyoureye-5](https://f.cloud.github.com/assets/187630/1940144/6a91f038-7f71-11e3-9faa-4a0f559302c6.png)

This change applies to all tables created in markdown for all countries as it is probably the desired behaviour.
