### PR TITLE
Allow slug redirects for OrganisationKinds.

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -561,6 +561,10 @@ class OrganisationKind(ModelBase):
     class Meta:
        ordering = ["slug"]
 
+    @models.permalink
+    def get_absolute_url(self):
+        return ('organisation_kind', (self.slug,))
+
 
 class OrganisationQuerySet(models.query.GeoQuerySet):
     def parties(self):

--- a/pombola/core/tests/test_organisation_kinds.py
+++ b/pombola/core/tests/test_organisation_kinds.py
@@ -8,10 +8,22 @@ from django.contrib.contenttypes.models import ContentType
 
 
 class OrganisationKindTest(TestCase):
-    def test_redirect(self):
+
+    def setUp(self):
+        # Create some example objects so that the requests don't 404
+        # after redirection:
         organisation_kind = models.OrganisationKind.objects.create(
             name='New',
             slug='new',
+            )
+        models.Organisation.objects.create(
+            slug='example-org',
+            name='Example Organisation',
+            kind=organisation_kind,
+            )
+        models.PositionTitle.objects.create(
+            name='Job Title',
+            slug='job-title',
             )
 
         SlugRedirect.objects.create(
@@ -21,6 +33,7 @@ class OrganisationKindTest(TestCase):
             old_object_slug='old',
             )
 
+    def test_redirect_organisation_kind(self):
         response = self.client.get(
             reverse('organisation_kind', kwargs={'slug': 'old'}),
             )
@@ -28,3 +41,35 @@ class OrganisationKindTest(TestCase):
             response,
             reverse('organisation_kind', kwargs={'slug': 'new'}),
             )
+
+    def test_redirect_position_pt_ok(self):
+        response = self.client.get(
+            reverse('position_pt_ok', kwargs={
+                'pt_slug': 'job-title',
+                'ok_slug': 'old',
+            })
+        )
+        self.assertRedirects(
+            response,
+            reverse('position_pt_ok', kwargs={
+                'pt_slug': 'job-title',
+                'ok_slug': 'new',
+            })
+        )
+
+    def test_redirect_position_pt_ok_o(self):
+        response = self.client.get(
+            reverse('position_pt_ok_o', kwargs={
+                'pt_slug': 'job-title',
+                'ok_slug': 'old',
+                'o_slug': 'example-org',
+            })
+        )
+        self.assertRedirects(
+            response,
+            reverse('position_pt_ok_o', kwargs={
+                'pt_slug': 'job-title',
+                'ok_slug': 'new',
+                'o_slug': 'example-org',
+            })
+        )

--- a/pombola/core/tests/test_organisation_kinds.py
+++ b/pombola/core/tests/test_organisation_kinds.py
@@ -1,0 +1,30 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from pombola.core import models
+from pombola.slug_helpers.models import SlugRedirect
+
+from django.contrib.contenttypes.models import ContentType
+
+
+class OrganisationKindTest(TestCase):
+    def test_redirect(self):
+        organisation_kind = models.OrganisationKind.objects.create(
+            name='New',
+            slug='new',
+            )
+
+        SlugRedirect.objects.create(
+            content_type=ContentType.objects.get_for_model(
+                models.OrganisationKind),
+            new_object=organisation_kind,
+            old_object_slug='old',
+            )
+
+        response = self.client.get(
+            reverse('organisation_kind', kwargs={'slug': 'old'}),
+            )
+        self.assertRedirects(
+            response,
+            reverse('organisation_kind', kwargs={'slug': 'new'}),
+            )

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -342,14 +342,11 @@ class OrganisationDetailSub(SubSlugRedirectMixin, DetailView):
                 context['sorted_positions'] = positions.order_by_person_name()
         return context
 
-class OrganisationKindList(SingleObjectMixin, ListView):
+class OrganisationKindList(SlugRedirectMixin, SingleObjectMixin, ListView):
     model = models.OrganisationKind
 
-    def get(self, request, *args, **kwargs):
-        self.object = self.get_object(queryset=self.model.objects.all())
-        return super(OrganisationKindList, self).get(request, *args, **kwargs)
-
     def get_queryset(self):
+        self.object = self.get_object(queryset=self.model.objects.all())
         orgs = (
             self.object
                 .organisation_set

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -1,7 +1,6 @@
 import time
 import calendar
 import datetime
-from functools import wraps
 import random
 from urlparse import urlsplit, urlunsplit
 
@@ -17,14 +16,10 @@ from django.views.generic.detail import SingleObjectMixin
 from django.core.cache import cache
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.contrib.contenttypes.models import ContentType
 
-from speeches.models import Section, Speech, Speaker, Tag
-from speeches.views import NamespaceMixin, SpeechView, SectionView
+from speeches.models import Speaker
 
 from pombola.core import models
-from pombola.info.models import InfoPage
-from pombola.slug_helpers.models import SlugRedirect
 from pombola.slug_helpers.views import SlugRedirectMixin
 
 


### PR DESCRIPTION
Use SlugRedirectMixin to allow an old organisation kind slug to
redirect to a replacement slug.

If this change is accepted, #1669 just needs a row adding to the slug redirects table to redirect the  'political-party' `OrganisationKind` to 'party'.