### PR TITLE
Add API help page for Mzalendo

### DIFF
--- a/pombola/core/context_processors.py
+++ b/pombola/core/context_processors.py
@@ -19,5 +19,6 @@ def add_settings( request ):
             'MAP_BOUNDING_BOX_EAST':        settings.MAP_BOUNDING_BOX_EAST,
             'MAP_BOUNDING_BOX_SOUTH':       settings.MAP_BOUNDING_BOX_SOUTH,
             'MAP_BOUNDING_BOX_WEST':        settings.MAP_BOUNDING_BOX_WEST,
+            'POPIT_API_URL':                settings.POPIT_API_URL,
         }
     }

--- a/pombola/kenya/templates/menu_entries.html
+++ b/pombola/kenya/templates/menu_entries.html
@@ -154,6 +154,11 @@
         <li>
             <a href="{% url "info_page" slug='contact' %}">Contact</a>
         </li>
+        {% if settings.POPIT_API_URL %}
+        <li>
+            <a href="{% url 'help-api' %}">Get the data</a>
+        </li>
+        {% endif %}
     </ul>
     {% endif %}
 </li>


### PR DESCRIPTION
Overrides the core template to suppress the references to daily data dumps and "a number of ways of accessing ... data" if `dump_base_path` is not included in the view context

Note to self/deployer - relies on setting a valid `POPIT_API_URL` in the site config