### PR TITLE
Revise pinned requirements for sayit & co

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,8 +55,9 @@ python-memcached==1.53
 django-mapit==1.0.3
 
 # SayIt and ZA hansard scrapers - need to be made available to be added as an optional app
-git+git://github.com/mysociety/sayit.git@24428b51033e1b569eec10c057d9349700cd05e5
-git+git://github.com/mysociety/za-hansard.git@f7bb072aecfc978689757fc416f4bd7758d66342
+# Note, if the subsequent -e are ever removed, please remove manually from virtualenv/src !
+-e git+git://github.com/mysociety/sayit.git@pombola#egg=django-sayit
+-e git+git://github.com/mysociety/za-hansard.git@master#egg=za-hansard
 git+git://github.com/mysociety/popit-resolver@abcfc79d787c8ca054560a4911352fed8aa8c40d
 git+git://github.com/mysociety/popit-django@61bc32b67f76262d08339e00dd83bda9def92279
 


### PR DESCRIPTION
- Pin sayit to 'pombola' branch, as that is a branch specifically
  designed to always be deployable for pombola.
- Pin za-hansard to 'master', as za-hansard only integrates with
  pombola, so master should always be deployable.
- Add -e flag for above, to make sure they are re-installed on change.
- NB: Retain specific commits for popit-django and popit-resolver
