### PR TITLE
Don't try to return boundary changes for places with no MapIt area

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -810,6 +810,12 @@ class Place(ModelBase, ScorecardMixin):
 
         result = {}
 
+        # Occasionally a place will not have a MapIt area associated
+        # with it; in these cases we can't find which boundaries it
+        # overlaps with, so just return an empty dictionary.
+        if self.mapit_area is None:
+            return result
+
         for key, session in (('previous', previous_session),
                              ('next', next_session)):
             if not session:


### PR DESCRIPTION
We were getting error emails for a couple of places that had no MapIt
area associated with them - these are historic data where it's going to
be difficult to get missing data, so let's just settle for not showing
boundary changes for these cases.

Fixes #1335 and #1377.
