### PR TITLE
Don't show HTML in Hansard appearance excerpts

### DIFF
--- a/pombola/south_africa/templates/core/person_speech_list.html
+++ b/pombola/south_africa/templates/core/person_speech_list.html
@@ -1,3 +1,5 @@
+{% load speech_utils %}
+
 {% comment %}
 
   Arguments:
@@ -28,9 +30,9 @@
             &mdash;
             {{ speech.start_date }}
         </p>
-        <p>
-            {{ speech.text|truncatewords:50 }}
-        </p>
+        <div>
+            {{ speech.text|bleach|truncatewords_html:50 }}
+        </div>
     </li>
     {% empty %}
         No speeches found


### PR DESCRIPTION
This suppresses the `<p>` tags that appear on pages like this:

  http://www.pa.org.za/person/cameron-mackenzie/
