### PR TITLE
ZA: Replace election list org links with links to election candidate lists

### DIFF
--- a/pombola/south_africa/templates/core/person_detail_position.html
+++ b/pombola/south_africa/templates/core/person_detail_position.html
@@ -1,4 +1,22 @@
+{% load za_election_list_links %}
+
 {% with o=position.organisation %}
   {{ position.title }}
-    {% if o %} at <a href="{% url "organisation" slug=o.slug %}">{{ o }}</a>{% endif %}
+    {% if o %}
+      {% if 'election-list' in o.slug %}
+        {% with year=position.start_date.year|stringformat:"s" province=o.slug|get_place_slug %}
+          {% if 'provincial' in o.slug %}
+            at <a href="{% url "sa-election-candidates-provincial-party" election_year=year party_name=o.slug|get_party_slug province_name=province %}">{{o}}</a>
+          {% elif 'national' in o.slug %}
+            at <a href="{% url "sa-election-candidates-national-party" election_year=year party_name=o.slug|get_party_slug %}">{{o}}</a>
+          {% elif province %}
+            at <a href="{% url "sa-election-candidates-national-province-party" election_year=year party_name=o.slug|get_party_slug province_name=province %}">{{o}}</a>
+          {% else %}
+            at <a href="{% url "organisation" slug=o.slug %}">{{ o }}</a>
+          {% endif %}
+        {% endwith %}
+      {% else %}
+        at <a href="{% url "organisation" slug=o.slug %}">{{ o }}</a>
+      {% endif %}
+    {% endif %}
 {% endwith %}

--- a/pombola/south_africa/templatetags/za_election_list_links.py
+++ b/pombola/south_africa/templatetags/za_election_list_links.py
@@ -1,0 +1,38 @@
+from django import template
+import re
+
+register = template.Library()
+
+@register.filter()
+def get_party_slug(org_slug):
+    """Takes the original slug of an election list 'organisation' and returns
+    the party slug
+    """
+
+    re_matches = decompose_slug(org_slug)
+    return re_matches.group('party')
+
+@register.filter()
+def get_place_slug(org_slug):
+    """Takes the original slug of an election list 'organisation'
+    and returns the place (province) slug
+    (or None if the slug contains no province information)
+    """
+
+    re_matches = decompose_slug(org_slug)
+    return re_matches.group('place')
+
+def decompose_slug(slug):
+    """Returns regexp matches
+    """
+    election_list_slug_re = re.compile(
+        r'''^
+        (?P<party>.*)-
+        (?P<place_type>provincial|national|regional)-
+        (?:(?P<place>.*)-)*
+        election-list-
+        (?P<year>.*)
+        $''',
+        re.VERBOSE
+    )
+    return election_list_slug_re.search(slug)


### PR DESCRIPTION
On profile pages, the link to e.g. "3rd Candidate at Inkatha Freedom
Party National Election List 2014 (Election List)" were resolving to
blank pages as an Election List is only valid for a short time and will
have no associated members once the election is complete. This change
replaces these links (except in the case of a "Regional" election link
which look as though it may be a duplicate of "Provincial" election data)
with a link to the appropriate election candidate list instead.

Fixes #1603 