### PR TITLE
Fix the ShineYourEye PU number lookup

### DIFF
--- a/pombola/nigeria/tests.py
+++ b/pombola/nigeria/tests.py
@@ -1,11 +1,14 @@
 import unittest
 import doctest
+import re
 from . import views
 
 from django.test import TestCase
+from django_webtest import WebTest
 
 from nose.plugins.attrib import attr
 
+from mapit.models import Area, CodeType, NameType, Type
 from pombola.info.models import InfoPage
 
 # Needed to run the doc tests in views.py
@@ -40,3 +43,95 @@ class InfoBlogListTest(TestCase):
     def test_html_not_escaped(self):
         response = self.client.get('/blog/')
         self.assertNotIn('&lt;p&gt;', response.content)
+
+
+@attr(country='nigeria')
+class NGSearchViewTest(WebTest):
+
+    def setUp(self):
+        self.poll_unit_code_type = CodeType.objects.create(
+            code='poll_unit',
+            description='Polling Unit Number',
+            )
+
+        self.poll_unit_name_type = NameType.objects.create(
+            code='poll_unit',
+            description='Polling Unit Number names',
+            )
+
+        self.lga_type = Type.objects.create(
+            code='LGA',
+            description='LGA',
+            )
+
+        self.mapit_test_lga = Area.objects.create(
+            name="Akoko South West",
+            type=self.lga_type,
+            )
+
+        self.mapit_test_lga.codes.get_or_create(
+            type=self.poll_unit_code_type,
+            code="OD:4",
+         )
+
+        self.mapit_test_lga.names.get_or_create(
+            type=self.poll_unit_name_type,
+            name="AKOKO SOUTH WEST"
+        )
+
+        self.ward_type = Type.objects.create(
+            code='WRD',
+            description='Ward',
+            )
+
+        self.mapit_test_ward = Area.objects.create(
+            name="Test Ward",
+            type=self.ward_type,
+            parent_area = self.mapit_test_lga,
+            )
+
+        self.mapit_test_ward.codes.get_or_create(
+            type=self.poll_unit_code_type,
+            code="OD:4:7",
+         )
+
+        self.mapit_test_ward.names.get_or_create(
+            type=self.poll_unit_name_type,
+            name="Test Ward"
+        )
+
+    def tearDown(self):
+        self.mapit_test_ward.delete()
+        self.ward_type.delete()
+        self.mapit_test_lga.delete()
+        self.lga_type.delete()
+        self.poll_unit_name_type.delete()
+        self.poll_unit_code_type.delete()
+
+    def test_four_part_pun_is_recognised(self):
+        response = self.app.get("/search/?q=01:02:03:04")
+        self.assertIn(
+            'No results were found for the poll unit number AB:2:3:4',
+            response.content
+        )
+
+    def test_slash_formatted_pun_is_recognised(self):
+        response = self.app.get("/search/?q=01/02/03/04")
+        self.assertIn(
+            'No results were found for the poll unit number AB:2:3:4',
+            response.content
+        )
+
+    def test_partial_match(self):
+        response = self.app.get("/search/?q=28/04/09")
+        self.assertIn(
+            'Best match is "AKOKO SOUTH WEST" with poll unit number \'OD:4\'',
+            response.content
+        )
+
+    def test_complete_match(self):
+        response = self.app.get("/search/?q=28/04/07")
+        self.assertIn(
+            'Best match is "Test Ward" with poll unit number \'OD:4:7\'',
+            response.content
+        )

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -117,7 +117,8 @@ pun_re = re.compile('''
     ^(
        [A-Z]{2}|
        [A-Z]{2}:\d+|
-       [A-Z]{2}:\d+:\d+
+       [A-Z]{2}:\d+:\d+|
+       [A-Z]{2}:\d+:\d+:\d+
     )$
 ''', re.VERBOSE)
 
@@ -183,7 +184,7 @@ class NGSearchView(SearchBaseView):
         super(NGSearchView, self).parse_params()
         tidied_as_if_pun = tidy_up_pun(self.query)
         # Check if this is a known form of PUN:
-        if pun_re.search(self.query):
+        if pun_re.search(tidied_as_if_pun):
             self.pun = tidied_as_if_pun
         else:
             self.pun = None


### PR DESCRIPTION
This was breaking because the regex that was checking for a valid
PU number was expecting a PU formatted string and we were passing
it the raw query instead, so the PU lookup was being bypassed
unless the search string took the form of OD:1:2.

Although we don't do anything with the last part of a full 4 part
PU number, we are now accepting the full 01:02:03:04 format as
input for our PU number lookup.

Fixes #1675 

<!---
@huboard:{"order":368.1259765625}
-->
