### PR TITLE
Update static generation number

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -104,7 +104,7 @@ STATIC_URL = '/static/'
 
 # integer which when updated causes the caches to fetch new content. See note in
 # 'base.html' for a better alternative in Django 1.4
-STATIC_GENERATION_NUMBER = 37
+STATIC_GENERATION_NUMBER = 38
 
 # Additional locations of static files
 STATICFILES_DIRS = (


### PR DESCRIPTION
Changes in #1365 are not displaying correctly at www.pa.org.za as the main css file is being cached - I forgot to increment `STATIC_GENERATION_NUMBER` as part of the changes.

If it is simpler to make this change directly and to bypass this pull request then please do so.
