### PR TITLE
Add a default set of models to search in autocomplete

### DIFF
--- a/pombola/search/views.py
+++ b/pombola/search/views.py
@@ -126,6 +126,13 @@ def autocomplete(request):
             model = known_kinds.get(model_kind, None)
             if model:
                 sqs = sqs.models(model)
+        else:
+            sqs = sqs.models(
+                models.Person,
+                models.Organisation,
+                models.Place,
+                models.PositionTitle,
+            )
 
         # collate the results into json for the autocomplete js
         for result in sqs.all()[0:10]:


### PR DESCRIPTION
Previously, by default the autocomplete was searching across every model
in Elasticsearch - this caused problems because this included models
created by popit-resolver, for example, which would cause errors on
rendering.

Instead, only search a default set of models (Person, Place,
Organisation, PositionTitle) unless a particular model has been
specified in the request.

Fixes #1487
