### PR TITLE
Use the post_init signal instead of overriding the model contructor

### DIFF
--- a/pombola/core/tests/test_persons.py
+++ b/pombola/core/tests/test_persons.py
@@ -51,6 +51,13 @@ class PersonTest(WebTest):
         person.save()
         self.assertEqual(person.sort_name, 'Vaughan Williams')
 
+    def test_only_query(self):
+        at_least_one_person = models.Person.objects.create(
+            legal_name='Ralph Vaughan Williams',
+            sort_name='Vaughan Williams')
+        all_people_id_and_slug = list(models.Person.objects.only('id', 'slug'))
+        at_least_one_person.delete()
+
     def test_urls(self):
         person = models.Person(
             legal_name="Alfred Smith",


### PR DESCRIPTION
Overriding the constructor seemed to cause problems; in particular that
described in issue #1394:

```
Although under normal circumstances one can createPerson objects
and fetch them from the database fine with the new overriden
__init__, this fails if you call:

    Person.objects.only('id', 'slug')

... as in core_list_malformed_slugs where the line:

    if self.legal_name and not self.sort_name:

... causes the queryset to be evaluated again [which causes a
'RuntimeError: maximum recursion depth exceeded' error].
```

I've seen a suggestion in various places that overriding the
constructor of a Django model is a bad idea, and that one should use the
post_init signal instead.  This commit makes that change, and adds a
test that fails with the previous code.

Fixes #1394.
