### PR TITLE
1719 name matching algorithm settings

### DIFF
--- a/pombola/hansard/constants.py
+++ b/pombola/hansard/constants.py
@@ -1,0 +1,4 @@
+# Symbols for different name matching algorithms
+
+NAME_SUBSTRING_MATCH = 1  # Look for the whole name without the title.
+NAME_SET_INTERSECTION_MATCH = 2  # Intersect sets of words, including the title.

--- a/pombola/hansard/management/commands/hansard_assign_speakers.py
+++ b/pombola/hansard/management/commands/hansard_assign_speakers.py
@@ -1,14 +1,13 @@
-import datetime
-
+from django.conf import settings
 from django.core.management.base import NoArgsCommand
 
 from pombola.hansard.models import Entry
+
 
 class Command(NoArgsCommand):
     help = 'Try to assign a person to each entry'
     args = ''
 
     def handle_noargs(self, **options):
-
-        Entry.assign_speakers()
-
+        algorithm = settings.HANSARD_NAME_MATCHING_ALGORITHM
+        Entry.assign_speakers(name_matching_algorithm=algorithm)

--- a/pombola/hansard/models/__init__.py
+++ b/pombola/hansard/models/__init__.py
@@ -2,4 +2,4 @@ from alias   import Alias
 from source  import Source, SourceUrlCouldNotBeRetrieved, SourceCouldNotParseTimeString
 from venue   import Venue
 from sitting import Sitting
-from entry   import Entry
+from entry   import Entry, NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH

--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -106,6 +106,7 @@ class Entry(HansardModelBase):
                     update_aliases=True,
                     name_matching_algorithm=name_matching_algorithm,
                     )
+                cache[cache_key] = speakers
 
             if speakers and len(speakers) == 1:
                 speaker = speakers[0]

--- a/pombola/hansard/tests/test_kenya_parser.py
+++ b/pombola/hansard/tests/test_kenya_parser.py
@@ -13,7 +13,10 @@ from django.conf import settings
 from nose.plugins.attrib import attr
 
 from pombola.hansard.kenya_parser import KenyaParser, KenyaParserCouldNotParseTimeString
-from pombola.hansard.models import Source, Sitting, Entry, Venue, Alias
+from pombola.hansard.models import (
+    Source, Sitting, Entry, Venue, Alias,
+    NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH,
+    )
 
 from pombola.core.models import Person, PositionTitle, Position
 
@@ -132,7 +135,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
         self.assertEqual( entry_qs.unassigned_speeches().count(), 31 )
 
         # Assign speakers
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
 
         # check that none of the speakers got assigned - there are no entries in the database
         self.assertEqual( entry_qs.unassigned_speeches().count(), 31 )
@@ -147,7 +150,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
             legal_name = 'James Gabbow',
             slug       = 'james-gabbow',
         )
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 31 )
         self.assertEqual( unassigned_aliases_qs.count(), 11 )
 
@@ -163,7 +166,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
             end_date   = ApproximateDate( future=True ),
             category = 'political',
         )
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 26 )
         self.assertEqual( unassigned_aliases_qs.count(), 10 )
 
@@ -187,7 +190,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
             category = 'political',
             )
 
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 24 )
         self.assertEqual( unassigned_aliases_qs.count(), 9 )
 
@@ -203,7 +206,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
             end_date   = ApproximateDate( year=2009, month=1, day = 1 ),
             category = 'political',
         )
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 24 )
         self.assertEqual( unassigned_aliases_qs.count(), 9 )
 
@@ -216,7 +219,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
         betty_laboso_alias.person = betty_laboso
         betty_laboso_alias.save()
 
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 22 )
         self.assertEqual( unassigned_aliases_qs.count(), 8 )
 
@@ -225,7 +228,7 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
         prof_kaloki_alias.ignored = True
         prof_kaloki_alias.save()
 
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 22 )
         self.assertEqual( unassigned_aliases_qs.count(), 7 )
 
@@ -234,10 +237,77 @@ class KenyaParserAssemblyTest(KenyaParserVenueSpecificTestBase, TestCase):
             alias.person = betty_laboso
             alias.save()
 
-        Entry.assign_speakers()
+        Entry.assign_speakers(name_matching_algorithm=settings.HANSARD_NAME_MATCHING_ALGORITHM)
         self.assertEqual( entry_qs.unassigned_speeches().count(), 8 )
         self.assertEqual( unassigned_aliases_qs.count(), 0 )
 
+class TestMatchNames(TestCase):
+    def test_alias_match_score(self):
+        self.assertEqual(Entry().alias_match_score('Mr Bob Smith', 'Mr Bob Smith'), 3)
+        self.assertEqual(Entry().alias_match_score('Mr Bob Smith', 'Mr Smith'), 2)
+        self.assertEqual(Entry().alias_match_score('Mr Bob Smith', 'Bob Smith'), 2)
+        self.assertEqual(Entry().alias_match_score('Mr Bob Smith', 'Bob'), 1)
+        self.assertEqual(Entry().alias_match_score('Bob Smith', 'Smith, Bob'), 2)
+        self.assertEqual(Entry().alias_match_score('Mr Bob Smith', 'Miss Alice Jones'), 0)
+
+    def test_possible_matching_speakers(self):
+        sitting = Sitting(
+            start_date=datetime.date(2011, 1, 2),
+            )
+
+        entry = Entry(
+            sitting=sitting,
+            )
+
+        james_smith = Person.objects.create(
+            legal_name='James Smith',
+            slug='james-smith',
+            )
+
+        james_smith2 = Person.objects.create(
+            title='Mr',
+            legal_name='Bob Smith James',
+            slug='james-smith2',
+            )
+
+        mp = PositionTitle.objects.create(
+            name='Member of Parliament',
+            slug='mp',
+            )
+
+        Position.objects.create(
+            person=james_smith,
+            title=mp,
+            start_date=ApproximateDate(year=2011, month=1, day=1),
+            end_date=ApproximateDate(future=True),
+            category='political',
+            )
+
+        Position.objects.create(
+            person=james_smith2,
+            title=mp,
+            start_date=ApproximateDate(year=2011, month=1, day=1),
+            end_date=ApproximateDate(future=True),
+            category='political',
+            )
+
+        entry.speaker_name = 'James Smith'
+        speakers = entry.possible_matching_speakers(name_matching_algorithm=NAME_SUBSTRING_MATCH)
+        self.assertListEqual(list(speakers), [james_smith])
+
+        entry.speaker_name = 'Mr Smith'
+        speakers = entry.possible_matching_speakers(name_matching_algorithm=NAME_SUBSTRING_MATCH)
+        self.assertItemsEqual(speakers, (james_smith, james_smith2))
+
+        speakers = entry.possible_matching_speakers(name_matching_algorithm=NAME_SET_INTERSECTION_MATCH)
+        self.assertListEqual(list(speakers), [james_smith2])
+
+        entry.speaker_name = 'Mr James Smith'
+        speakers = entry.possible_matching_speakers(name_matching_algorithm=NAME_SUBSTRING_MATCH)
+        self.assertListEqual(list(speakers), [james_smith])
+
+        speakers = entry.possible_matching_speakers(name_matching_algorithm=NAME_SET_INTERSECTION_MATCH)
+        self.assertListEqual(list(speakers), [james_smith2, james_smith])
 
 
 class KenyaParserTest(TestCase):

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -6,6 +6,8 @@ from .apps import *
 
 from django.template.defaultfilters import slugify
 
+from pombola.hansard.constants import NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH
+
 IN_TEST_MODE = False
 
 # Work out where we are to set up the paths correctly and load config
@@ -348,6 +350,16 @@ QUESTION_JSON_CACHE  = os.path.join( HANSARD_CACHE, 'questions_json' )
 
 PMG_COMMITTEE_USER = config.get('PMG_COMMITTEE_USER', '')
 PMG_COMMITTEE_PASS = config.get('PMG_COMMITTEE_PASS', '')
+
+# Algorithm to use for matching names when scraping hansard
+# NAME_SUBSTRING_MATCH
+# - strips the title from the name and then searches for current politicians
+#   with names containing that string (used by Kenya).
+# NAME_SET_INTERSECTION_MATCH
+# - splits the name, including title, into words, and then compares the
+#   set of these words with similar sets from current politicians,
+#   looking for the largest intersection.
+HANSARD_NAME_MATCHING_ALGORITHM = NAME_SET_INTERSECTION_MATCH
 
 # Which popit instance to use
 POPIT_API_URL = config.get('POPIT_API_URL')

--- a/pombola/settings/kenya_base.py
+++ b/pombola/settings/kenya_base.py
@@ -1,3 +1,5 @@
+from pombola.hansard.constants import NAME_SUBSTRING_MATCH
+
 COUNTRY_APP = 'kenya'
 
 OPTIONAL_APPS = [
@@ -82,3 +84,5 @@ COUNTRY_JS = {
         'output_filename': 'js/shujaaz.js',
     }
 }
+
+HANSARD_NAME_MATCHING_ALGORITHM = NAME_SUBSTRING_MATCH


### PR DESCRIPTION
Add a setting to allow the Hansard name matching algorithm to be changed per country - this means Kenya can carry on doing it the old way, while we use the new improved algorithm for Ghana.

Fixes #1719 