### PR TITLE
Fix location search form layout

### DIFF
--- a/pombola/search/templates/search/location.html
+++ b/pombola/search/templates/search/location.html
@@ -6,7 +6,10 @@
 {% endblock %}
 
 {% block search_form %}
-  <input type="text" name="q" value="{{ query }}" id="id_q" />
+  <div class="inline-search-box">
+    <input type="text" name="q" value="{{ query }}" id="id_q" placeholder="Enter your location&hellip;"/>
+    <input type="submit" value="Search" class="button">
+  </div>
 {% endblock %}
 
 {% block search_results %}

--- a/pombola/search/templates/search/location.html
+++ b/pombola/search/templates/search/location.html
@@ -13,31 +13,35 @@
 {% endblock %}
 
 {% block search_results %}
-  {% compressed_js 'google-map' %}
+  {% if geocoder_results %}
+    {% compressed_js 'google-map' %}
 
-  <div class="geocoded_results">
+    <div class="geocoded_results">
 
-    <div id="map_canvas">&nbsp;</div>
+      <div id="map_canvas">&nbsp;</div>
 
-    <ul>
-      {% for result in geocoder_results %}
-        <li>
-          <a href="/place/latlon/{{ result.latitude }},{{result.longitude }}/">
-            {{ result.address }}
-          </a>
-        </li>
-        <script>
-          markers_to_add.push({
-            lat: {{ result.latitude }},
-            lng: {{ result.longitude }},
-            url: "/place/latlon/{{ result.latitude }},{{result.longitude }}/",
-            name: "{{ result.address }}"
-          });
-        </script>
-      {% endfor %}
-    </ul>
+      <ul>
+        {% for result in geocoder_results %}
+          <li>
+            <a href="/place/latlon/{{ result.latitude }},{{result.longitude }}/">
+              {{ result.address }}
+            </a>
+          </li>
+          <script>
+            markers_to_add.push({
+              lat: {{ result.latitude }},
+              lng: {{ result.longitude }},
+              url: "/place/latlon/{{ result.latitude }},{{result.longitude }}/",
+              name: "{{ result.address }}"
+            });
+          </script>
+        {% endfor %}
+      </ul>
 
-    <br style="clear: both;">
+      <br style="clear: both;">
 
-  </div>
+    </div>
+  {% else %}
+    No results for the location '{{ query }}'
+  {% endif %}
 {% endblock %}

--- a/pombola/search/tests/views.py
+++ b/pombola/search/tests/views.py
@@ -7,31 +7,31 @@ from mock import patch
 def fake_geocoder(country, q, decimal_places=3):
     if q == 'anywhere':
         return []
-    elif q == 'Cape Town':
+    elif q == 'Garissa':
         return [
-            {'latitude': -33.925,
-             'longitude': 18.424,
-             'address': u'Cape Town, South Africa'}
+            {'latitude': -0.453,
+             'longitude': 39.646,
+             'address': u'Garissa, Kenya'}
         ]
-    elif q == 'Trafford Road':
+    elif q == 'Rift Valley':
         return [
-            {'latitude': -29.814,
-             'longitude': 30.839,
-             'address': u'Trafford Road, Pinetown 3610, South Africa'},
-            {'latitude': -33.969,
-             'longitude': 18.703,
-             'address': u'Trafford Road, Cape Town 7580, South Africa'},
-            {'latitude': -32.982,
-             'longitude': 27.868,
-             'address': u'Trafford Road, East London 5247, South Africa'}
+            {'latitude': 0.524,
+             'longitude': 35.273,
+             'address': u'Rift Valley Railways Eldoret, Eldoret, Kenya'},
+            {'latitude': -0.944,
+             'longitude': 36.596,
+             'address': u'Rift Valley Academy - AIM, Kijabe, Kenya'},
+            {'latitude': 0.0,
+             'longitude': 36.0,
+             'address': u'Eastern Rift Valley, Kenya'}
         ]
     else:
         raise Exception, u"Unexpected input to fake_geocoder: {}".format(q)
 
 # If there's no COUNTRY_APP set then the GeocodeView will fail, so use
-# south_africa for testing location search:
+# kenya for testing location search:
 
-@override_settings(COUNTRY_APP='south_africa')
+@override_settings(COUNTRY_APP='kenya')
 class SearchViewTest(WebTest):
 
     def setUp(self):
@@ -42,9 +42,8 @@ class SearchViewTest(WebTest):
         response = self.app.get(
             "{0}?q={1}".format(self.search_location_url, 'anywhere'))
         results_div = response.html.find('div', class_='geocoded_results')
-        lis = results_div.find('ul').findAll('li')
-        self.assertEqual(len(lis), 0)
-        mocked_geocoder.assert_called_once_with(q='anywhere', country='za')
+        self.assertIsNone(results_div)
+        mocked_geocoder.assert_called_once_with(q='anywhere', country='ke')
 
     def get_search_result_list_items(self, query_string):
         response = self.app.get(
@@ -54,16 +53,16 @@ class SearchViewTest(WebTest):
 
     @patch('pombola.search.views.geocoder', side_effect=fake_geocoder)
     def test_single_result_place(self, mocked_geocoder):
-        lis = self.get_search_result_list_items('Cape Town')
+        lis = self.get_search_result_list_items('Garissa')
         self.assertEqual(len(lis), 1)
-        self.assertEqual(lis[0].a['href'], '/place/latlon/-33.925,18.424/')
-        mocked_geocoder.assert_called_once_with(q='Cape Town', country='za')
+        self.assertEqual(lis[0].a['href'], '/place/latlon/-0.453,39.646/')
+        mocked_geocoder.assert_called_once_with(q='Garissa', country='ke')
 
     @patch('pombola.search.views.geocoder', side_effect=fake_geocoder)
     def test_multiple_result_place(self, mocked_geocoder):
-        lis = self.get_search_result_list_items('Trafford Road')
+        lis = self.get_search_result_list_items('Rift Valley')
         self.assertEqual(len(lis), 3)
-        self.assertEqual(lis[0].a['href'], '/place/latlon/-29.814,30.839/')
-        self.assertEqual(lis[1].a['href'], '/place/latlon/-33.969,18.703/')
-        self.assertEqual(lis[2].a['href'], '/place/latlon/-32.982,27.868/')
-        mocked_geocoder.assert_called_once_with(q='Trafford Road', country='za')
+        self.assertEqual(lis[0].a['href'], '/place/latlon/0.524,35.273/')
+        self.assertEqual(lis[1].a['href'], '/place/latlon/-0.944,36.596/')
+        self.assertEqual(lis[2].a['href'], '/place/latlon/0.0,36.0/')
+        mocked_geocoder.assert_called_once_with(q='Rift Valley', country='ke')

--- a/pombola/south_africa/templates/search/location.html
+++ b/pombola/south_africa/templates/search/location.html
@@ -25,31 +25,35 @@
 {% endblock %}
 
 {% block search_results %}
-  {% compressed_js 'google-map' %}
+  {% if geocoder_results %}
+    {% compressed_js 'google-map' %}
 
-  <div class="geocoded_results">
+    <div class="geocoded_results">
 
-    <div id="map_canvas">&nbsp;</div>
+      <div id="map_canvas">&nbsp;</div>
 
-    <ul>
-      {% for result in geocoder_results %}
-        <li>
-          <a href="/place/latlon/{{ result.latitude }},{{result.longitude }}/">
-            {{ result.address }}
-          </a>
-        </li>
-        <script>
-          markers_to_add.push({
-            lat: {{ result.latitude }},
-            lng: {{ result.longitude }},
-            url: "/place/latlon/{{ result.latitude }},{{result.longitude }}/",
-            name: "{{ result.address }}"
-          });
-        </script>
-      {% endfor %}
-    </ul>
+      <ul>
+        {% for result in geocoder_results %}
+          <li>
+            <a href="/place/latlon/{{ result.latitude }},{{result.longitude }}/">
+              {{ result.address }}
+            </a>
+          </li>
+          <script>
+            markers_to_add.push({
+              lat: {{ result.latitude }},
+              lng: {{ result.longitude }},
+              url: "/place/latlon/{{ result.latitude }},{{result.longitude }}/",
+              name: "{{ result.address }}"
+            });
+          </script>
+        {% endfor %}
+      </ul>
 
-    <br style="clear: both;">
+      <br style="clear: both;">
 
-  </div>
+    </div>
+  {% else %}
+    No results for the location '{{ query }}'
+  {% endif %}
 {% endblock %}

--- a/pombola/south_africa/templates/search/location.html
+++ b/pombola/south_africa/templates/search/location.html
@@ -18,8 +18,10 @@
 {% endblock %}
 
 {% block search_form %}
-  <input type="text" name="q" value="{{ query }}" id="id_q" placeholder="Enter your location&hellip;"/>
-
+  <div class="inline-search-box">
+    <input type="text" name="q" value="{{ query }}" id="id_q" placeholder="Enter your location&hellip;"/>
+    <input type="submit" value="Search" class="button">
+  </div>
 {% endblock %}
 
 {% block search_results %}

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -29,9 +29,32 @@ from pombola import south_africa
 from pombola.core.views import PersonSpeakerMappingsMixin
 from instances.models import Instance
 from pombola.interests_register.models import Category, Release, Entry, EntryLineItem
-from pombola.search.tests.views import fake_geocoder
 
 from nose.plugins.attrib import attr
+
+def fake_geocoder(country, q, decimal_places=3):
+    if q == 'anywhere':
+        return []
+    elif q == 'Cape Town':
+        return [
+            {'latitude': -33.925,
+             'longitude': 18.424,
+             'address': u'Cape Town, South Africa'}
+        ]
+    elif q == 'Trafford Road':
+        return [
+            {'latitude': -29.814,
+             'longitude': 30.839,
+             'address': u'Trafford Road, Pinetown 3610, South Africa'},
+            {'latitude': -33.969,
+             'longitude': 18.703,
+             'address': u'Trafford Road, Cape Town 7580, South Africa'},
+            {'latitude': -32.982,
+             'longitude': 27.868,
+             'address': u'Trafford Road, East London 5247, South Africa'}
+        ]
+    else:
+        raise Exception, u"Unexpected input to fake_geocoder: {}".format(q)
 
 @attr(country='south_africa')
 class HomeViewTest(TestCase):

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -187,8 +187,12 @@ class SASearchViewTest(WebTest):
 
     @patch('pombola.search.views.geocoder', side_effect=fake_geocoder)
     def test_unknown_place(self, mocked_geocoder):
-        lis = self.get_search_result_list_items('anywhere')
-        self.assertEqual(len(lis), 0)
+        response = self.app.get(
+            "{0}?q={1}".format(self.search_location_url, 'anywhere'))
+        self.assertIsNone(
+            response.html.find('div', class_='geocoded_results')
+        )
+        self.assertIn("No results for the location 'anywhere'", response)
         mocked_geocoder.assert_called_once_with(q='anywhere', country='za')
 
     @patch('pombola.search.views.geocoder', side_effect=fake_geocoder)


### PR DESCRIPTION
This adds a submit button to the location search form and applies the search form stylings that are used elsewhere.

It should also prevent a blank map from being displayed when there are no search results

(Applies to the base search/location template as well as the custom template for South Africa)

Fixes #1657 

<!---
@huboard:{"order":838.5,"milestone_order":1697,"custom_state":""}
-->
