### PR TITLE
Fix query that was running infinitely

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -568,8 +568,10 @@ class OrganisationQuerySet(models.query.GeoQuerySet):
         return (
             self
                 .parties()
-                .filter(position__in=active_politician_positions)
-                .filter(position__in=active_member_positions)
+                .filter(
+                    Q(position__in=active_politician_positions) |
+                    Q(position__in=active_member_positions)
+                )
                 .distinct()
             )
 


### PR DESCRIPTION
Previously this query was creating two inner joins for the same table,
which seemed to be causing postgres to never return from the query.

This change uses Q to OR together the two querysets which seems to work
correctly.

The query that is now produced by this method is:

```sql
SELECT DISTINCT "core_organisation"."id", "core_organisation"."created", "core_organisation"."updated", "core_organisation"."name", "core_organisation"."slug", "core_organisation"."summary", "core_organisation"."kind_id", "core_organisation"."started", "core_organisation"."ended", "core_organisation"."_summary_rendered"
FROM "core_organisation"
INNER JOIN "core_organisationkind" ON (
  "core_organisation"."kind_id" = "core_organisationkind"."id"
)
INNER JOIN "core_position" ON (
  "core_organisation"."id" = "core_position"."organisation_id"
)
WHERE (
  "core_organisationkind"."slug" = party
  AND (
    "core_position"."id" IN (
      SELECT "core_position"."id"
      FROM "core_position"
      WHERE (
        "core_position"."category" = political
        AND "core_position"."sorting_start_date" <= 2015-01-14
        AND (
          "core_position"."sorting_end_date_high" >= 2015-01-14
          OR "core_position"."end_date" =
        )
      )
    )
    OR "core_position"."id" IN (
      SELECT "core_position"."id"
      FROM "core_position"
      INNER JOIN "core_positiontitle" ON (
        "core_position"."title_id" = "core_positiontitle"."id"
      )
      WHERE (
        "core_positiontitle"."slug" = member
        AND "core_position"."sorting_start_date" <= 2015-01-14
        AND ("core_position"."sorting_end_date_high" >= 2015-01-14
          OR "core_position"."end_date" =
        )
      )
    )
  )
)
ORDER BY "core_organisation"."slug" ASC
```

The query looks correct to me, but it's hard to verify its behaviour because I was unable to run the previous query because it hung.

I'm also not 100% sure how to test this as it's a complex query which requires exactly the right data to be in the right place. Any suggestions welcome!

Fixes #1569 