### PR TITLE
ZA Internet explorer fixes

### DIFF
--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -8,7 +8,9 @@
 {% block css_headers %}
   {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/libs/responsive-carousel.css' %}" />
+  <!--[if !IE]><!-->
   <link rel="stylesheet" type="text/css" href="{% static 'css/libs/responsive-carousel.fade.css' %}" />
+  <!--<![endif]-->
 {% endblock %}
 
 {% block extra_js_to_load %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ psycopg2==2.5.4
 Django==1.6.5
 django-pagination==1.0.7
 South==1.0.1
-django-pipeline==1.3.25
+django-pipeline==1.3.27
 django-pipeline-compass-rubygem==0.1.8
 
 ### Pombola dependencies


### PR DESCRIPTION
This updates django-pipeline to a version which uses `text/javascript` in the type attribute on script tags. It fixes the carousel in IE 8.

Fixes #1577 