### PR TITLE
Make the survey / experiment views easier to reuse

### DIFF
--- a/pombola/experiments/views.py
+++ b/pombola/experiments/views.py
@@ -76,6 +76,25 @@ class ExperimentViewDataMixin(object):
         experiment = Experiment.objects.get(slug=self.experiment_slug)
         experiment.event_set.create(**event_kwargs)
 
+    def sanitize_data_parameters(self, request, parameters):
+        """Return a cleaned version of known experiment parameters"""
+        result = {}
+        result['variant'] = sanitize_parameter(
+            key='variant',
+            parameters=parameters,
+            allowed_values=self.variants,
+            default_value='n')
+        for key, possible_values in self.demographic_keys.items():
+            result[key] = sanitize_parameter(
+                key=key,
+                parameters=parameters,
+                allowed_values=possible_values,
+                default_value='?'
+            )
+        result['user_key'] = sanitize_random_key('user_key', parameters)
+        result['via'] = sanitize_random_key('via', parameters)
+        return result
+
 
 class ExperimentFormSubmissionMixin(ExperimentViewDataMixin):
     """A mixin useful for handling form data posted from an experiment page"""
@@ -122,25 +141,3 @@ def sanitize_random_key(key, parameters):
     if key in parameters and random_key_re.search(parameters[key]):
         return parameters[key]
     return '?'
-
-def sanitize_data_parameters(request, parameters):
-    """Return a cleaned version of known experiment parameters"""
-    result = {}
-    result['variant'] = sanitize_parameter(
-        key='variant',
-        parameters=parameters,
-        allowed_values=('o', 't', 'n', 'os', 'ts', 'ns'),
-        default_value='n')
-    result['g'] = sanitize_parameter(
-        key='g',
-        parameters=parameters,
-        allowed_values=('m', 'f'),
-        default_value='?')
-    result['agroup'] = sanitize_parameter(
-        key='agroup',
-        parameters=parameters,
-        allowed_values=('under', 'over'),
-        default_value='?')
-    result['user_key'] = sanitize_random_key('user_key', parameters)
-    result['via'] = sanitize_random_key('via', parameters)
-    return result

--- a/pombola/experiments/views.py
+++ b/pombola/experiments/views.py
@@ -1,0 +1,124 @@
+import json
+import re
+
+from pombola.experiments.models import Experiment
+from pombola.feedback.models import Feedback
+
+
+class ExperimentViewDataMixin(object):
+    """A mixin with helper methods for creating events and feedback
+
+    This assumes that you've created the view with as_view specifying
+    keyword arguments including:
+
+        experiment_slug (the slug for the Experiment model)
+        session_key_prefix (the prefix used before keys in the session)
+
+    Note that this mixin also assumes that you have the only keys you
+    need to store in the session are those identifying the user
+    ('user_key'), their demographics ('g' and 'agroup'), the variant
+    they got ('variant') and whether they came from a particular
+    message shared on social media ('via').
+    """
+
+    # We need to set all of these on the class, since you may only
+    # pass as keyword parameters into as_view properties that already
+    # exist on the class.
+    experiment_slug = None
+    session_key_prefix = None
+    base_view_name = None
+    pageview_label = None
+    experiment_key = None
+    qualtrics_sid = None
+    variants = None
+    demographic_keys= None
+
+    def qualify_key(self, key):
+        prefix = self.session_key_prefix
+        return prefix + ':' + key
+
+    def create_feedback(self, form, comment='', email=''):
+        """A helper method for adding feedback to the database"""
+        feedback = Feedback()
+        feedback.status = 'non-actionable'
+        prefix_data = self.get_session_data()
+        prefix_data['experiment_slug'] = self.experiment_slug
+        comment_prefix = json.dumps(prefix_data)
+        feedback.comment = comment_prefix + ' ' + comment
+        feedback.email = email
+        feedback.url = self.request.build_absolute_uri()
+        if self.request.user.is_authenticated():
+            feedback.user = self.request.user
+        feedback.save()
+
+    def get_session_data(self):
+        result = {}
+        for key in ('user_key', 'variant', 'g', 'agroup', 'via'):
+            full_key = self.qualify_key(key)
+            value = self.request.session.get(full_key)
+            if value is not None:
+                result[key] = value
+        return result
+
+    def create_event(self, data):
+        data.update(self.get_session_data())
+        standard_cols = ('user_key', 'variant', 'category', 'action', 'label')
+        event_kwargs = {}
+        extra_data = data.copy()
+        for column in standard_cols:
+            if column in data:
+                value = data.get(column, '?')
+                if value != '?':
+                    event_kwargs[column] = value
+                del extra_data[column]
+        extra_data_json = json.dumps(extra_data)
+        event_kwargs['extra_data'] = extra_data_json
+        experiment = Experiment.objects.get(slug=self.experiment_slug)
+        experiment.event_set.create(**event_kwargs)
+
+def sanitize_parameter(key, parameters, allowed_values, default_value=None):
+    """Check that the value for key in parameters is in allowed_values
+
+    If it's an allowed value, return that.  If it's not an allowed
+    value, and there's a default_value supplied, return the
+    default_value.  Otherwise (an unknown key, and no default_value)
+    raise a ValueError."""
+    value = parameters.get(key)
+    if value not in allowed_values:
+        if default_value is None:
+            message = "An allowed value for '{0}' must be provided"
+            raise ValueError(message.format(key))
+        value = default_value
+    return value
+
+# A regular expression that the random keys we generate must match in
+# order to be valid:
+random_key_re = re.compile(r'^[a-zA-Z0-9]+$')
+
+def sanitize_random_key(key, parameters):
+    """Return parameters[key] if it's valid or '?' otherwise"""
+    if key in parameters and random_key_re.search(parameters[key]):
+        return parameters[key]
+    return '?'
+
+def sanitize_data_parameters(request, parameters):
+    """Return a cleaned version of known experiment parameters"""
+    result = {}
+    result['variant'] = sanitize_parameter(
+        key='variant',
+        parameters=parameters,
+        allowed_values=('o', 't', 'n', 'os', 'ts', 'ns'),
+        default_value='n')
+    result['g'] = sanitize_parameter(
+        key='g',
+        parameters=parameters,
+        allowed_values=('m', 'f'),
+        default_value='?')
+    result['agroup'] = sanitize_parameter(
+        key='agroup',
+        parameters=parameters,
+        allowed_values=('under', 'over'),
+        default_value='?')
+    result['user_key'] = sanitize_random_key('user_key', parameters)
+    result['via'] = sanitize_random_key('via', parameters)
+    return result

--- a/pombola/experiments/views.py
+++ b/pombola/experiments/views.py
@@ -76,6 +76,28 @@ class ExperimentViewDataMixin(object):
         experiment = Experiment.objects.get(slug=self.experiment_slug)
         experiment.event_set.create(**event_kwargs)
 
+
+class ExperimentFormSubmissionMixin(ExperimentViewDataMixin):
+    """A mixin useful for handling form data posted from an experiment page"""
+
+    def form_invalid(self, form):
+        """Redirect back to a reduced version of the page from either form"""
+        extra_context = {
+            '{0}_form'.format(self.form_key): form,
+            'major_partials': ['_county_{0}.html'.format(self.form_key)],
+            'correct_errors': True}
+        context = self.get_context_data(**extra_context)
+        return self.render_to_response(context)
+
+    def form_valid(self, form):
+        self.create_feedback_from_form(form)
+        self.create_event({'category': 'form',
+                           'action': 'submit',
+                           'label': self.form_key})
+        return super(ExperimentFormSubmissionMixin,
+                     self).form_valid(form)
+
+
 def sanitize_parameter(key, parameters, allowed_values, default_value=None):
     """Check that the value for key in parameters is in allowed_values
 

--- a/pombola/kenya/urls.py
+++ b/pombola/kenya/urls.py
@@ -24,9 +24,10 @@ urlpatterns = patterns('',
 # Create the two County Performance pages:
 
 for experiment_slug in ('mit-county', 'mit-county-larger'):
-    base_name = EXPERIMENT_DATA[experiment_slug]['base_view_name']
-    base_path = r'^' + base_name
     view_kwargs = {'experiment_slug': experiment_slug}
+    view_kwargs.update(EXPERIMENT_DATA[experiment_slug])
+    base_name = view_kwargs['base_view_name']
+    base_path = r'^' + base_name
     urlpatterns.append(
         url(base_path + r'$',
             CountyPerformanceView.as_view(**view_kwargs),

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -16,7 +16,7 @@ from pombola.core.models import Person
 from pombola.core.views import PersonDetail, PersonDetailSub
 from pombola.experiments.views import (
     ExperimentViewDataMixin, ExperimentFormSubmissionMixin,
-    sanitize_parameter, sanitize_data_parameters
+    sanitize_parameter
 )
 from pombola.hansard.views import HansardPersonMixin
 from pombola.kenya import shujaaz
@@ -28,6 +28,11 @@ EXPERIMENT_DATA = {
         'pageview_label': 'county-performance',
         'experiment_key': None,
         'qualtrics_sid': 'SV_5hhE4mOfYG1eaOh',
+        'variants': ('o', 't', 'n', 'os', 'ts', 'ns'),
+        'demographic_keys': {
+            'g': ('m', 'f'),
+            'agroup': ('under', 'over'),
+        },
     },
     'mit-county-larger': {
         'session_key_prefix': 'MIT2',
@@ -35,6 +40,11 @@ EXPERIMENT_DATA = {
         'pageview_label': 'county-performance-2',
         'experiment_key': settings.COUNTY_PERFORMANCE_EXPERIMENT_KEY,
         'qualtrics_sid': 'SV_5hhE4mOfYG1eaOh',
+        'variants': ('o', 't', 'n', 'os', 'ts', 'ns'),
+        'demographic_keys': {
+            'g': ('m', 'f'),
+            'agroup': ('under', 'over'),
+        },
     }
 }
 
@@ -99,7 +109,10 @@ class CountyPerformanceView(ExperimentViewDataMixin, TemplateView):
             reverse(self.base_view_name + '-senate-submission')
         context['experiment_key'] = self.experiment_key
 
-        data = sanitize_data_parameters(self.request, self.request.GET)
+        data = self.sanitize_data_parameters(
+            self.request,
+            self.request.GET
+        )
         variant = data['variant']
 
         # If there's no user key in the session, this is the first

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -1,7 +1,6 @@
 # Create your views here.
 # -*- coding: utf-8 -*-
 
-import hashlib
 import json
 from random import randint, shuffle
 import re
@@ -9,18 +8,15 @@ import sys
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
 from django.utils.http import urlquote
 from django.views.generic.base import TemplateView, RedirectView
 from django.views.generic.edit import FormView
 
 from .forms import CountyPerformancePetitionForm, CountyPerformanceSenateForm
 
-from django.shortcuts import redirect
-
 from pombola.core.models import Person
 from pombola.core.views import PersonDetail, PersonDetailSub
-from pombola.experiments.models import Experiment, Event
+from pombola.experiments.models import Experiment
 from pombola.feedback.models import Feedback
 from pombola.hansard.views import HansardPersonMixin
 from pombola.kenya import shujaaz

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -15,7 +15,8 @@ from .forms import CountyPerformancePetitionForm, CountyPerformanceSenateForm
 from pombola.core.models import Person
 from pombola.core.views import PersonDetail, PersonDetailSub
 from pombola.experiments.views import (
-    ExperimentViewDataMixin, sanitize_parameter, sanitize_data_parameters
+    ExperimentViewDataMixin, ExperimentFormSubmissionMixin,
+    sanitize_parameter, sanitize_data_parameters
 )
 from pombola.hansard.views import HansardPersonMixin
 from pombola.kenya import shujaaz
@@ -145,28 +146,7 @@ class CountyPerformanceView(ExperimentViewDataMixin, TemplateView):
         return context
 
 
-class CountyPerformanceSubmissionMixin(ExperimentViewDataMixin):
-    """A mixin useful for handling senate comment and petition emails"""
-
-    def form_invalid(self, form):
-        """Redirect back to a reduced version of the page from either form"""
-        extra_context = {
-            '{0}_form'.format(self.form_key): form,
-            'major_partials': ['_county_{0}.html'.format(self.form_key)],
-            'correct_errors': True}
-        context = self.get_context_data(**extra_context)
-        return self.render_to_response(context)
-
-    def form_valid(self, form):
-        self.create_feedback_from_form(form)
-        self.create_event({'category': 'form',
-                           'action': 'submit',
-                           'label': self.form_key})
-        return super(CountyPerformanceSubmissionMixin,
-                     self).form_valid(form)
-
-
-class CountyPerformanceSenateSubmission(CountyPerformanceSubmissionMixin,
+class CountyPerformanceSenateSubmission(ExperimentFormSubmissionMixin,
                                         FormView):
     """A view for handling submissions of comments for the senate"""
 
@@ -182,7 +162,7 @@ class CountyPerformanceSenateSubmission(CountyPerformanceSubmissionMixin,
         self.create_feedback(form, comment=new_comment)
 
 
-class CountyPerformancePetitionSubmission(CountyPerformanceSubmissionMixin,
+class CountyPerformancePetitionSubmission(ExperimentFormSubmissionMixin,
                                           FormView):
     """A view for handling a petition signature"""
 

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -1,9 +1,7 @@
 # Create your views here.
 # -*- coding: utf-8 -*-
 
-import json
 from random import randint, shuffle
-import re
 import sys
 
 from django.conf import settings
@@ -16,8 +14,9 @@ from .forms import CountyPerformancePetitionForm, CountyPerformanceSenateForm
 
 from pombola.core.models import Person
 from pombola.core.views import PersonDetail, PersonDetailSub
-from pombola.experiments.models import Experiment
-from pombola.feedback.models import Feedback
+from pombola.experiments.views import (
+    ExperimentViewDataMixin, sanitize_parameter, sanitize_data_parameters
+)
 from pombola.hansard.views import HansardPersonMixin
 from pombola.kenya import shujaaz
 
@@ -75,102 +74,7 @@ class KEPersonDetailAppearances(HansardPersonMixin, PersonDetailSub):
         return context
 
 
-def sanitize_parameter(key, parameters, allowed_values, default_value=None):
-    """Check that the value for key in parameters is in allowed_values
-
-    If it's an allowed value, return that.  If it's not an allowed
-    value, and there's a default_value supplied, return the
-    default_value.  Otherwise (an unknown key, and no default_value)
-    raise a ValueError."""
-    value = parameters.get(key)
-    if value not in allowed_values:
-        if default_value is None:
-            message = "An allowed value for '{0}' must be provided"
-            raise ValueError(message.format(key))
-        value = default_value
-    return value
-
-# A regular expression that the random keys we generate must match in
-# order to be valid:
-random_key_re = re.compile(r'^[a-zA-Z0-9]+$')
-
-def sanitize_random_key(key, parameters):
-    """Return parameters[key] if it's valid or '?' otherwise"""
-    if key in parameters and random_key_re.search(parameters[key]):
-        return parameters[key]
-    return '?'
-
-def sanitize_data_parameters(request, parameters):
-    """Return a cleaned version of known experiment parameters"""
-    result = {}
-    result['variant'] = sanitize_parameter(
-        key='variant',
-        parameters=parameters,
-        allowed_values=('o', 't', 'n', 'os', 'ts', 'ns'),
-        default_value='n')
-    result['g'] = sanitize_parameter(
-        key='g',
-        parameters=parameters,
-        allowed_values=('m', 'f'),
-        default_value='?')
-    result['agroup'] = sanitize_parameter(
-        key='agroup',
-        parameters=parameters,
-        allowed_values=('under', 'over'),
-        default_value='?')
-    result['user_key'] = sanitize_random_key('user_key', parameters)
-    result['via'] = sanitize_random_key('via', parameters)
-    return result
-
-
-class CountyPerformanceDataMixin(object):
-    """A mixin with helper methods for creating events and feedback"""
-
-    def qualify_key(self, key):
-        prefix = EXPERIMENT_DATA[self.experiment_slug]['session_key_prefix']
-        return prefix + ':' + key
-
-    def create_feedback(self, form, comment='', email=''):
-        """A helper method for adding feedback to the database"""
-        feedback = Feedback()
-        feedback.status = 'non-actionable'
-        prefix_data = self.get_session_data()
-        prefix_data['experiment_slug'] = self.experiment_slug
-        comment_prefix = json.dumps(prefix_data)
-        feedback.comment = comment_prefix + ' ' + comment
-        feedback.email = email
-        feedback.url = self.request.build_absolute_uri()
-        if self.request.user.is_authenticated():
-            feedback.user = self.request.user
-        feedback.save()
-
-    def get_session_data(self):
-        result = {}
-        for key in ('user_key', 'variant', 'g', 'agroup', 'via'):
-            full_key = self.qualify_key(key)
-            value = self.request.session.get(full_key)
-            if value is not None:
-                result[key] = value
-        return result
-
-    def create_event(self, data):
-        data.update(self.get_session_data())
-        standard_cols = ('user_key', 'variant', 'category', 'action', 'label')
-        event_kwargs = {}
-        extra_data = data.copy()
-        for column in standard_cols:
-            if column in data:
-                value = data.get(column, '?')
-                if value != '?':
-                    event_kwargs[column] = value
-                del extra_data[column]
-        extra_data_json = json.dumps(extra_data)
-        event_kwargs['extra_data'] = extra_data_json
-        experiment = Experiment.objects.get(slug=self.experiment_slug)
-        experiment.event_set.create(**event_kwargs)
-
-
-class CountyPerformanceView(CountyPerformanceDataMixin, TemplateView):
+class CountyPerformanceView(ExperimentViewDataMixin, TemplateView):
     """This view displays a page about county performance with calls to action
 
     There are some elements of the page that are supposed to be
@@ -178,7 +82,6 @@ class CountyPerformanceView(CountyPerformanceDataMixin, TemplateView):
     page that include different information."""
 
     template_name = 'county-performance.html'
-    experiment_slug = None
 
     def get_context_data(self, **kwargs):
         context = super(CountyPerformanceView, self).get_context_data(**kwargs)
@@ -186,16 +89,14 @@ class CountyPerformanceView(CountyPerformanceDataMixin, TemplateView):
         context['senate_form'] = CountyPerformanceSenateForm()
 
         # Add URLs based on the experiment that's being run:
-        experiment_data = EXPERIMENT_DATA[self.experiment_slug]
-        base_view_name = experiment_data['base_view_name']
-        context['survey_url'] = reverse(base_view_name + '-survey')
-        context['base_url'] = reverse(base_view_name)
-        context['share_url'] = reverse(base_view_name + '-share')
+        context['survey_url'] = reverse(self.base_view_name + '-survey')
+        context['base_url'] = reverse(self.base_view_name)
+        context['share_url'] = reverse(self.base_view_name + '-share')
         context['petition_submission_url'] = \
-            reverse(base_view_name + '-petition-submission')
+            reverse(self.base_view_name + '-petition-submission')
         context['senate_submission_url'] = \
-            reverse(base_view_name + '-senate-submission')
-        context['experiment_key'] = experiment_data['experiment_key']
+            reverse(self.base_view_name + '-senate-submission')
+        context['experiment_key'] = self.experiment_key
 
         data = sanitize_data_parameters(self.request, self.request.GET)
         variant = data['variant']
@@ -220,10 +121,9 @@ class CountyPerformanceView(CountyPerformanceDataMixin, TemplateView):
         if 'utm_expid' in self.request.GET:
             self.request.session[self.qualify_key('variant')] = variant
             # Now create the page view event:
-            label = EXPERIMENT_DATA[self.experiment_slug]['pageview_label']
             self.create_event({'category': 'page',
                                'action': 'view',
-                               'label': label})
+                               'label': self.pageview_label})
 
         context['show_social_context'] = variant in ('ns', 'ts', 'os')
         context['show_threat'] = (variant[0] == 't')
@@ -245,7 +145,7 @@ class CountyPerformanceView(CountyPerformanceDataMixin, TemplateView):
         return context
 
 
-class CountyPerformanceSubmissionMixin(CountyPerformanceDataMixin):
+class CountyPerformanceSubmissionMixin(ExperimentViewDataMixin):
     """A mixin useful for handling senate comment and petition emails"""
 
     def form_invalid(self, form):
@@ -273,11 +173,9 @@ class CountyPerformanceSenateSubmission(CountyPerformanceSubmissionMixin,
     template_name = 'county-performance.html'
     form_class = CountyPerformanceSenateForm
     form_key = 'senate'
-    experiment_slug = None
 
     def get_success_url(self):
-        base_view_name = EXPERIMENT_DATA[self.experiment_slug]['base_view_name']
-        return '/{0}/senate/thanks'.format(base_view_name)
+        return '/{0}/senate/thanks'.format(self.base_view_name)
 
     def create_feedback_from_form(self, form):
         new_comment = form.cleaned_data.get('comments', '').strip()
@@ -291,11 +189,9 @@ class CountyPerformancePetitionSubmission(CountyPerformanceSubmissionMixin,
     template_name = 'county-performance.html'
     form_class = CountyPerformancePetitionForm
     form_key = 'petition'
-    experiment_slug = None
 
     def get_success_url(self):
-        base_view_name = EXPERIMENT_DATA[self.experiment_slug]['base_view_name']
-        return '/{0}/petition/thanks'.format(base_view_name)
+        return '/{0}/petition/thanks'.format(self.base_view_name)
 
     def create_feedback_from_form(self, form):
         new_comment = form.cleaned_data.get('name', '').strip()
@@ -304,11 +200,10 @@ class CountyPerformancePetitionSubmission(CountyPerformanceSubmissionMixin,
                              email=form.cleaned_data.get('email'))
 
 
-class CountyPerformanceShare(CountyPerformanceDataMixin, RedirectView):
+class CountyPerformanceShare(ExperimentViewDataMixin, RedirectView):
     """For recording & enacting Facebook / Twitter share actions"""
 
     permanent = False
-    experiment_slug = None
 
     def get_redirect_url(self, *args, **kwargs):
         social_network = sanitize_parameter(
@@ -320,7 +215,7 @@ class CountyPerformanceShare(CountyPerformanceDataMixin, RedirectView):
                            'action': 'click',
                            'label': social_network,
                            'share_key': share_key})
-        path = reverse(EXPERIMENT_DATA[self.experiment_slug]['base_view_name'])
+        path = reverse(self.base_view_name)
         built = self.request.build_absolute_uri(path)
         built += '?via=' + share_key
         url_parameter = urlquote(built, safe='')
@@ -330,18 +225,17 @@ class CountyPerformanceShare(CountyPerformanceDataMixin, RedirectView):
         return url_formats[social_network].format(url_parameter)
 
 
-class CountyPerformanceSurvey(CountyPerformanceDataMixin, RedirectView):
+class CountyPerformanceSurvey(ExperimentViewDataMixin, RedirectView):
     """For redirecting to the Qualtrics survey"""
 
     permanent = False
-    experiment_slug = None
 
     def get_redirect_url(self, *args, **kwargs):
         self.create_event({'category': 'take-survey',
                            'action': 'click',
                            'label': 'take-survey'})
-        prefix = EXPERIMENT_DATA[self.experiment_slug]['session_key_prefix']
-        sid = EXPERIMENT_DATA[self.experiment_slug]['qualtrics_sid']
+        prefix = self.session_key_prefix
+        sid = self.qualtrics_sid
         url = "http://survey.az1.qualtrics.com/SE/?SID={0}&".format(sid)
         url += "&".join(
             k + "=" + self.request.session.get(prefix + ':' + k, '?')

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -235,6 +235,7 @@ class CountyPerformanceSurvey(ExperimentViewDataMixin, RedirectView):
             for k in ('user_key', 'variant', 'g', 'agroup'))
         return url
 
+
 class ThanksTemplateView(TemplateView):
 
     base_view_name = None


### PR DESCRIPTION
The views used for the County Performance experiments could be
reused for other similar pages, but several properties of those
experiments were hardcoded in the views. In addition, it makes
sense for the generic view code to be in the experiments application
instead of kenya.