### PR TITLE
Add django-debug-toolbar to help with local development

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -134,3 +134,4 @@ BREADCRUMB_URL_NAME_MAPPINGS:
         - Search
         - /search/
 
+DEBUG_TOOLBAR: True

--- a/pombola/settings.py
+++ b/pombola/settings.py
@@ -202,6 +202,8 @@ MIDDLEWARE_CLASSES = (
 )
 if 'speeches' in OPTIONAL_APPS:
     MIDDLEWARE_CLASSES += ( 'pombola.middleware.FakeInstanceMiddleware', )
+if config.get('DEBUG_TOOLBAR', True):
+    MIDDLEWARE_CLASSES += ( 'debug_toolbar.middleware.DebugToolbarMiddleware', )
 
 ROOT_URLCONF = 'pombola.urls'
 
@@ -267,6 +269,8 @@ INSTALLED_APPS = (
     'pombola.file_archive',
     'pombola.map',
 )
+if config.get('DEBUG_TOOLBAR', True):
+    INSTALLED_APPS += ('debug_toolbar',)
 INSTALLED_APPS += OPTIONAL_APPS
 
 # mapit related settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,9 @@ git+git://github.com/mysociety/mapit.git@master#egg=django-mapit
 
 python-dateutil>=1.5,!=2.0
 
+# Packages that are helpful for development:
 coverage>=3
+django-debug-toolbar
 
 ## votematch
 django-model-utils


### PR DESCRIPTION
See #888 

This commit adds the very helpful django-debug-toolbar plugin, which
is enabled by default when DEBUG is True and you're connecting to
the server at localhost.  Matthew Somerville pointed out that the
toolbar can cause page loads to be very slow when you have many
templates used on a single page, so (similarly to SayIt) I've added
a DEBUG_TOOLBAR option in general.yml-example, defaulting to True
which you can change to False to disable it.

This commit doesn't set INTERNAL_IPS, leaving it at the default
value of (), so the toolbar uses '127.0.0.1' and '::1'.  If someone
in the future is keen to use this on their development host, for
example, they can add a config option to set INTERNAL_IPS.  However,
so much information is revealed by the toolbar that this shouldn't
be done without careful consideration.
