### PR TITLE
ZA: redirect person/../appearances/ to person/../

### DIFF
--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -54,6 +54,9 @@ urlpatterns += patterns('',
     # FIXME - implement a redirect to /persons/joe-bloggs#appearances when #930
     # done
     # url(r'^person/(?P<person_slug>[-\w]+)/appearances/$', ........ ),
+    url(r'^person/(?P<slug>[-\w]+)/appearances/$',
+        RedirectView.as_view(pattern_name='person', permanent=False),
+        name='sa-person-appearances'),
 
     url(
         r'^person/(?P<person_slug>[-\w]+)/appearances/(?P<speech_tag>[-\w]+)$',


### PR DESCRIPTION
The `person/../appearances` url (accessible via breadcrumbs or manual editing of the url on a page such as [this](http://www.pa.org.za/person/sibongile-pearm-tsoleli/appearances/committee)) currently displays 'No appearances were found.' (e.g. [this page](http://www.pa.org.za/person/sibongile-pearm-tsoleli/appearances/)). This issue has [been flagged](https://github.com/mysociety/pombola/blob/a71412c8de6c7dcd97933df782c96d9cd43ae595/pombola/south_africa/urls.py#L54) but depends on #930. This temporary fix redirects the user to the person's profile and avoids an error.
