### PR TITLE
Make two URLs for the two County Performance experiments

### DIFF
--- a/pombola/kenya/templates/_county_petition.html
+++ b/pombola/kenya/templates/_county_petition.html
@@ -1,4 +1,4 @@
-<form id="petition" method="post" action="{% url 'county-performance-petition-submission' %}">
+<form id="petition" method="post" action="{{ petition_submission_url }}">
   {% csrf_token %}
   <h2>
     <label for="name">If you believe that County Budgets need to be spent responsibly, then add your name to our petition asking for greater government accountability</label>

--- a/pombola/kenya/templates/_county_senate.html
+++ b/pombola/kenya/templates/_county_senate.html
@@ -1,4 +1,4 @@
-<form id="senate" method="post" action="{% url 'county-performance-senate-submission' %}">
+<form id="senate" method="post" action="{{ senate_submission_url }}">
   {% csrf_token %}
   <h2><label for="comments">Tell the senate what you think</label></h2>
   <p>We will also send any comments through to the Senate Majority Leader</p>

--- a/pombola/kenya/templates/_share_facebook.html
+++ b/pombola/kenya/templates/_share_facebook.html
@@ -1,1 +1,1 @@
-<a id="share-facebook" class="share-link" href="{% url 'county-performance-share' %}?n=facebook" id="share-facebook">Share this article on Facebook</a>
+<a id="share-facebook" class="share-link" href="{{ share_url }}?n=facebook" id="share-facebook">Share this article on Facebook</a>

--- a/pombola/kenya/templates/_share_twitter.html
+++ b/pombola/kenya/templates/_share_twitter.html
@@ -1,1 +1,1 @@
-<a id="share-twitter" class="share-link" href="{% url 'county-performance-share' %}?n=twitter" id="share-twitter">Share this article on Twitter</a>
+<a id="share-twitter" class="share-link" href="{{ share_url }}?n=twitter" id="share-twitter">Share this article on Twitter</a>

--- a/pombola/kenya/templates/county-performance-petition-submission.html
+++ b/pombola/kenya/templates/county-performance-petition-submission.html
@@ -20,6 +20,6 @@
 
   <h1>Thank-you for signing the petition</h1>
 
-  <p><a href="{% url 'county-performance' %}">Return to the information page about county government budgets</a></p>
+  <p><a href="{{ base_url }}">Return to the information page about county government budgets</a></p>
 
 {% endblock %}

--- a/pombola/kenya/templates/county-performance-senate-submission.html
+++ b/pombola/kenya/templates/county-performance-senate-submission.html
@@ -20,6 +20,6 @@
 
   <h1>Thank-you for submitting your message for the senate</h1>
 
-  <p><a href="{% url 'county-performance' %}">Return to the information page about county government budgets</a></p>
+  <p><a href="{{ base_url }}">Return to the information page about county government budgets</a></p>
 
 {% endblock %}

--- a/pombola/kenya/templates/county-performance.html
+++ b/pombola/kenya/templates/county-performance.html
@@ -155,7 +155,7 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
 
       <div id="survey">
         <p>Take our 5 minute survey and enter to win $100 in airtime!</p>
-        <a href="{% url 'county-performance-survey' %}" id="take-survey">Take Survey</a>
+        <a href="{{ survey_url }}" id="take-survey">Take Survey</a>
       </div>
 
   {% endif %}


### PR DESCRIPTION
We don't want to risk people following links from the earlier trial
experiment while the larger experiment is running and the data being
contaminated by that. The safest way to do that is to use two different
base URLs for the two experiments - one is now /county-performance and
the other is /county-performance-2

The commit introduces that change, while reusing the same view classes
with minor modifications.
