### PR TITLE
SYE: Make blog list content as html safe

### DIFF
--- a/pombola/nigeria/templates/info/blog_list.html
+++ b/pombola/nigeria/templates/info/blog_list.html
@@ -19,7 +19,7 @@
         {{ object.publication_date|date }}
       </p>
 
-      {{ object.content_as_cleaned_html|truncatewords_html:80 }}
+      {{ object.content_as_cleaned_html|safe|truncatewords_html:80 }}
 
       <p><a href="{{ object.get_absolute_url }}">Read more &hellip;</a></p>
 


### PR DESCRIPTION
When listing blog posts on the ShineYourEye blog the content is in raw
html, therefore we need to mark the html string as safe so that it will
render correctly.

I tried to write a test for this, but for some reason I couldn't reproduce the escaping but in the tests? Here's the code I put in `pombola/nigeria/tests.py`:

```python
from pombola.info.models import InfoPage

class InfoBlogListTest(TestCase):
    def setUp(self):
        InfoPage.objects.create(slug='escaping-test', kind='blog', title='Escaping Test', markdown_content="\nTesting\n\nEscaped\n\nContent")

    def test_html_not_escaped(self):
        response = self.client.get('/blog/')
        self.assertNotIn('&ltp&gt', response.content)
```

However the test seems to pass before and after the change in this pull request, so I'm not sure what I've done wrong!

Fixes #1586 