### PR TITLE
Fix elasticsearch version mismatch, which caused errors on reindexing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Markdown==2.5.1
 django-markitup==2.2.1
 
 requests==2.5
-elasticsearch==1.2.0
+elasticsearch==0.4.5
 django-haystack==2.3.1
 
 # Testing helpers


### PR DESCRIPTION
In edd668252b8b44d82b56 I upgraded elasticsearch, but didn't take into
account that the newer elasticsearch is only for Elasticsearch 1; we have
to stay on a version in the 0.4 series since we use Elasticsearch 0.9 on
our servers:

  https://github.com/elasticsearch/elasticsearch-py#compatibility

This was causing the errors:

```
org.elasticsearch.indices.InvalidTypeNameException: mapping type name [_mapping] can't start with '_'
```

... on reindexing; this is due the URLs used when putting a mapping
having changed between Elasticsearch 0.9 and later versions,
e.g. compare:

  http://www.elasticsearch.org/guide/en/elasticsearch/reference/0.90/indices-put-mapping.html
  http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html

Thanks to Matthew Somerville for explaining what was going on here.

Fixes #1584