### PR TITLE
Don't convert empty tags to self-closing tags in raw HTML blog posts

### DIFF
--- a/pombola/info/models.py
+++ b/pombola/info/models.py
@@ -136,7 +136,7 @@ class InfoPage(ModelBase):
             # Parsing the HTML with lxml and outputting it again
             # should ensure that we have only well-formed HTML:
             parsed = lxml.html.fromstring(self.raw_content)
-            return lxml.etree.tostring(parsed)
+            return lxml.etree.tostring(parsed, method='html')
         else:
             # Since there seems to be some doubt about whether
             # markdown's safe_mode is really safe, clean the rendered

--- a/pombola/info/tests.py
+++ b/pombola/info/tests.py
@@ -56,7 +56,7 @@ class InfoTest(TestCase):
             as_html = re.sub(r'</script><p>', '</script> <p>', as_html)
             self.assertEqual(
                 as_html,
-                "<div><h1 class=\"foo\">Hello there</h1> <script>alert('hi!');</script> <p>blah blah, unclosed paragraph <iframe/> </p><div>And then a div...</div></div>"
+                "<div><h1 class=\"foo\">Hello there</h1> <script>alert('hi!');</script> <p>blah blah, unclosed paragraph <iframe></iframe> </p><div>And then a div...</div></div>"
             )
             self.assertEqual(
                 re.sub(r'(?ms)\s+', ' ', danger_post.content_as_cleaned_html),
@@ -68,6 +68,26 @@ class InfoTest(TestCase):
             )
         finally:
             danger_post.delete()
+
+    @override_settings(INFO_PAGES_ALLOW_RAW_HTML=True)
+    def test_no_self_closing_tags(self):
+        example_post = InfoPage.objects.create(
+            slug="post-with-video",
+            title="Embedded YouTube Video",
+            raw_content='''<h1 class="foo">Hello there</h1>
+                <p>An introductory paragraph:
+                <iframe></iframe>
+                <p>And then a trailing paragraph...</p>''',
+            use_raw=True,
+            kind=InfoPage.KIND_BLOG,
+        )
+        self.assertEqual(
+            example_post.content_as_html,
+            '''<div><h1 class="foo">Hello there</h1>
+                <p>An introductory paragraph:
+                <iframe></iframe>
+                </p><p>And then a trailing paragraph...</p></div>'''
+        )
 
 
 class InfoBlogClientTests(TestCase):


### PR DESCRIPTION
There was a problem that content after embedded videos (included via
YouTube's suggested <iframe ...></iframe> HTML) wasn't being displayed.
This turned out to be because we pass the raw HTML through lxml to
ensure that the output is well-formed, but this was converting empty
tags to self-closing tags and <iframe .../> and that eats the following
content in the page.

Adding method="html" to lxml.etree's tostring function preserves the
separate close tag.

Fixes #1608