### PR TITLE
ZA: update person profile page

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -108,6 +108,9 @@
   <div id="profile" class="tab-content tab-active">
 
     <div class="person-summary">
+      {% if person.date_of_death %}
+        <p>Died {{ person.date_of_death }}</p>
+      {% endif %}
       {{ person.summary }}
     </div>
 

--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -24,7 +24,15 @@
       {% for party in object.parties_and_coalitions %}
         <li><a href="{{ party.get_absolute_url }}">{{ party.name }}</a></li>
       {% empty %}
-        <li>Not a member of any party</li>
+        {% if former_parties %}
+          {% for party in former_parties %}
+            <li><a href="{{ party.get_absolute_url }}">{{ party.name }}</a></li>
+          {% empty %}
+            <li>Not a member of any party</li>
+          {% endfor %}
+        {% else %}
+          <li>Not a member of any party</li>
+        {% endif %}
       {% endfor %}
     </ul>
 

--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -133,6 +133,20 @@
         {% endif %}
     {% endwith %}
 
+    {% if former_positions %}
+      <h3>Former Positions</h3>
+      <ul class="former-positions positions">
+      {% for position in former_positions %}
+        <li>{% include "core/person_detail_position.html" %}
+          {% if position.start_date %}
+            from {{ position.start_date }}
+          {% endif %}
+          until {{ position.end_date }}
+        </li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+
     {% if hansard.count or question.count or committee.count %}<h2>Recent Appearances</h2> {% endif %}
 
     {% if committee.count %}

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -4,6 +4,7 @@ from datetime import date, time
 from StringIO import StringIO
 from tempfile import mkdtemp
 from urlparse import urlparse
+from BeautifulSoup import Tag, NavigableString
 
 from mock import patch
 
@@ -375,6 +376,32 @@ class SAPersonDetailViewTest(PersonSpeakerMappingsMixin, TestCase):
             len(context['interests'][interest_offset]['categories'][category_offset+1]['entries'][0]),
             len(expected[1]['categories'][2]['entries'][0])
         )
+
+
+@attr(country='south_africa')
+class SAPersonProfileSubPageTest(WebTest):
+    def setUp(self):
+        self.deceased = models.Person.objects.create(
+            legal_name="Deceased Person",
+            slug='deceased-person',
+            date_of_birth='1965-12-31',
+            date_of_death='2010-01-01',
+        )
+
+    def tearDown(self):
+        self.deceased.delete()
+
+    def get_profile_tab(self, soup):
+        return soup.find('div', id='profile')
+
+    def get_profile_info(self, soup):
+        return soup.find('div', id='hfProfileInfo')
+
+    def test_person_death_date(self):
+        response = self.app.get('/person/deceased-person/')
+        profile_tab = self.get_profile_tab(response.html)
+
+        self.assertEqual(profile_tab.findNext('div').p.contents[0], 'Died 1st January 2010')
 
 
 @attr(country='south_africa')


### PR DESCRIPTION
Fixes #1602

* Inserts date of death at the top of the summary box, if applicable
* Retains the person's party affiliation if the deceased's membership has ended
* If there is only one current position (this is lazily assumed to be a party membership) - or nothing at all - to display on the profile summary, positions within "important organisations" + Electoral List positions will appear under the heading "Former Positions" (this should exclude party and committee memberships to avoid duplicating the contents of the Experience tab, especially where there is a long list of former positions)