### PR TITLE
Remove duplicate places from each person on the organisation detail page

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -942,6 +942,14 @@ class PositionQuerySet(models.query.GeoQuerySet):
         """Sort by the place name"""
         return self.select_related('person').order_by('person__legal_name')
 
+    def current_unique_places(self):
+        """Return the list of places associated with current positions"""
+        result = sorted(set(position.place for position in self.currently_active()
+                          if position.place),
+                      key=lambda p: p.name)
+        return result
+
+
 class PositionManager(ManagerBase):
     def get_query_set(self):
         return PositionQuerySet(self.model)

--- a/pombola/south_africa/templates/core/person_list_item.html
+++ b/pombola/south_africa/templates/core/person_list_item.html
@@ -11,17 +11,15 @@
 </a>
 
 {% if not skip_positions %}
-  {% for position in object.position_set.all.currently_active %}
-    {% if position.place %}
+  {% for place in object.position_set.all.current_unique_places %}
       <div class="position-place">
-        <a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>
+        <a href="{{ place.get_absolute_url }}">{{ place.name }}</a>
 
-        {% if position.place.parent_place %}
-          <a href="{{ position.place.parent_place.get_absolute_url }}">{{ position.place.parent_place.name }}</a>
-          {{ position.place.parent_place.kind.name }}
+        {% if place.parent_place %}
+          <a href="{{ place.parent_place.get_absolute_url }}">{{ place.parent_place.name }}</a>
+          {{ place.parent_place.kind.name }}
         {% endif %}
       </div>
-    {% endif %}
   {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Each person entry on an organisation detail page lists the places
that that person is associated with via currently active positions.
This wouldn't remove any redundancy, so you'd see a list like:

  "Western Cape  Western Cape  Western Cape  Western Cape"

This commit changes the behaviour so that only a unique places are
shown.  Fixes #1247.
