### PR TITLE
Mzalendo: add date sort options to hansard search

### DIFF
--- a/pombola/search/search_indexes.py
+++ b/pombola/search/search_indexes.py
@@ -48,8 +48,17 @@ if settings.ENABLED_FEATURES['hansard']:
     from pombola.hansard import models as hansard_models
 
     class HansardEntryIndex(BaseIndex, indexes.Indexable):
+        start_date = indexes.DateTimeField(null=True)
+
         def get_model(self):
             return hansard_models.Entry
+
+        def index_queryset(self, using=None):
+            """Used when the entire index for model is updated."""
+            return self.get_model().objects.select_related('sitting')
+
+        def prepare_start_date(self, obj):
+            return obj.sitting.start_date
 
 if 'pombola.info' in settings.INSTALLED_APPS:
     from pombola.info.models import InfoPage

--- a/pombola/search/templates/search/hansard.html
+++ b/pombola/search/templates/search/hansard.html
@@ -19,11 +19,20 @@
         <p>Alternatively, <a href="{% url "core_search"  %}" id="search-core-instead">search Mzalendo's data</a> instead.</p>
 
         <div class="search-box">
-            {{ form.q }}
+            <input id="id_q" name="q" type="search" value="{{ query }}">
+
+            <label for="search-results-order">Order by</label>
+              <select name="order" id="search-results-order">
+                <option value="relevance"{% if order == 'relevance' %} selected{% endif %}>Relevance</option>
+                <option value="date"{% if order == 'date' %} selected{% endif %}>Newest first</option>
+                <option value="adate"{% if order == 'adate' %} selected{% endif %}>Oldest first</option>
+              </select>
+
             <input type="submit" value="Search" class="button">
         </div>
 
         {% if query %}
+            <br />
             <h3>Results</h3>
 
             <style type="text/css">
@@ -33,7 +42,7 @@
             </style>
 
             <ul class="listing">
-            {% for result in page.object_list %}
+            {% for result in results %}
                 {% comment %}
                    FIXME: this next guard is only present because
                    currently we have a not-properly-understood
@@ -56,11 +65,11 @@
             {% endfor %}
             </ul>
 
-            {% if page.has_previous or page.has_next %}
+            {% if results.has_previous or results.has_next %}
                 <div>
-                    {% if page.has_previous %}<a href="?q={{ query }}&amp;page={{ page.previous_page_number }}">{% endif %}&laquo; Previous{% if page.has_previous %}</a>{% endif %}
+                    {% if results.has_previous %}<a href="?q={{ query }}&amp;page={{ results.previous_page_number }}">{% endif %}&laquo; Previous{% if results.has_previous %}</a>{% endif %}
                     |
-                    {% if page.has_next %}<a href="?q={{ query }}&amp;page={{ page.next_page_number }}">{% endif %}Next &raquo;{% if page.has_next %}</a>{% endif %}
+                    {% if results.has_next %}<a href="?q={{ query }}&amp;page={{ results.next_page_number }}">{% endif %}Next &raquo;{% if results.has_next %}</a>{% endif %}
                 </div>
             {% endif %}
         {% else %}

--- a/pombola/search/templates/search/hansard.html
+++ b/pombola/search/templates/search/hansard.html
@@ -67,9 +67,9 @@
 
             {% if results.has_previous or results.has_next %}
                 <div>
-                    {% if results.has_previous %}<a href="?q={{ query }}&amp;page={{ results.previous_page_number }}">{% endif %}&laquo; Previous{% if results.has_previous %}</a>{% endif %}
+                    {% if results.has_previous %}<a href="?q={{ query }}&amp;order={{ order }}&amp;page={{ results.previous_page_number }}">{% endif %}&laquo; Previous{% if results.has_previous %}</a>{% endif %}
                     |
-                    {% if results.has_next %}<a href="?q={{ query }}&amp;page={{ results.next_page_number }}">{% endif %}Next &raquo;{% if results.has_next %}</a>{% endif %}
+                    {% if results.has_next %}<a href="?q={{ query }}&amp;order={{ order }}&amp;page={{ results.next_page_number }}">{% endif %}Next &raquo;{% if results.has_next %}</a>{% endif %}
                 </div>
             {% endif %}
         {% else %}

--- a/pombola/search/urls.py
+++ b/pombola/search/urls.py
@@ -1,13 +1,9 @@
 from django.conf.urls import patterns, include, url
 from django.conf import settings
 
-from haystack.forms import ModelSearchForm, SearchForm
-from haystack.query import SearchQuerySet
-from haystack.views import SearchView
-
 from pombola.core    import models as core_models
 
-from .views import SearchBaseView, GeocoderView
+from .views import SearchBaseView, GeocoderView, HansardSearchView
 
 urlpatterns = patterns('pombola.search.views',
 
@@ -33,13 +29,7 @@ if settings.ENABLED_FEATURES['hansard']:
     urlpatterns += patterns('pombola.search.views',
         url(
             r'^hansard/$',
-            SearchView(
-                searchqueryset = SearchQuerySet().models(
-                    hansard_models.Entry,
-                ),
-                form_class=SearchForm,
-                template="search/hansard.html",
-            ),
+            HansardSearchView.as_view(),
             name='hansard_search',
         ),
     )

--- a/pombola/search/urls.py
+++ b/pombola/search/urls.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 from pombola.core    import models as core_models
 
-from .views import SearchBaseView, GeocoderView, HansardSearchView
+from .views import SearchBaseView, GeocoderView
 
 urlpatterns = patterns('pombola.search.views',
 
@@ -26,6 +26,7 @@ urlpatterns = patterns('pombola.search.views',
 # Hansard search - only loaded if hansard is enabled
 if settings.ENABLED_FEATURES['hansard']:
     from pombola.hansard import models as hansard_models
+    from .views import HansardSearchView
     urlpatterns += patterns('pombola.search.views',
         url(
             r'^hansard/$',

--- a/pombola/search/views.py
+++ b/pombola/search/views.py
@@ -1,17 +1,12 @@
-from collections import namedtuple
-import json
 import re
 import sys
 import simplejson
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.shortcuts  import render_to_response, get_object_or_404, redirect
-from django.template   import RequestContext
 from django.conf import settings
 
-from django.views.generic import TemplateView, FormView
+from django.views.generic import TemplateView
 
 from pombola.core import models
 

--- a/pombola/search/views.py
+++ b/pombola/search/views.py
@@ -217,6 +217,63 @@ class SearchBaseView(TemplateView):
         return result
 
 
+class HansardSearchView(TemplateView):
+    template_name = "search/hansard.html"
+    results_per_page = 20
+
+    def parse_params(self):
+        self.query = self.request.GET.get('q', '')
+        self.page = self.request.GET.get('page')
+        self.order = self.request.GET.get('order')
+
+    def get_data(self):
+        from pombola.hansard.models import Entry
+        defaults = {
+            'model': Entry,
+            'title': 'Hansard',
+        }
+        data_query = SearchQuerySet().models(defaults['model'])
+        data_query = data_query.filter(
+            content=AutoQuery(self.query)
+        )
+        if self.order == 'date':
+            data_query = data_query.order_by('-start_date')
+        if self.order == 'adate':
+            data_query = data_query.order_by('start_date')
+
+        result = defaults.copy()
+        result['results'] = data_query.highlight()
+        result['results_count'] = result['results'].count()
+        return result
+
+    def get_paginated_results(self, sqs):
+        paginator = Paginator(sqs, self.results_per_page)
+        try:
+            results = paginator.page(self.page)
+        except PageNotAnInteger:
+            results = paginator.page(1)
+        except EmptyPage:
+            results = paginator.page(paginator.num_pages)
+        return results
+
+    def get_context_data(self, **kwargs):
+        self.parse_params()
+        context = super(HansardSearchView, self).get_context_data(**kwargs)
+        context['query'] = self.query
+        context['order'] = self.order
+
+        query_dict = self.request.GET.copy()
+        if 'page' in query_dict:
+            del query_dict['page']
+        context['query_string'] = query_dict.urlencode()
+        if not self.query:
+            return context
+
+        data = self.get_data()
+        context['results'] = self.get_paginated_results(data['results'])
+        return context
+
+
 class GeocoderView(TemplateView):
     template_name = "search/location.html"
 


### PR DESCRIPTION
Fixes #1607 

* Adds a new field to `HansardEntryIndex` so that `start_date` is available to the sort function.
* Adds a drop-down box to the Hansard search form offering Sort by 'Relevance' (default), 'Oldest first' or 'Newest first'

I traded the `haystack.views` based `SearchView` for `HansardSearchView` which is a cut-down version of `SearchBaseView` minus sections and template_name resolution, mostly because trying to add `sort_by` to `SearchView` was giving me a headache. On the plus side, there is now scope to standardise the look of the Hansard search by including the existing partial templates for result items and pagination but I've avoided this in the first instance in case it introduces unwanted UI changes.