### PR TITLE
Update core_merge_people to merge interests register if installed.

### DIFF
--- a/pombola/core/management/commands/core_merge_people.py
+++ b/pombola/core/management/commands/core_merge_people.py
@@ -155,6 +155,12 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
         # (The scorecard application can be ignored, since those
         # results are regenerated automatically.)
 
+        # Then those in interests_register, if that application is installed:
+        #    interests_register_models.Entry
+        if 'interests_register' in settings.INSTALLED_APPS:
+            import pombola.interests_register.models as interests_register_models
+            interests_register_models.Entry.objects.filter(person=to_delete).update(person=to_keep)
+
         # Add any images for the person to delete as non-primary
         # images for the person to keep:
         Image.objects.filter(content_type=content_type_person,


### PR DESCRIPTION
Enables #1494 following import of new interests register.

@geoffkilpin: could you please sanity check that this actually matches the intent of the register?

<!---
@huboard:{"order":0.1435546875,"milestone_order":1557,"custom_state":""}
-->
