### PR TITLE
Stop using Google Analytics' Content Experiments for randomizing pages

### DIFF
--- a/pombola/experiments/views.py
+++ b/pombola/experiments/views.py
@@ -38,6 +38,7 @@ class ExperimentViewDataMixin(object):
     experiment_key = None
     qualtrics_sid = None
     variants = None
+    default_variant = None
     demographic_keys = None
     major_partials = None
 
@@ -99,7 +100,7 @@ class ExperimentViewDataMixin(object):
             key='variant',
             parameters=parameters,
             allowed_values=self.variants,
-            default_value='n')
+            default_value=self.default_variant)
         for key, possible_values in self.demographic_keys.items():
             result[key] = sanitize_parameter(
                 key=key,

--- a/pombola/experiments/views.py
+++ b/pombola/experiments/views.py
@@ -45,6 +45,12 @@ class ExperimentViewDataMixin(object):
         prefix = self.session_key_prefix
         return prefix + ':' + key
 
+    def get_session_value(self, key):
+        return self.request.session.get(self.qualify_key(key))
+
+    def set_session_value(self, key, value):
+        self.request.session[self.qualify_key(key)] = value
+
     def create_feedback(self, form, comment='', email=''):
         """A helper method for adding feedback to the database"""
         feedback = Feedback()
@@ -64,8 +70,7 @@ class ExperimentViewDataMixin(object):
         session_keys = ['user_key', 'variant', 'via']
         session_keys += self.demographic_keys.keys()
         for key in session_keys:
-            full_key = self.qualify_key(key)
-            value = self.request.session.get(full_key)
+            value = self.get_session_value(key)
             if value is not None:
                 result[key] = value
         return result

--- a/pombola/experiments/views.py
+++ b/pombola/experiments/views.py
@@ -1,5 +1,5 @@
 import json
-from random import randint
+from random import randint, choice
 import re
 import sys
 
@@ -45,6 +45,19 @@ class ExperimentViewDataMixin(object):
     def qualify_key(self, key):
         prefix = self.session_key_prefix
         return prefix + ':' + key
+
+    def get_random_variant(self, local_random=None):
+        if local_random is None:
+            return choice(self.variants)
+        return local_random.choice(self.variants)
+
+    def get_variant_from_session(self):
+        # If there's a variant in the session already, that's the one
+        # we'll use, so people get a consistent variant when they
+        # return to the page:
+        session_key = self.qualify_key('variant')
+        if session_key in self.request.session:
+            return self.request.session[session_key]
 
     def get_session_value(self, key):
         return self.request.session.get(self.qualify_key(key))

--- a/pombola/kenya/templates/county-performance.html
+++ b/pombola/kenya/templates/county-performance.html
@@ -9,22 +9,6 @@
 {% endcomment %}
 
 {% block ga_experiment %}
-{% if experiment_key %}
-<!-- Google Analytics Content Experiment code -->
-<script>function utmx_section(){}function utmx(){}(function(){var
-k='{{ experiment_key }}',d=document,l=d.location,c=d.cookie;
-if(l.search.indexOf('utm_expid='+k)>0)return;
-function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.
-indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.
-length:j))}}}var x=f('__utmx'),xx=f('__utmxx'),h=l.hash;d.write(
-'<sc'+'ript src="'+'http'+(l.protocol=='https:'?'s://ssl':
-'://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+
-'&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().
-valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
-'" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();
-</script><script>utmx('url','A/B');</script>
-<!-- End of Google Analytics Content Experiment code -->
-{% endif %}
 {% endblock %}
 
 {% block title %}How are our taxpayer shillings really being spent?{% endblock %}

--- a/pombola/kenya/templates/youth-employment.html
+++ b/pombola/kenya/templates/youth-employment.html
@@ -9,22 +9,6 @@
 {% endcomment %}
 
 {% block ga_experiment %}
-{% if experiment_key %}
-<!-- Google Analytics Content Experiment code -->
-<script>function utmx_section(){}function utmx(){}(function(){var
-k='{{ experiment_key }}',d=document,l=d.location,c=d.cookie;
-if(l.search.indexOf('utm_expid='+k)>0)return;
-function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.
-indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.
-length:j))}}}var x=f('__utmx'),xx=f('__utmxx'),h=l.hash;d.write(
-'<sc'+'ript src="'+'http'+(l.protocol=='https:'?'s://ssl':
-'://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+
-'&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().
-valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
-'" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();
-</script><script>utmx('url','A/B');</script>
-<!-- End of Google Analytics Content Experiment code -->
-{% endif %}
 {% endblock %}
 
 {% block title %}What is our Government doing about unemployment?{% endblock %}

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -34,6 +34,7 @@ EXPERIMENT_DATA = {
         'experiment_key': None,
         'qualtrics_sid': 'SV_5hhE4mOfYG1eaOh',
         'variants': ('o', 't', 'n', 'os', 'ts', 'ns'),
+        'default_variant': 'n',
         'demographic_keys': {
             'g': ('m', 'f'),
             'agroup': ('under', 'over'),
@@ -52,6 +53,7 @@ EXPERIMENT_DATA = {
         'experiment_key': settings.COUNTY_PERFORMANCE_EXPERIMENT_KEY,
         'qualtrics_sid': 'SV_5hhE4mOfYG1eaOh',
         'variants': ('o', 't', 'n', 'os', 'ts', 'ns'),
+        'default_variant': 'n',
         'demographic_keys': {
             'g': ('m', 'f'),
             'agroup': ('under', 'over'),
@@ -70,6 +72,7 @@ EXPERIMENT_DATA = {
         'experiment_key': settings.YOUTH_EMPLOYMENT_BILL_EXPERIMENT_KEY,
         'qualtrics_sid': 'SV_ebVXgzAevcuo2sB',
         'variants': ('y', 'n'),
+        'default_variant': 'n',
         'demographic_keys': {
             'g': ('m', 'f'),
             'agroup': ('under', 'over'),


### PR DESCRIPTION
All the data that MIT want is being stored in our database, and we're
not using Google Analytics for anything except picking a random variant
of the page.  Using it for randomization also has a few difficulties:
    
 * It does a redirect after the page load, and sometimes we don't seem
   to be getting that redirect (because of Javascript failures or
   network problems, we assume)
    
 * There's not a natural goal we can set for the content experiment, so
   we've just been setting 99.5% confidence that one variant increases
   page views across the site as a whole, which is unlikely to happen
   and stop the experiment, but still seems silly.
    
 * The code in the view is unnecessarily complicated to deal with
   essentially ignoring page views without a utm_expid.
    
So, this commit switches to picking a variant randomly ourselves, so
there should only be a single page load after clicking the Facebook
advertisement.
