### PR TITLE
Suppress the warnings about missing loggers for elasticsearch

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -244,6 +244,16 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+        'elasticsearch': {
+            'handlers': ['stream_to_stderr'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'elasticsearch.trace': {
+            'handlers': ['stream_to_stderr'],
+            'level': 'INFO',
+            'propagate': True,
+        },
     }
 }
 

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -277,7 +277,7 @@ PAGINATION_INVALID_PAGE_RAISES_404 = True
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-        'URL': 'http://127.0.0.1:9200/',
+        'URL': '127.0.0.1:9200',
         'INDEX_NAME': config.get('POMBOLA_DB_NAME'),
         'EXCLUDED_INDEXES': [],
     },


### PR DESCRIPTION
If there are no loggers defined for the elasticsearch Python package you
get errors like the following:

  No handlers could be found for logger "elasticsearch" (in production)
  No handlers could be found for logger "elasticsearch.trace" (local dev)

(I'm not sure why there's that difference in those logger names.)

This commit sets up loggers for both names in the Django settings module
that will send any logging of level INFO and above to standard error.
This suppresses that warning and should mean that we're able to see
real warnings and errors in the logs.