### PR TITLE
KE: Move committee memberships to own section on profile pages

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1087,6 +1087,14 @@ class PositionQuerySet(models.query.GeoQuerySet):
         """Filter down to only the political category"""
         return self.filter(category='political')
 
+    def committees(self):
+        """Filter down to committee memberships"""
+        return self.filter(organisation__slug__contains='committee') \
+            .order_by('-end_date', '-start_date')
+
+    def exclude_committees(self):
+        return self.exclude(organisation__slug__contains='committee')
+
     def education(self):
         """Filter down to only the education category"""
         return self.filter(category='education')

--- a/pombola/kenya/templates/core/person_experience.html
+++ b/pombola/kenya/templates/core/person_experience.html
@@ -1,0 +1,37 @@
+{% extends 'core/person_base.html' %}
+
+{% block title %}{{ object.name }} Experience{% endblock %}
+
+{% block subcontent %}
+  <h2>Experience</h2>
+  <div>
+      <div class="left-col">
+          <section>
+              <h3>Current Political Positions</h3>
+              {% include 'core/person_position_section.html' with positions=object.position_set.all.political.currently_active.exclude_committees %}
+          </section>
+
+          <section>
+              <h3>Previous Political Positions</h3>
+              {% include 'core/person_position_section.html' with positions=object.position_set.all.political.currently_inactive.exclude_committees %}
+          </section>
+
+          <section>
+              <h3>Committee Memberships</h3>
+              {% include 'core/person_position_section.html' with positions=object.position_set.all.committees %}
+          </section>
+      </div>
+
+      <div class="right-col">
+          <section>
+              <h3>Job History</h3>
+              {% include 'core/person_position_section.html' with positions=object.position_set.all.other %}
+          </section>
+
+          <section>
+              <h3>Education</h3>
+              {% include 'core/person_position_section.html' with positions=object.position_set.all.education %}
+          </section>
+      </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
* Adds `committees` and `exclude_committees` filters to `PositionQuerySet`
* Excludes committee memberships from the existing sections and groups them into a new **Committee Memberships** which sits in the lefthand column, under **Previous Political Positions**

The new committee filter checks whether the organisation's slug contains 'committee' which may ultimately prove fragile, but I couldn't see a more reliable option.

Closes #1643