### PR TITLE
KE: Retain linebreaks in address data using template filters not CSS

### DIFF
--- a/pombola/kenya/static/sass/_kenya_overrides.scss
+++ b/pombola/kenya/static/sass/_kenya_overrides.scss
@@ -154,7 +154,6 @@ body {
     }
     .contact-details-address {
       word-break: normal;
-      white-space: pre; // addresses are often formatted with line breaks, so preserve them
     }
   }
 }

--- a/pombola/kenya/templates/core/person_base.html
+++ b/pombola/kenya/templates/core/person_base.html
@@ -106,7 +106,7 @@
 
               {% case 'address' %}
                   <h3>Post</h3>
-                  <p class="contact-details-address">{{ c.value|urlizetrunc:50 }}</p>
+                  <p class="contact-details-address">{{ c.value|urlizetrunc:50|linebreaksbr }}</p>
 
               {% else %}
                   <h3>{{ c.kind.name }}</h3>


### PR DESCRIPTION
Using 'white-space: pre' causes addresses that are formatted without
linebreaks to be displayed as a continuous line which breaks the
layout of the person pages. This commit uses Django's linebreakbr
filter to force linebreaks in the address text to be rendered as
`<br>` tags instead.

Fixes #1700