### PR TITLE
Move Google Analytics JS to static page, rather than lazy-loading.

### DIFF
--- a/pombola/core/static/js/analytics.js
+++ b/pombola/core/static/js/analytics.js
@@ -1,11 +1,3 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-ga('create', pombola_settings.google_analytics_account);
-ga('send', 'pageview');
-
 // add in some tracking to detect when users print pages. Will be used to judge
 // how often this happens.
 

--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -62,6 +62,14 @@
                 );
             }
 
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+            ga('create', pombola_settings.google_analytics_account);
+            ga('send', 'pageview');
+
             {% block extra_js_to_load %}
                 // no extra js added to be loaded
             {% endblock %}


### PR DESCRIPTION
GA is not blocking (the original reason for it being lazy), and this allows GA to detect the tracking code and stop complaining.

* Closes #1707

nb This keeps extra print event tracking (in analytics.js) as lazy and compressed, since the `ga` object will be initialised by that point anyway.