### PR TITLE
ZA: Reduce queries used on the organisation detail page

### DIFF
--- a/pombola/south_africa/templates/core/organisation_detail.html
+++ b/pombola/south_africa/templates/core/organisation_detail.html
@@ -39,6 +39,20 @@
     {% include "core/_position_listing.html" with positions=positions %}
   {% endif %}
 
+  <div class="pagination">
+    {% if positions.has_previous %}
+      <a href="?page={{ positions.previous_page_number }}">Previous</a>
+    {% endif %}
+
+    <span class="current">
+      Page {{ positions.number }} of {{ positions.paginator.num_pages }}
+    </span>
+
+     {% if positions.has_next %}
+      <a href="?page={{ positions.next_page_number }}">Next</a>
+    {% endif %}
+  </div>
+
 {% endblock %}
 
 {# Put a map in the profile_pic block #}

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -325,6 +325,15 @@ class SAOrganisationDetailView(OrganisationDetailView):
             key=key_position_sort_last_name,
         )
 
+        paginator = Paginator(context['positions'], 20)
+        page = self.request.GET.get('page')
+        try:
+            context['positions'] = paginator.page(page)
+        except PageNotAnInteger:
+            context['positions'] = paginator.page(1)
+        except EmptyPage:
+            context['positions'] = paginator.page(paginator.num_pages)
+
         return context
 
     def add_parliament_counts_to_context_data(self, context):


### PR DESCRIPTION
Despite the careful use of select_related and prefetch_related in
pombola.core.views:OrganisationDetailView, the loading of an
organization with even a small number of people in it generate a huge
number of queries.

This is caused by the additional information requested by the South
African override of core/person_list_item.html, which does two costly
operations:

 1. Finding places associated with that person by iterating over
    position_set.all.current_unique_places and then accessing
    parent_place for each of those too.

 2. Calling the 'parties' method on each person, which creates a new
    queryset for each person.

Neither of these are all that easy to make more efficient while still
providing the same information without restructuring a lot of the
template code, so instead this commit just paginates the results so that
the page load times don't become excessive. (This reduces the number of
queries for a page load from thousands to about 80; still much higher
than we'd like, but the performance is OK.)

Fixes #1610

<!---
@huboard:{"order":1619.0,"milestone_order":1619,"custom_state":""}
-->
