### PR TITLE
Make PA homepage quote user-editable

### DIFF
--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -33,10 +33,7 @@
 
             <div class="home-right">
                 <h2 id="home-intro">
-                    &ldquo;In what is likely to be a more confrontational
-                    parliament, the ANC is deploying its strongest MPs to
-                    lead parliamentary committees&rdquo; <small> &ndash;
-                    Political analyst Ralph Mathekga</small>
+                    {{ quote_content }}
                 </h2>
             </div>
 

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -69,6 +69,13 @@ class SAHomeView(HomeView):
             except Category.DoesNotExist:
                 pass
 
+        # If there is editable homepage content make it available to the templates.
+        try:
+            page = InfoPage.objects.get(slug="homepage-quote")
+            context['quote_content'] = page.content
+        except InfoPage.DoesNotExist:
+            context['quote_content'] = None
+
         return context
 
 class SAGeocoderView(GeocoderView):


### PR DESCRIPTION
The quote on the home page now pulls content from an info page with slug `homepage-quote`.
- Closes #1521
