### PR TITLE
Changes to organisation views

### DIFF
--- a/pombola/south_africa/templates/core/organisation_party.html
+++ b/pombola/south_africa/templates/core/organisation_party.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+{% load pagination_tags %}
+{% load thumbnail %}
+
+
+{% block title %}{{ object.name }} {{ party.slug.upper }} members{% endblock %}
+
+{% block content %}
+
+  <h2>{{ party.name }} members of the {{ object.name }}</h2>
+  <div class="layout layout-major-minor">
+
+    <div class="column minor-column">
+      <div class="filters sidebar">
+        <h3>Show</h3>
+        <p><a href="?historic=" class="{% if not request.GET.historic and not request.GET.office and not request.GET.all %}active{% endif %}">Current members</a></p>
+        <p><a href="?historic=1" class="{% if request.GET.historic %}active{% endif %}">Past members</a></p>
+
+        {% if object.slug == 'national-assembly' %}
+          {% comment %}
+            Exclude for now - need to decide how to handle past office bearers, etc. TODO - fix.
+            <p><a href="?office=1" class="{% if request.GET.office %}active{% endif %}">Office bearers</a></p>
+          {% endcomment %}
+        {% endif %}
+        <p><a href="?all=1" class="{% if request.GET.all %}active{% endif %}">All members</a></p>
+
+        {% comment %}
+            Exclude. All NCOP members are delegates? TODO - fix.
+        {% if object.slug == 'ncop' %}
+          <p><a href="?delegates=1" class="{% if request.GET.delegate %}active{% endif %}">Delegates</a></p>
+        {% endif %}
+        {% endcomment %}
+
+
+      </div>
+    </div>
+
+    {% regroup sorted_positions by person as regroup_on_person_list %}
+
+    <div class="column major-column">
+      <div class="list-of-things list-of-people">
+          {% autopaginate regroup_on_person_list %}
+
+          <ul class="unstyled-list">
+          {% for regroup_item in regroup_on_person_list %}
+              {% with person=regroup_item.grouper positions=regroup_item.list %}
+
+                <li class="list-of-things-item {{ person.css_class }}-list-item{% if not person.show_active %} inactive{% endif %}">
+
+                  <a href="{{ person.get_absolute_url }}">
+                      {% thumbnail person.primary_image "58x78" crop="center" as im %}
+                      <img src="{{ im.url }}" alt="{{ person.name }}" width="{{ im.width }}" height="{{ im.height }}" />
+                      {% empty %}
+                      <img src="{{STATIC_URL}}images/person-90x90.jpg" height="58" width="58"/>
+                      {% endthumbnail %}
+
+                      <span class="name">{{ person.name }}</span>
+                  </a>
+
+                  {% for position in positions %}
+                      {{ position.title }}
+                      {% if position.place %}
+                          (<a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>)
+                      {% endif %}
+                      <br/>
+                  {% endfor %}
+
+                </li>
+
+              {% endwith %}
+          {% empty %}
+              <li>No records found.</li>
+          {% endfor %}
+          </ul>
+
+          {# pombola/south_africa/templates/core/_search_pagination_text.html #}
+          {% include "core/_search_pagination_text.html" %}
+
+          {% paginate %}
+      </div>
+    </div>
+  </div>
+
+{% endblock content %}

--- a/pombola/south_africa/templates/core/place_detail.html
+++ b/pombola/south_africa/templates/core/place_detail.html
@@ -48,6 +48,16 @@
 
 
 
+    <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#provinicial-legislature-people">Members of the Provincial Legislature ({{ legislature_people_count }})</a>
+
+    <div id="provinicial-legislature-people" class="person-panel js-hide-reveal">
+        {% include "core/_people_listing.html" with people=legislature_people skip_positions=1 %}
+        {% if former_legislature_people %}
+        <p>Former members</p>
+        {% include "core/_people_listing.html" with people=former_legislature_people skip_positions=1 %}
+        {% endif %}
+    </div>
+    
     <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#national-assembly-people">Members of the National Assembly ({{ national_assembly_people_count }})</a>
 
     <div id="national-assembly-people" class="person-panel js-hide-reveal">
@@ -65,16 +75,6 @@
         {% if former_ncop_people %}
         <p>Former members</p>
         {% include "core/_people_listing.html" with people=former_ncop_people skip_positions=1 %}
-        {% endif %}
-    </div>
-
-    <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#provinicial-legislature-people">Members of the Provincial Legislature ({{ legislature_people_count }})</a>
-
-    <div id="provinicial-legislature-people" class="person-panel js-hide-reveal">
-        {% include "core/_people_listing.html" with people=legislature_people skip_positions=1 %}
-        {% if former_legislature_people %}
-        <p>Former members</p>
-        {% include "core/_people_listing.html" with people=former_legislature_people skip_positions=1 %}
         {% endif %}
     </div>
 

--- a/pombola/south_africa/templates/south_africa/organisation_house.html
+++ b/pombola/south_africa/templates/south_africa/organisation_house.html
@@ -36,7 +36,7 @@ the organisation detail page.
     <ul class="house-page-list">
       {% for party in parties %}
       <li>
-      <a href="{% url "organisation" slug=party.slug %}">
+      <a href="{% url 'organisation_party' slug=object.slug sub_page_identifier=party.slug %}">
         {{ party.name }}
         <span class="percent">{{ party.percentage|floatformat:"-1" }}%</span>
       </a>

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -193,6 +193,82 @@ class SAPersonDetailViewTest(TestCase):
         speaker = PersonSpeakerMappings().pombola_person_to_sayit_speaker(person)
         self.assertEqual( speaker.name, 'Moomin Finn' )
 
+class SAOrganisationPartySubPageTest(TestCase):
+    
+    def setUp(self):
+        org_kind_party = models.OrganisationKind.objects.create(name='Party', slug='party')
+        org_kind_parliament = models.OrganisationKind.objects.create(name='Parliament', slug='parliament')
+
+        party1 = models.Organisation.objects.create(name='Party1', slug='party1', kind=org_kind_party)
+        party2 = models.Organisation.objects.create(name='Party2', slug='party2', kind=org_kind_party)
+        house1 = models.Organisation.objects.create(name='House1', slug='house1', kind=org_kind_parliament)
+        
+        positiontitle1 = models.PositionTitle.objects.create(name='Member', slug='member')
+        positiontitle2 = models.PositionTitle.objects.create(name='Delegate', slug='delegate')
+        positiontitle3 = models.PositionTitle.objects.create(name='Whip', slug='whip')
+        
+        person1 = models.Person.objects.create(name='Person1', slug='person1')
+        person2 = models.Person.objects.create(name='Person2', slug='person2')
+        person3 = models.Person.objects.create(name='Person3', slug='person3')
+        person4 = models.Person.objects.create(name='Person4', slug='person4')
+        person5 = models.Person.objects.create(name='Person5', slug='person5')
+        
+        position1 = models.Position.objects.create(person=person1, organisation=party1, title=positiontitle1)
+        position2 = models.Position.objects.create(person=person2, organisation=party1, title=positiontitle1)
+        position3 = models.Position.objects.create(person=person3, organisation=party1, title=positiontitle1)
+        position4 = models.Position.objects.create(person=person4, organisation=party2, title=positiontitle1)
+        position5 = models.Position.objects.create(person=person5, organisation=party2, title=positiontitle2)
+        
+        position6 = models.Position.objects.create(person=person1, organisation=house1, title=positiontitle1)
+        position7 = models.Position.objects.create(person=person2, organisation=house1, title=positiontitle1)
+        position8 = models.Position.objects.create(person=person3, organisation=house1, title=positiontitle1, end_date='2013-02-16')
+        position9 = models.Position.objects.create(person=person4, organisation=house1, title=positiontitle1)
+        position10 = models.Position.objects.create(person=person5, organisation=house1, title=positiontitle1, end_date='2013-02-16')
+        
+        #check for person who is no longer an official, but still a member
+        position11 = models.Position.objects.create(person=person1, organisation=house1, title=positiontitle3, end_date='2013-02-16')
+        
+    def test_display_current_members(self):
+        context1 = self.client.get(reverse('organisation_party', args=('house1', 'party1'))).context
+        context2 = self.client.get(reverse('organisation_party', args=('house1', 'party2'))).context
+        
+        expected1 = ['<Position:  (Member at House1)>', '<Position:  (Member at House1)>']
+        expected2 = ['<Position:  (Member at House1)>']
+        
+        self.assertQuerysetEqual(context1['sorted_positions'], expected1)
+        self.assertQuerysetEqual(context2['sorted_positions'], expected2)
+        self.assertEqual(context1['sorted_positions'][1].person.slug, 'person1')
+        self.assertEqual(context1['sorted_positions'][0].person.slug, 'person2')
+        self.assertEqual(context2['sorted_positions'][0].person.slug, 'person4')
+        
+    def test_display_past_members(self):
+        context1 = self.client.get(reverse('organisation_party', args=('house1', 'party1')), {'historic': '1'}).context
+        context2 = self.client.get(reverse('organisation_party', args=('house1', 'party2')), {'historic': '1'}).context
+        
+        expected1 = ['<Position:  (Member at House1)>']
+        expected2 = ['<Position:  (Member at House1)>']
+        
+        self.assertQuerysetEqual(context1['sorted_positions'], expected1)
+        self.assertQuerysetEqual(context2['sorted_positions'], expected2)
+        self.assertEqual(context1['sorted_positions'][0].person.slug, 'person3')
+        self.assertEqual(context2['sorted_positions'][0].person.slug, 'person5')
+        
+    def test_display_all_members(self):
+        context1 = self.client.get(reverse('organisation_party', args=('house1', 'party1')), {'all': '1'}).context
+        context2 = self.client.get(reverse('organisation_party', args=('house1', 'party2')), {'all': '1'}).context
+        
+        expected1 = ['<Position:  (Member at House1)>','<Position:  (Member at House1)>','<Position:  (Whip at House1)>','<Position:  (Member at House1)>']
+        expected2 = ['<Position:  (Member at House1)>','<Position:  (Member at House1)>']
+        
+        self.assertQuerysetEqual(context1['sorted_positions'], expected1)
+        self.assertQuerysetEqual(context2['sorted_positions'], expected2)
+        self.assertEqual(context1['sorted_positions'][0].person.slug, 'person3')
+        self.assertEqual(context1['sorted_positions'][1].person.slug, 'person2')
+        self.assertEqual(context1['sorted_positions'][2].person.slug, 'person1')
+        self.assertEqual(context2['sorted_positions'][0].person.slug, 'person5')
+        self.assertEqual(context2['sorted_positions'][1].person.slug, 'person4')
+        
+
 class SAHansardIndexViewTest(TestCase):
 
     def setUp(self):

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -17,6 +17,17 @@ for index, pattern in enumerate(organisation_patterns):
     if pattern.name == 'organisation':
         organisation_patterns[index] = url(r'^(?P<slug>[-\w]+)/$', SAOrganisationDetailView.as_view(), name='organisation')
 
+#add organisation party sub-page
+organisation_patterns += patterns(
+    'pombola.south_africa.views',
+    url(
+        '^(?P<slug>[-\w]+)/party/(?P<sub_page_identifier>[-\w]+)/$',  #url regex
+        SAOrganisationDetailSub.as_view(),                              #view function
+        { 'sub_page': 'party' },                                      #pass in the 'sub_page' arg
+        'organisation_party'                                          #url name
+    )
+)
+
 # Override the person url so we can add some extra data
 for index, pattern in enumerate(person_patterns):
     if pattern.name == 'person':

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -13,6 +13,7 @@ from django.views.generic import RedirectView, TemplateView
 from django.shortcuts import get_object_or_404
 from django import forms
 from django.utils.translation import ugettext_lazy as _
+from django.db.models import Q
 
 import mapit
 from haystack.views import SearchView
@@ -253,6 +254,27 @@ class SAOrganisationDetailSub(OrganisationDetailSub):
                 context['sorted_positions'] = all_positions.filter(title__slug='delegate')
             elif self.request.GET.get('office'):
                 context['sorted_positions'] = all_positions.exclude(title__slug='member')
+
+            if self.request.GET.get('order') == 'place':
+                context['sorted_positions'] = context['sorted_positions'].order_by_place()
+            else:
+                context['sorted_positions'] = context['sorted_positions'].order_by_person_name()
+                
+        if self.kwargs['sub_page'] == 'party':
+            context['party'] = get_object_or_404(models.Organisation,slug=self.kwargs['sub_page_identifier'])
+            
+            context['sorted_positions'] = context['all_positions'] = self.object.position_set.filter(person__position__organisation__slug=self.kwargs['sub_page_identifier'])
+            
+            if self.request.GET.get('all'):
+                context['sorted_positions'] = context['sorted_positions']
+            elif self.request.GET.get('historic'):
+                context['historic'] = True
+                #FIXME - limited to members and delegates so that current members who are no longer officials are not displayed, but this
+                #means that if a former member was an official this is not shown
+                context['sorted_positions'] = context['sorted_positions'].filter(Q(title__slug='member') | Q(title__slug='delegate')).currently_inactive()
+            else:
+                context['historic'] = True
+                context['sorted_positions'] = context['sorted_positions'].currently_active()
 
             if self.request.GET.get('order') == 'place':
                 context['sorted_positions'] = context['sorted_positions'].order_by_place()


### PR DESCRIPTION
This includes two changes that I have been discussing with PMG:
- Provincial pages now list MPLs before other representatives.
- Clicking on a party name on the NA or NCOP page links to a list of members of that party who are members of that house. A new view for this has been created.
