### PR TITLE
Refactor and fix bugs in the breadcrumb template tag

### DIFF
--- a/pombola/core/tests/test_templatetags.py
+++ b/pombola/core/tests/test_templatetags.py
@@ -2,7 +2,7 @@
 
 from django.test import TestCase
 
-from ..templatetags.breadcrumbs import breadcrumbs, url_name_mappings
+from ..templatetags.breadcrumbs import breadcrumbs, path_element_overrides
 from ..templatetags.active_class import active_class
 
 
@@ -48,8 +48,8 @@ class BreadcrumbTest(TestCase):
             actual = breadcrumbs(url)
             self.assertEqual(actual, expected)
 
-    def test_breadcrumb_url_name_mappings(self):
-        for name, title_url in url_name_mappings.iteritems():
+    def test_breadcrumb_path_element_overrides(self):
+        for name, title_url in path_element_overrides.iteritems():
             title, url = title_url
             actual = breadcrumbs(name + '/foo')
             self.assertTrue(title in actual, "Expected {0} to be in {1}".format(title, actual))


### PR DESCRIPTION
The code in pombola/core/templatetags/breadcrumbs.py was difficult
to follow and had a number of bugs in it. These commits do an
incremental refactoring of this code to make it clearer and fix the
following issues:
- #1333
- #1334
- A possible XSS vulnerability
