### PR TITLE
run-tests: make it harder to ignore test failures

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -1,15 +1,41 @@
 #!/bin/bash
 
-# Since we have to invoke the country-specific tests with new
-# invocations of ./manage.py test, make sure that we exit after any
-# test run - this is to avoid you missing, say, that the generic tests
-# failed if your terminal's just showing the last country-specific
-# tests passing:
-set -ex
+EXIT_CODE=0
 
 cd $(dirname "$BASH_SOURCE")
 
-./manage.py test --settings=pombola.settings.tests
+update_exit_code() {
+    LAST_EXIT_CODE=$?
+    if [ $LAST_EXIT_CODE != 0 ]
+    then
+        EXIT_CODE=$LAST_EXIT_CODE
+    fi
+}
 
-./manage.py test --settings=pombola.settings.tests_kenya
-./manage.py test --settings=pombola.settings.tests_south_africa
+TEST_SETTINGS_MODULES=(
+    'pombola.settings.tests'
+    'pombola.settings.tests_kenya'
+    'pombola.settings.tests_south_africa'
+)
+
+for TEST_SETTINGS_MODULE in "${TEST_SETTINGS_MODULES[@]}"
+do
+    COMMAND="./manage.py test --settings=$TEST_SETTINGS_MODULE"
+    echo Running: $COMMAND
+    $COMMAND
+    update_exit_code
+done
+
+# If any test failed, make sure we output an error message in red at
+# the end of the test run, just in case the test failures from the
+# core tests went off the top of the terminal:
+
+if [ $EXIT_CODE != 0 ]
+then
+    echo "$(tput setaf 1)Tests failed.$(tput sgr0)"
+fi
+
+# And now exit with 0 if all tests succeeded, or otherwise with the
+# last non-zero exit code:
+
+exit $EXIT_CODE


### PR DESCRIPTION
It seems that the behaviour where we wouldn't run the country-specific
test if the core tests failed was unhelpful, in that you might not
realise that some of those tests were failing.  The concern with
running them all was you might miss a test failure that had scrolled
off the top of the terminal.  To address that, while still running
all of the tests, this commit keeps track of whether any of the
commands failed, and, if so, prints out an error in red and exits
non-zero.
