### PR TITLE
Add the Code4SA ward councillor widget

### DIFF
--- a/pombola/south_africa/templates/south_africa/ward_councillor_lookup.html
+++ b/pombola/south_africa/templates/south_africa/ward_councillor_lookup.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+
+{% block title %}Ward Councillor Lookup{% endblock %}
+
+{% block body_attributes %} class="ward-councillor-lookup" {% endblock %}
+
+{% block content %}
+<div id="councillor-iframe"></div>
+<script type="text/javascript" src="http://nearby.code4sa.org/static/councillor-embed.js"></script>{% endblock %}

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import patterns, include, url
-from django.views.generic.base import RedirectView
+from django.views.generic.base import RedirectView, TemplateView
 
 from pombola.south_africa import views
 from pombola.south_africa.views import (SAHomeView, LatLonDetailNationalView,
@@ -62,6 +62,14 @@ urlpatterns += patterns('',
         r'^person/(?P<person_slug>[-\w]+)/appearances/(?P<speech_tag>[-\w]+)$',
         SAPersonAppearanceView.as_view(),
         name='sa-person-appearance'
+    ),
+)
+
+# This is for the Code4SA ward councillor widget lookup:
+urlpatterns += patterns('',
+    url(r'^ward-councillor-lookup/$',
+        TemplateView.as_view(template_name='south_africa/ward_councillor_lookup.html'),
+        name='ward-councillor-lookup'
     ),
 )
 


### PR DESCRIPTION
This isn't ideally how we'd like to incorporate this lookup, since
it depends on Javascript and uses an iframe, but there's some time
pressure on adding this feature and Code4SA have made it very easy
with this widget.

Fixes #1730 

![ward-councillor-lookup](https://cloud.githubusercontent.com/assets/7907/9414455/86901aec-4830-11e5-830a-c22d318b5b6f.png)

![ward-councillor-result](https://cloud.githubusercontent.com/assets/7907/9414459/89fd9e0c-4830-11e5-8968-747e599b1ec8.png)
