### PR TITLE
Add CDF budgets to a person's details view

### DIFF
--- a/pombola/kenya/templates/core/person_detail.html
+++ b/pombola/kenya/templates/core/person_detail.html
@@ -23,4 +23,13 @@
     {% endwith %}
   {% endif %}
 
+  {% if cdf_budget_constituencies %}
+    <div class="person-detail-cdf-budgets">
+      <h3>Constituencies Development Fund Budget</h3>
+      {% for cdf_constituency in cdf_budget_constituencies %}
+        <p><a href="{{ constituency.get_absolute_url }}">{{ cdf_constituency.constituency.name }}</a>, {{ cdf_constituency.budget.budget_session }}: <b>{{ cdf_constituency.budget.formatted_value }}</b></p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -45,6 +45,20 @@ class KEPersonDetail(HansardPersonMixin, PersonDetail):
     def get_context_data(self, **kwargs):
         context = super(KEPersonDetail, self).get_context_data(**kwargs)
         context['hansard_entries_to_show'] = ":3"
+
+        constituencies = self.object.constituencies().filter(
+            budget_entries__organisation='CDF'
+        ).select_related()
+
+        # We only retrieve one budget because we only really care about the
+        # latest. budgets() are default sorted by date of the budget session.
+        cdf_budget_constituencies = [
+            {'constituency': c, 'budget': c.budgets()[0]}
+            for c in constituencies
+        ]
+
+        context['cdf_budget_constituencies'] = cdf_budget_constituencies
+
         return context
 
 


### PR DESCRIPTION
- Closes #1504 

Adds CDF budget data to a person, showing budgets for their current constituencies.
