### PR TITLE
Better Hansard speech reattribution functionality

### DIFF
--- a/pombola/core/management/commands/core_merge_people.py
+++ b/pombola/core/management/commands/core_merge_people.py
@@ -148,7 +148,7 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
         # Then those in hansard, if that application is installed:
         #    hansard_models.Alias
         #    hansard_models.Entry
-        if 'hansard' in settings.INSTALLED_APPS:
+        if 'pombola.hansard' in settings.INSTALLED_APPS:
             import pombola.hansard.models as hansard_models
             hansard_models.Alias.objects.filter(person=to_delete).update(person=to_keep)
             hansard_models.Entry.objects.filter(speaker=to_delete).update(speaker=to_keep)
@@ -157,7 +157,7 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
 
         # Then those in interests_register, if that application is installed:
         #    interests_register_models.Entry
-        if 'interests_register' in settings.INSTALLED_APPS:
+        if 'pombola.interests_register' in settings.INSTALLED_APPS:
             import pombola.interests_register.models as interests_register_models
             interests_register_models.Entry.objects.filter(person=to_delete).update(person=to_keep)
 

--- a/pombola/core/management/commands/core_merge_people.py
+++ b/pombola/core/management/commands/core_merge_people.py
@@ -42,14 +42,17 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
 
     help = "Merge two Person records into one, deleting one of the originals"
     option_list = BaseCommand.option_list + (
-        make_option("--keep-person", dest="keep_person", type="int",
-                    help="The ID of the person to retain",
+        make_option("--keep-person", dest="keep_person", type="string",
+                    help="The ID or slug of the person to retain",
                     metavar="PERSON-ID"),
-        make_option("--delete-person", dest="delete_person", type="int",
-                    help="The ID of the person to delete",
+        make_option("--delete-person", dest="delete_person", type="string",
+                    help="The ID or slug of the person to delete",
                     metavar="PERSON-ID"),
         make_option("--sayit-id-scheme", dest="sayit_id_scheme", type="string",
                     help="The name of the SayIt ID schema (if used)"),
+        make_option('--noinput',  dest='interactive',
+                    action='store_false', default=True,
+                    help="Do NOT prompt the user for input of any kind"),
         make_option("--quiet", dest="quiet",
                     help="Suppress progress output",
                     default=False, action='store_true'))
@@ -66,15 +69,22 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
 
         verbose = int(options['verbosity']) > 1
 
-        to_keep = core_models.Person.objects.get(pk=options['keep_person'])
-        to_delete = core_models.Person.objects.get(pk=options['delete_person'])
+        to_keep = core_models.Person.objects.get_by_slug_or_id(options['keep_person'])
+        to_delete = core_models.Person.objects.get_by_slug_or_id(options['delete_person'])
 
         to_keep_admin_url = reverse('admin:core_person_change',
                                     args=(to_keep.id,))
 
-        if not options['quiet']:
-            print "Going to keep:", to_keep, "with ID", to_keep.id
-            print "Going to delete:", to_delete, "with ID", to_delete.id
+        if to_keep.id == to_delete.id:
+            raise CommandError("--keep-person and --delete-person are the same")
+
+        print "Going to keep:", to_keep, "with ID", to_keep.id
+        print "Going to delete:", to_delete, "with ID", to_delete.id
+
+        if options['interactive']:
+            answer = raw_input('Do you wish to continue? (y/[n]): ')
+            if answer != 'y':
+                raise CommandError("Command halted by user, no changes made")
 
         if not check_basic_fields(['title',
                                    'gender',
@@ -96,6 +106,9 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
 
         # If a SayIt ID scheme is specified, move speeches from deleted person
         if 'speeches' in settings.INSTALLED_APPS:
+
+            if not options['quiet']:
+                print "Moving SayIt speeches"
 
             if options['sayit_id_scheme'] is None:
                 raise CommandError("You must specify --sayit-id-scheme")
@@ -150,7 +163,12 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
         #    hansard_models.Entry
         if 'pombola.hansard' in settings.INSTALLED_APPS:
             import pombola.hansard.models as hansard_models
+
+            if not options['quiet']:
+                print "Moving Hansard entries"
+
             hansard_models.Alias.objects.filter(person=to_delete).update(person=to_keep)
+
             hansard_models.Entry.objects.filter(speaker=to_delete).update(speaker=to_keep)
         # (The scorecard application can be ignored, since those
         # results are regenerated automatically.)
@@ -159,6 +177,10 @@ class Command(PersonSpeakerMappingsMixin, BaseCommand):
         #    interests_register_models.Entry
         if 'pombola.interests_register' in settings.INSTALLED_APPS:
             import pombola.interests_register.models as interests_register_models
+
+            if not options['quiet']:
+                print "Moving interests register entries"
+
             interests_register_models.Entry.objects.filter(person=to_delete).update(person=to_keep)
 
         # Add any images for the person to delete as non-primary

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -224,6 +224,16 @@ class PersonManager(ManagerBase):
         else:
             return None
 
+    def get_by_slug_or_id(self, identifier):
+        try:
+            return self.get(slug=identifier)
+        except self.model.DoesNotExist:
+            try:
+                person_id = int(identifier)
+            except ValueError:
+                raise self.model.DoesNotExist, "Person matching query does not exist."
+            return self.get(pk=person_id)
+
     def get_featured(self):
         # select all the presidential aspirants
         return self.filter(can_be_featured=True)

--- a/pombola/core/tests/test_models.py
+++ b/pombola/core/tests/test_models.py
@@ -241,6 +241,40 @@ class PositionCurrencyTest(unittest.TestCase):
         self.person.delete()
 
 
+
+class PersonGetSlugOrIdTest( unittest.TestCase ):
+    def setUp(self):
+        self.person = models.Person(
+            legal_name = "Test Person",
+            slug       = 'test-person'
+        )
+        self.person.save()
+
+    def tearDown(self):
+        self.person.delete()
+
+    def test_get_with_id(self):
+        result = models.Person.objects.get_by_slug_or_id(self.person.id)
+        self.assertEqual(result.id, self.person.id)
+
+    def test_get_with_slug(self):
+        result = models.Person.objects.get_by_slug_or_id(self.person.slug)
+        self.assertEqual(result.id, self.person.id)
+
+    def test_id_not_found(self):
+        temp_person = models.Person.objects.create(
+            legal_name = 'Temp Person'
+        )
+        person_id = temp_person.id
+        temp_person.delete()
+        with self.assertRaises(models.Person.DoesNotExist):
+            models.Person.objects.get_by_slug_or_id(person_id)
+
+    def test_slug_not_found(self):
+        with self.assertRaises(models.Person.DoesNotExist):
+            models.Person.objects.get_by_slug_or_id('not-in-db')
+
+
 class PersonAndContactTasksTest( unittest.TestCase ):
     def setUp(self):
         self.person = models.Person(

--- a/pombola/hansard/management/commands/hansard_reattribute_entries.py
+++ b/pombola/hansard/management/commands/hansard_reattribute_entries.py
@@ -1,0 +1,86 @@
+# This admin command is to save having to move Hansard Entries
+# individually in the admin console, which is not fun - or particularly
+# safe - when there are more than one or two of them
+
+from dateutil import parser
+import sys
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from optparse import make_option
+
+import pombola.core.models as core_models
+import pombola.hansard.models as hansard_models
+
+
+class Command(BaseCommand):
+    help = 'Move Hansard Entries from one Person to another'
+
+    option_list = BaseCommand.option_list + (
+        make_option("--person-from", dest="person_from", type="string",
+                    help="The ID or slug of the person whose speeches you want to move",
+                    metavar="PERSON-ID"),
+        make_option("--person-to", dest="person_to", type="string",
+                    help="The ID or slug of the person who will become associated with the speeches",
+                    metavar="PERSON-ID"),
+        make_option("--date-from", dest="date_from", type="string",
+                    help="The date of the earliest entry to reattribute as YYYY-MM-DD (optional)"),
+        make_option("--date-to", dest="date_to", type="string",
+                    help="The date of the last entry to reattribute as YYYY-MM-DD (optional)"),
+        make_option('--noinput',
+                    action='store_false', dest='interactive', default=True,
+                    help="Do NOT prompt the user for input of any kind."),
+        make_option("--quiet", dest="quiet",
+                    help="Suppress progress output",
+                    default=False, action='store_true'))
+
+    @transaction.commit_on_success
+    def handle(self, *args, **options):
+        if not options['person_from']:
+            raise CommandError("You must specify --person-from")
+        if not options['person_to']:
+            raise CommandError("You must specify --person-to")
+        if args:
+            message = "Don't supply arguments, only --person-from and --person-to"
+            raise CommandError(message)
+
+        verbose = int(options['verbosity']) > 1
+
+        entries_from = core_models.Person.objects.get_by_slug_or_id(options['person_from'])
+        entries_to = core_models.Person.objects.get_by_slug_or_id(options['person_to'])
+
+        if entries_from.id == entries_to.id:
+            raise CommandError("--person-from and --person-to are the same")
+
+        date_from = date_to = None
+        if options['date_from']:
+            date_from = parser.parse(options['date_from']).date()
+
+        if options['date_to']:
+            date_to = parser.parse(options['date_to']).date()
+
+        entries = hansard_models.Entry.objects.filter(speaker=entries_from)
+        if date_from:
+            entries = entries.filter(sitting__start_date__gte=date_from)
+        if date_to:
+            entries = entries.filter(sitting__start_date__lte=date_to)
+
+        message = "Going to move {count} entries from {from_name} ({from_id}) to {to_name} ({to_id})"
+        message = message.format(
+            count=entries.count(),
+            from_name=entries_from.name,
+            from_id=entries_from.id,
+            to_name=entries_to.name,
+            to_id=entries_to.id)
+        print message
+
+        if options['interactive']:
+            answer = raw_input('Do you wish to continue? (y/[n]): ')
+            if answer != 'y':
+                raise Exception("Command halted by user, no changes made")
+
+        entries.update(speaker=entries_to)

--- a/pombola/hansard/tests/test_reattribute_entries.py
+++ b/pombola/hansard/tests/test_reattribute_entries.py
@@ -1,0 +1,134 @@
+# Tests for the Django management command hansard_reattribute_speeches
+
+import contextlib
+from datetime import date
+from mock import patch
+import sys
+
+from pombola.core.models import Person
+from pombola.hansard.models import (
+    Entry, Source, Sitting, Venue
+)
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from django.utils import unittest
+
+from pombola.core.tests.test_commands import no_stderr
+
+
+class ReattributeEntriesCommandTest(TestCase):
+
+    def setUp(self):
+        self.venue = Venue.objects.create(
+            name = 'test'
+        )
+        self.source = Source.objects.create(
+            date = date(2015, 8, 24)
+        )
+        self.sitting_1 = Sitting.objects.create(
+            start_date = date( 2011, 11, 15 ),
+            source = self.source,
+            venue = self.venue,
+        )
+        self.sitting_2 = Sitting.objects.create(
+            start_date = date( 2012, 11, 15 ),
+            source = self.source,
+            venue = self.venue,
+        )
+        self.sitting_3 = Sitting.objects.create(
+            start_date = date( 2013, 11, 15 ),
+            source = self.source,
+            venue = self.venue,
+        )
+
+        self.person_a = Person.objects.create(
+            name="Daffy Duck",
+            slug="daffy-duck")
+        self.person_b = Person.objects.create(
+            name="Bugs Bunny",
+            slug="bugs-bunny")
+
+        self.entry_1 = Entry.objects.create(
+            speaker = self.person_a,
+            sitting = self.sitting_1,
+            page_number = 42,
+            text_counter = 12
+        )
+        self.entry_2 = Entry.objects.create(
+            speaker = self.person_a,
+            sitting = self.sitting_2,
+            page_number = 42,
+            text_counter = 12
+        )
+        self.entry_3 = Entry.objects.create(
+            speaker = self.person_a,
+            sitting = self.sitting_3,
+            page_number = 42,
+            text_counter = 12
+        )
+
+        self.options = {
+            'person_to': self.person_b.id,
+            'person_from': self.person_a.id,
+            'quiet': True,
+            'interactive': False
+        }
+
+    @patch('__builtin__.raw_input', return_value='y')
+    def test_reassign_all(self, mock_input):
+        call_command('hansard_reattribute_entries', **self.options)
+
+        # Check that person_a has no entries and person_b has 3:
+        self.assertEqual(0, Entry.objects.filter(speaker=self.person_a).count())
+        self.assertEqual(3, Entry.objects.filter(speaker=self.person_b).count())
+
+    @patch('__builtin__.raw_input', return_value='y')
+    def test_reassign_all_with_slugs(self, mock_input):
+        options = {
+            'person_to': self.person_b.slug,
+            'person_from': self.person_a.slug,
+            'quiet': True
+        }
+        call_command('hansard_reattribute_entries', **options)
+
+        # Check that person_a has no entries and person_b has 3:
+        self.assertEqual(0, Entry.objects.filter(speaker=self.person_a).count())
+        self.assertEqual(3, Entry.objects.filter(speaker=self.person_b).count())
+
+    @patch('__builtin__.raw_input', return_value='y')
+    def test_reassign_with_from_date(self, mock_input):
+        options = self.options.copy()
+        options['date_from'] = '2012-01-01'
+
+        call_command('hansard_reattribute_entries', **options)
+
+        # Check that person_a has 1 entry and person_b has 2:
+        self.assertEqual(1, Entry.objects.filter(speaker=self.person_a).count())
+        self.assertEqual(2, Entry.objects.filter(speaker=self.person_b).count())
+
+    @patch('__builtin__.raw_input', return_value='y')
+    def test_reassign_with_to_date(self, mock_input):
+        options = self.options.copy()
+
+        options['date_to'] = '2013-01-01'
+
+        call_command('hansard_reattribute_entries', **options)
+
+        # Check that person_a has 2 entries and person_b has 1:
+        self.assertEqual(1, Entry.objects.filter(speaker=self.person_a).count())
+        self.assertEqual(2, Entry.objects.filter(speaker=self.person_b).count())
+
+    @patch('__builtin__.raw_input', return_value='y')
+    def test_reassign_with_to_and_from_dates(self, mock_input):
+        options = self.options.copy()
+        options['date_from'] = '2012-01-01'
+        options['date_to'] = '2013-01-01'
+
+        call_command('hansard_reattribute_entries', **options)
+
+        # Check that person_a has 1 entry and person_b has 2:
+        self.assertEqual(2, Entry.objects.filter(speaker=self.person_a).count())
+        self.assertEqual(1, Entry.objects.filter(speaker=self.person_b).count())


### PR DESCRIPTION
Fixes a bug in the `core_merge_people` management command which was preventing it from picking up hansard speeches and interests register information. Also provides more data to the user and offers them the choice of whether or not to continue once both speakers have been identified (with a specific warning if both speakers turn out to be the same person - i.e. if one is an alias of the other).

Adds a new management command, `hansard_reattribute_entries` which takes 2 person identifers and optional to and from dates in order to assign one person's speeches to another. Does not attempt to delete the donor speaker from the database even if this leaves them with no contributions.

Both commands will now accept either a numeric person id (as before) or a slug.

Partially fixes #1712 (won't be properly fixed until the updated commands have been run on the live site and the csv files have been regenerated correctly)