### PR TITLE
NG: Return more detailed info in PUN search

### DIFF
--- a/pombola/nigeria/templates/search/poll-unit-number.html
+++ b/pombola/nigeria/templates/search/poll-unit-number.html
@@ -26,7 +26,7 @@
 
 {% block search_results %}
   {% if area %}
-    <p>Best match is "{{ area_pun_name }}" with poll unit number '{{ area_pun_code }}'</p>
+    <p>Best match is the {{ area_pun_type }} "{{ area_pun_name }}" with poll unit number '{{ area_pun_code }}'</p>
 
     {% if state %}
       <h3>State</h3>

--- a/pombola/nigeria/templates/search/poll-unit-number.html
+++ b/pombola/nigeria/templates/search/poll-unit-number.html
@@ -28,6 +28,11 @@
   {% if area %}
     <p>Best match is "{{ area_pun_name }}" with poll unit number '{{ area_pun_code }}'</p>
 
+    {% if state %}
+      <h3>State</h3>
+      <a href="{{ state.get_absolute_url }}">{{ state.name }}</a>
+    {% endif %}
+
     <h3>Overlapping Federal Constituencies</h3>
 
     <ul>

--- a/pombola/nigeria/templates/search/poll-unit-number.html
+++ b/pombola/nigeria/templates/search/poll-unit-number.html
@@ -30,14 +30,27 @@
 
     {% if state %}
       <h3>State</h3>
-      <a href="{{ state.get_absolute_url }}">{{ state.name }}</a>
+      <p>
+        <a href="{{ state.get_absolute_url }}">{{ state.name }}</a>,
+        {% if governor %}
+          current governor <a href="{{ governor.get_absolute_url }}">{{ governor.name }}</a>
+        {% else %}
+          no current governor
+        {% endif %}
+      </p>
     {% endif %}
 
     <h3>Overlapping Federal Constituencies</h3>
 
     <ul>
-      {% for place in federal_constutencies %}
-        <li><a href="{{ place.get_absolute_url }}">{{ place.name }}</a></li>
+      {% for place in federal_constituencies %}
+        <li><a href="{{ place.district_url }}">{{ place.district_name }}</a>,
+          {% if place.rep_url %}
+            current representative <a href="{{ place.rep_url}}">{{ place.rep_name }}</a>
+          {% else %}
+            no current representative
+          {% endif %}
+        </li>
       {% empty %}
         <li>No overlapping Federal Constituencies</li>
       {% endfor %}
@@ -47,7 +60,13 @@
 
     <ul>
       {% for place in senatorial_districts %}
-      <li><a href="{{ place.get_absolute_url }}">{{ place.name }}</a></li>
+      <li><a href="{{ place.district_url }}">{{ place.district_name }}</a>,
+        {% if place.rep_url %}
+          current senator <a href="{{ place.rep_url}}">{{ place.rep_name }}</a>
+        {% else %}
+          no current senator
+        {% endif %}
+      </li>
       {% empty %}
         <li>No overlapping Senatorial Districts</li>
       {% endfor %}

--- a/pombola/nigeria/tests.py
+++ b/pombola/nigeria/tests.py
@@ -125,13 +125,13 @@ class NGSearchViewTest(WebTest):
     def test_partial_match(self):
         response = self.app.get("/search/?q=28/04/09")
         self.assertIn(
-            'Best match is "AKOKO SOUTH WEST" with poll unit number \'OD:4\'',
+            'Best match is the local government area "AKOKO SOUTH WEST" with poll unit number \'OD:4\'',
             response.content
         )
 
     def test_complete_match(self):
         response = self.app.get("/search/?q=28/04/07")
         self.assertIn(
-            'Best match is "Test Ward" with poll unit number \'OD:4:7\'',
+            'Best match is the ward "Test Ward" with poll unit number \'OD:4:7\'',
             response.content
         )

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -145,18 +145,7 @@ class NGSearchView(SearchBaseView):
         context['area'] = None
         context['results'] = []
 
-        # Find mapit area that matches the PUN. If not found trim off
-        # components from the end until match or no more searches possible.
-        # Need this as we don't have the polling stations and want to be
-        # forgiving in case of input error.
-        while query:
-            try:
-                context['area'] = Area.objects.get(codes__code=query)
-                break
-            except Area.DoesNotExist:
-                # strip off last component
-                query = re.sub(r'[^:]+$', '', query)
-                query = re.sub(r':$', '', query)
+        context['area'] = self.get_area_from_pun(query)
 
         # If area found find places of interest
         if context['area']:
@@ -243,3 +232,21 @@ class NGSearchView(SearchBaseView):
             return Place.objects.get(mapit_area=area)
         except Place.DoesNotExist:
             return None
+
+    def get_area_from_pun(self, pun):
+        """Find MapIt area that matches the PUN.
+
+        If not found trim off components from the end until match
+        or no more searches possible.
+        Need this as we don't have the polling stations and want to be
+        forgiving in case of input error.
+        """
+
+        while pun:
+            try:
+                area = Area.objects.get(codes__code=pun)
+                return area
+            except Area.DoesNotExist:
+                # strip off last component
+                pun = re.sub(r'[^:]+$', '', pun)
+                pun = re.sub(r':$', '', pun)

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -157,6 +157,9 @@ class NGSearchView(SearchBaseView):
                 query[0:2],
                 area)
 
+            # work out what level of the PUN we've matched
+            context['area_pun_type'] = self.get_pun_type(context['area_pun_code'])
+
             # work out the polygons to match to, may need to go up tree to parents.
             area_for_polygons = area
             while area_for_polygons and not area_for_polygons.polygons.exists():
@@ -261,3 +264,15 @@ class NGSearchView(SearchBaseView):
             # matched area is the state, convert it to place data
             state_area = area
         return self.convert_area_to_place(state_area)
+
+    def get_pun_type(self, pun):
+        # use the length of the matched PUN to determine whether
+        # we've matched a ward, an lga or a state
+        # ref: http://www.inecnigeria.org/?page_id=20
+        pun_level = len(pun.split(':'))
+        if pun_level == 3:
+            return 'ward'
+        elif pun_level == 2:
+            return 'local government area'
+        else:
+            return 'state'


### PR DESCRIPTION
This changes the PUN search so that it displays whether it matched the PUN at a state, LGA or ward level, and always displays the name of the containing state of the search results.

Adds the name of the current representative for the overlapping districts, where available (or the text 'no current representative' where the representative's name is not held).

Fixes #1714 