### PR TITLE
An old migration means we still need django_sluggable.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -125,3 +125,10 @@ GDAL
 
 # This comes as standard in Python 2.7+ anyway
 argparse
+
+# An old migration in za-hansard requires django-sluggable to be installed.
+# at some point in the future we should stop this being needed, perhaps by
+# editing the migrations to remove it.
+# In an ideal world, this should be pulled in by sayit, but it isn't.
+# See https://github.com/mysociety/sayit/issues/161
+-e git+https://github.com/mysociety/django-sluggable@with_unique_with#egg=django-sluggable


### PR DESCRIPTION
At some point in the past za-hansard had a django-sluggable field
on one of its models and this made it into a migration. Even though
the field in question has now gone, in order to run all the migrations
you still need to have django_sluggable installed.

You'd hope that pip would pull this in from the requirements.txt of sayit,
but sadly it doesn't delve into the requirements.txt files of requirements.
