### PR TITLE
Add a link to the API help page

### DIFF
--- a/pombola/south_africa/templates/menu_entries.html
+++ b/pombola/south_africa/templates/menu_entries.html
@@ -88,6 +88,7 @@
       <li><a href="{% url "info_page" slug="infographics" %}">Infographics</a></li>
       <li><a href="{% url "info_page" slug="survey-archive" %}">Survey Archive</a></li>
       <li><a href="{% url "sa-election-overview-year" election_year="2014" %}">Election 2014 Candidates</a></li>
+      <li><a href="{% url 'help-api' %}">Get the data</a>
     </ul>
   {% endif %}
 </li>


### PR DESCRIPTION
This pull request is ready for when we're happy with the content of the page,
which is live now but not linked-to.