### PR TITLE
NG: Add events link to main site nav

### DIFF
--- a/pombola/nigeria/templates/menu_entries.html
+++ b/pombola/nigeria/templates/menu_entries.html
@@ -58,6 +58,9 @@
 </li>
 
 
+<li><a href="{% url "info_page" slug='events' %}">Events</a></li>
+
+
 <li><a href="{% url "info_blog_list" %}">Blog</a></li>
 
 


### PR DESCRIPTION
Adds link to "Events" between the main navigation, between "Places" and "Blog" (which feels right as there is no subnavigation).

I have also removed the "This is an example of an events page (not currently linked to from the main navigation)" and the duplicate header from the Events infopage in the ShineYourEye admin.

I have noticed that the breadcrumb for that page is Home >> Information >> Events where clicking on Information results in a 404 (the already published About page has the same issue), which is not ideal.

Also we should probably check back with ShineYourEye to make sure the Events page is ready for launch before we deploy.

Fixes #1694 