### PR TITLE
Remove research survey from Mzalendo

### DIFF
--- a/pombola/kenya/templates/header.html
+++ b/pombola/kenya/templates/header.html
@@ -3,7 +3,3 @@
 {% include 'site_header.html' %}
 
 {% include 'main_menu.html' %}
-
-<div id="ms_srv_wrapper" style="display:none" data-display-percentage="1">
-    <a href="https://www.surveygizmo.co.uk/s3/2009337/2014-Baselining-Mzalendo" id="ms_srv_link" target="_blank">We&rsquo;re running a short survey to help us understand how well Mzalendo works and how we can make it better. If you&rsquo;d like to take it, click here.</a>
-</div>

--- a/pombola/settings/kenya_base.py
+++ b/pombola/settings/kenya_base.py
@@ -83,10 +83,4 @@ COUNTRY_JS = {
         ),
         'output_filename': 'js/shujaaz.js',
     },
-    'survey': {
-        'source_filenames': (
-            'js/survey.js',
-        ),
-        'output_filename': 'js/survey.js',
-    },
 }


### PR DESCRIPTION
Pulls the now complete Quant 1 research survey from display on Mzalendo.

Some elements remain, as they're also used for the ZA survey.