### PR TITLE
Switch from using simplejson (deprecated) to json

### DIFF
--- a/pombola/core/kenya_import_scripts/import_contituencies_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_contituencies_from_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import os
 import sys
 
@@ -12,14 +13,13 @@ sys.path.append(
 
 
 
-import simplejson
 from pprint import pprint
 from django.template.defaultfilters import slugify
 from pombola.core import models
 from django_date_extensions.fields import ApproximateDateField, ApproximateDate
 
 constituency_kind = models.PlaceKind.objects.get(slug="constituency")
-objects    = simplejson.loads( sys.stdin.read() )
+objects    = json.loads( sys.stdin.read() )
 
 for obj in objects:
     pprint( obj )

--- a/pombola/core/kenya_import_scripts/import_data_from_mzalendo.py
+++ b/pombola/core/kenya_import_scripts/import_data_from_mzalendo.py
@@ -12,12 +12,12 @@ sys.path.append(
 
 
 
-import simplejson
+import json
 from pprint import pprint
 from django.template.defaultfilters import slugify
 from pombola.core import models
 
-mps = simplejson.loads( sys.stdin.read() )
+mps = json.loads( sys.stdin.read() )
 
 constituency_kind = models.PlaceKind.objects.get(slug="constituency")
 party_kind        = models.OrganisationKind.objects.get(slug="party")

--- a/pombola/core/kenya_import_scripts/import_member_comments_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_member_comments_from_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import os
 import sys
 import re
@@ -13,7 +14,6 @@ sys.path.append(
 
 
 
-import simplejson
 from pprint import pprint
 from pombola.core.models import Person
 
@@ -23,7 +23,7 @@ from django.template.defaultfilters import slugify
 
 from comments2.models import Comment
 
-comments = simplejson.loads( sys.stdin.read() )
+comments = json.loads( sys.stdin.read() )
 
 for old_comment in comments:
     pprint( old_comment )

--- a/pombola/core/kenya_import_scripts/import_member_photos.py
+++ b/pombola/core/kenya_import_scripts/import_member_photos.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import os
 import sys
 
@@ -12,7 +13,6 @@ sys.path.append(
 
 
 
-import simplejson
 import time
 import urllib
 
@@ -23,7 +23,7 @@ from pombola.images.models import Image
 
 constituency_kind = models.PlaceKind.objects.get(slug="constituency")
 
-objects    = simplejson.loads( sys.stdin.read() )
+objects    = json.loads( sys.stdin.read() )
 
 for obj in objects:
     

--- a/pombola/core/kenya_import_scripts/import_members_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_members_from_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import os
 import sys
 import re
@@ -13,7 +14,6 @@ sys.path.append(
 
 
 
-import simplejson
 from pprint import pprint
 from django.template.defaultfilters import slugify
 from pombola.core import models
@@ -29,7 +29,7 @@ phone_kind   = models.ContactKind.objects.get(slug='phone')
 address_kind = models.ContactKind.objects.get(slug='address')
 email_kind   = models.ContactKind.objects.get(slug='email')
 
-objects           = simplejson.loads( sys.stdin.read() )
+objects           = json.loads( sys.stdin.read() )
 
 for obj in objects:
 

--- a/pombola/core/kenya_import_scripts/import_parties_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_parties_from_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import os
 import sys
 
@@ -12,14 +13,13 @@ sys.path.append(
 
 
 
-import simplejson
 from pprint import pprint
 from django.template.defaultfilters import slugify
 from pombola.core import models
 from django_date_extensions.fields import ApproximateDateField, ApproximateDate
 
 party_kind = models.OrganisationKind.objects.get(slug="party")
-parties    = simplejson.loads( sys.stdin.read() )
+parties    = json.loads( sys.stdin.read() )
 
 for party in parties:
     pprint( party )

--- a/pombola/core/kenya_import_scripts/import_positions_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_positions_from_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import os
 import sys
 import re
@@ -13,7 +14,6 @@ sys.path.append(
 
 
 
-import simplejson
 from pprint import pprint
 from pombola.core import models
 from django_date_extensions.fields import ApproximateDate
@@ -24,10 +24,10 @@ json_filename = '/home/evdb/Mzalendo_Educational_Positions.json'
 
 # python 2.6
 # with open(json_filename) as json_file:
-#     objects = simplejson.loads( json_file.read() )
+#     objects = json.loads( json_file.read() )
 
 # python 2.5
-objects = simplejson.loads( open(json_filename).read() )
+objects = json.loads( open(json_filename).read() )
 
 org_lookup   = {}
 title_lookup = {}
@@ -169,4 +169,4 @@ for obj in objects['positions']:
     )
 
 with open(json_filename, 'w') as json_file:
-    simplejson.dump( objects, json_file, sort_keys=True, indent=4, ensure_ascii=False, )
+    json.dump( objects, json_file, sort_keys=True, indent=4, ensure_ascii=False, )

--- a/pombola/search/views.py
+++ b/pombola/search/views.py
@@ -1,10 +1,10 @@
+import json
 import re
 import sys
 
 from django.http import HttpResponse
 from django.shortcuts  import render_to_response, get_object_or_404, redirect
 from django.template   import RequestContext
-from django.utils import simplejson
 from django.conf import settings
 
 from django.views.generic import TemplateView
@@ -163,7 +163,7 @@ def autocomplete(request):
 
     # send back the results as JSON
     return HttpResponse(
-        simplejson.dumps(response_data),
+        json.dumps(response_data),
         mimetype='application/json'
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,6 @@ numpy==1.6.1
 parslepy==0.2.0
 python-magic==0.4.6
 pytz==2013.9
-simplejson==3.3.2
 six==1.5.2
 slumber==0.6.0
 sqlparse==0.1.10


### PR DESCRIPTION
Using simplejson (the version from Django) gives a deprecation
warning in Django 1.6 and the warning suggests using the core json
module instead.  There seems to be no reason not to be using
the core json module instead of either (a) the Django version or
(b) the PyPi version referred to in requirements.txt.

(If there is some reason to be using simplejson instead, it would
be worth adding a test that demonstrates why.)
