### PR TITLE
Fix broken link in Vagrantfile

### DIFF
--- a/conf/Vagrantfile.example
+++ b/conf/Vagrantfile.example
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # We need curl to fetch the install script
     apt-get update -qq
     apt-get install -qq -y curl >/dev/null
-    curl -s -O https://raw.github.com/mysociety/commonlib/dev-argument/bin/install-site.sh
+    curl -s -O -L https://raw.githubusercontent.com/mysociety/commonlib/dev-argument/bin/install-site.sh
     sh install-site.sh --dev pombola vagrant 127.0.0.1.xip.io
     # All done
     echo "****************"


### PR DESCRIPTION
I tried setting up a Pombola vagrant box today. After I'd copied the example Vagrantfile into the same directory as the `pombola` directory, `vagrant up` failed with:

```
    default: Running: inline script
==> default: stdin: is not a tty
==> default: sh: 0: Can't open install-site.sh
```

The reason `sh` couldn't open `install-site.sh` is because…

```
curl -s -O https://raw.github.com/mysociety/commonlib/dev-argument/bin/install-site.sh
```

…didn't output anything, because `curl` encountered a redirect (to raw.githubusercontent.com) and didn't follow it. No `install-site.sh` file was created.

This pull request fixes that – first by calling the correct URL in the first place, and second by following redirects in case GitHub moves the file again.
