### PR TITLE
ZA: Merge "That Week in Parliament" and "Impressions" on the homepage

### DIFF
--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -62,10 +62,11 @@
 
     <div id="news">
 
-      {% for category, articles in news_categories %}
+      <h2 class="home-news-heading">That Week in Parliament</h2>
+
+      {% for articles in article_columns %}
 
         <div class="home-news">
-            <h2><a href="{% url 'info_blog_category' slug=category.slug %}">{{ category.name }}</a></h2>
             <ul class="home-news-list">
             {% for article in articles %}
             <li>
@@ -77,12 +78,11 @@
             </li>
             {% endfor %}
             </ul>
-            <p><a class="readmore" href="{% url 'info_blog_category' slug=category.slug %}">See All &#187;</a></p>
         </div>
 
       {% endfor %}
 
-
+      <p><a class="readmore" href="{% url 'info_blog_list' %}">See All &#187;</a></p>
 
         <div class="home-news-bottom">
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -39,7 +39,7 @@ class HomeViewTest(TestCase):
         response = self.client.get('/')
         self.assertIn('featured_person', response.context)
         self.assertIn('featured_persons', response.context)
-        self.assertIn('news_categories', response.context)
+        self.assertIn('article_columns', response.context)
 
 @attr(country='south_africa')
 class ConstituencyOfficesTestCase(WebTest):

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -50,14 +50,18 @@ class SAHomeView(HomeView):
         articles = InfoPage.objects.filter(
             kind=InfoPage.KIND_BLOG).order_by("-publication_date")
 
-        context['news_categories'] = []
-        for slug in ('week-parliament', 'impressions'):
-            try:
-                c = Category.objects.get(slug=slug)
-                context['news_categories'].append(
-                    (c, articles.filter(categories=c)[:3]))
-            except Category.DoesNotExist:
-                pass
+        articles_for_front_page = \
+            InfoPage.objects.filter(
+                categories__slug__in=(
+                    'week-parliament',
+                    'impressions'
+                )
+            ).order_by('-publication_date')
+
+        context['article_columns'] = [
+            articles_for_front_page[0:3],
+            articles_for_front_page[3:6],
+        ]
 
         context['other_news_categories'] = []
         for slug in ('advocacy-campaigns', 'commentary', 'mp-corner'):


### PR DESCRIPTION
PMG have requested that instead of having "Impression" and "That Week in
Parliament" as separate sections on the front page, we merge these two
into a single list across the two columns called "That Week in
Parliament".

Fixes #1516
