### PR TITLE
ZA: Paginate Hansards page

### DIFF
--- a/pombola/south_africa/fallback_urls.py
+++ b/pombola/south_africa/fallback_urls.py
@@ -34,9 +34,9 @@ urlpatterns = [
 # Make sure the top level custom indexes work:
 
 urlpatterns += patterns('',
-    url(r'^hansard/$', SAHansardIndex.as_view(), name='section-list-hansard'),
-    url(r'^committee-minutes/$', SACommitteeIndex.as_view(), name='section-list-committee-minutes'),
-    url(r'^question/$', SAQuestionIndex.as_view(), name='section-list-question'),
+    url(r'^hansard/?$', SAHansardIndex.as_view(), name='section-list-hansard'),
+    url(r'^committee-minutes/?$', SACommitteeIndex.as_view(), name='section-list-committee-minutes'),
+    url(r'^question/?$', SAQuestionIndex.as_view(), name='section-list-question'),
 )
 
 # Anything else unmatched we assume is dealt with by SayIt (which will

--- a/pombola/south_africa/templates/south_africa/hansard_index.html
+++ b/pombola/south_africa/templates/south_africa/hansard_index.html
@@ -21,9 +21,9 @@
 </div>
 
 
-{% regroup entries by section.parent.title.strip as by_title %}
+{% regroup entries by parent.title.strip as by_title %}
 {% for t in by_title %}
-  {% with first_section_id=t.list.0.section_id %}
+  {% with first_section_id=t.list.0.id %}
     {% regroup t.list by start_date as by_date %}
     <div>
         <a class="js-hide-reveal-link hansard-section-title has-dropdown-dark" href="#{{ t.grouper|slugify }}-{{ first_section_id }}">
@@ -36,7 +36,7 @@
         <div class="js-hide-reveal hansard-section" id="{{ t.grouper|slugify }}-{{ first_section_id }}">
             {% for item in t.list %}
             <p>
-                <a href="{% url 'speeches:section-view' item.section.get_path %}">{{ item.section.title }}</a>
+                <a href="{% url 'speeches:section-view' item.get_path %}">{{ item.title }}</a>
                 ({{ item.speech_count }})
             </p>
             {% endfor %}
@@ -45,4 +45,26 @@
     </div>
   {% endwith %}
 {% endfor %}
+
+<br ><br >
+<div class="step-pagination">
+    <span class="step-links">
+        {% if page_obj.has_previous %}
+          <a href="?page={{ page_obj.previous_page_number }}">
+              Previous
+          </a>
+        {% endif %}
+
+        <span class="current">
+          Page <strong>{{ page_obj.number }}</strong> of <strong>{{ page_obj.paginator.num_pages }}</strong>
+        </span>
+
+        {% if page_obj.has_next %}
+          <a href="?page={{ page_obj.next_page_number }}">
+              Next
+          </a>
+        {% endif %}
+    </span>
+</div>
+
 {% endblock %}

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -6,7 +6,7 @@ import re
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.http import Http404
-from django.db.models import Count
+from django.db.models import Count, Max, Min
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import redirect
@@ -637,10 +637,11 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
     template_name = 'south_africa/hansard_index.html'
     top_section_name='Hansard'
     sections_to_show = 25
-    section_parent_field = 'section__parent__parent__parent__parent__parent'
+    section_parent_field = 'parent__parent__parent__parent'
 
     def get_context_data(self, **kwargs):
         context = super(SASpeechesIndex, self).get_context_data(**kwargs)
+        self.page = self.request.GET.get('page')
 
         # Get the top level section, or 404
         top_section = get_object_or_404(Section, title=self.top_section_name, parent=None)
@@ -648,51 +649,61 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
 
         # As we know that the hansard section structure is
         # "Hansard" -> yyyy -> mm -> dd -> section -> subsection -> [speeches]
-        # we can create a very specific query to drill up to the top level one
-        # that we want.
+        # we can create very specific queries to fetch the sections
+        # then the subsections containing the speeches themselves.
+        #
+        # FIXME ideally we'd have start_date for sections rather than
+        # having to get MAX('start_date') from the speeches table
 
-        section_parent_filter = { self.section_parent_field : top_section }
-        entries = Speech \
+        # exclude sections without subsections and
+        # with subsections that have no speeches
+        section_filter = {
+            self.section_parent_field : top_section,
+            'children__speech__id__isnull' : False,
+            'children__id__isnull' : False
+         }
+
+        # get a list of all the sections
+        parent_sections = Section \
+              .objects \
+              .filter(**section_filter) \
+              .values('id', 'title') \
+              .annotate(latest_start_date=Max('children__speech__start_date')) \
+              .order_by('-latest_start_date')
+
+        # use Paginator to cut this down to the sections for the current page
+        paginator = Paginator(parent_sections, self.sections_to_show)
+        try:
+            top_level_sections = paginator.page(self.page)
+        except PageNotAnInteger:
+            top_level_sections = paginator.page(1)
+        except EmptyPage:
+            top_level_sections = paginator.page(paginator.num_pages)
+
+        # get the subsections based on the relevant section ids
+        # exclude those with blank titles as we have no way of linking to them
+        parent_ids = list(section['id'] for section in top_level_sections)
+        debate_sections = Section \
             .objects \
-            .filter(**section_parent_filter) \
-            .values('section_id', 'start_date') \
-            .annotate(speech_count=Count('id')) \
-            .order_by('-start_date')
+            .filter(parent_id__in=parent_ids, speech__id__isnull=False) \
+            .annotate(start_order=Min('speech__id'), start_date=Max('speech__start_date'), speech_count=Count('speech__id')) \
+            .exclude(title='') \
+            .order_by('-start_date', 'parent__id', 'start_order')
 
-        # loop through and add all the section objects. This is not efficient,
-        # but makes the templates easier as we can (for example) use get_absolute_url.
-        # Also lets us retrieve the last N parent sections which is what we need for the
-        # display.
-        parent_sections = set()
-        display_entries = []
-        for entry in entries:
-            section = Section.objects.get(pk=entry['section_id'])
-            parent_sections.add(section.parent.id)
-            if len(parent_sections) > self.sections_to_show:
-                break
-            display_entries.append(entry)
-            display_entries[-1]['section'] = section
-
-        # PAGINATION NOTE - it would be possible to add pagination to this by simply
-        # removing the `break` after self.sections_to_show has been reached and then
-        # finding a more efficient way to inflate the sections (perhaps using an
-        # embedded lambda, or a custom templatetag). However paginating this page may
-        # not be as useful as creating an easy to use drill down based on date, or
-        # indeed using search.
-
-        context['entries'] = display_entries
+        context['entries'] = debate_sections
+        context['page_obj'] = top_level_sections
         return context
 
 class SAHansardIndex(SASpeechesIndex):
     template_name = 'south_africa/hansard_index.html'
     top_section_name='Hansard'
-    section_parent_field = 'section__parent__parent__parent__parent__parent'
+    section_parent_field = 'parent__parent__parent__parent'
     sections_to_show = 25
 
 class SACommitteeIndex(SASpeechesIndex):
     template_name = 'south_africa/hansard_index.html'
     top_section_name='Committee Minutes'
-    section_parent_field = 'section__parent__parent__parent'
+    section_parent_field = 'parent__parent'
     sections_to_show = 25
 
 def questions_section_sort_key(section):


### PR DESCRIPTION
Adds pagination controls to the Hansard and Committee Minutes pages (they're derived from the same Index view).

Formulates the Sections queries in a top-down manner rather than the previous drill-up strategy. No longer retrieves individual Speech entries as only the speech counts are used by the display template.

Force groups the subsections by named section in SQL to remove duplicate section names as this was causing uneven pagination effects where one page could be 3 sections or more longer than expected while the next page may only consist of 2 sections. As this strategy has a knock-on effect of occasionally creating a really long list of subsections - which results in a large number of database lookups to render the links - the page length for Hansard listings has been shortened from 25 to 15 sections; hopefully this shouldn't be a major problem as adding pagination reduces the need to display as many things as possible on the first page. The Committee Minutes page is largely unaffected so remains a 25 section per page view.