### PR TITLE
Better Hansard speaker matching

### DIFF
--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -16,13 +16,13 @@ class EntryQuerySet(models.query.QuerySet):
 
         dates = self.dates('sitting__start_date','month', 'DESC')
         counts = []
-        
+
         for d in dates:
             qs = self.filter(sitting__start_date__month=d.month, sitting__start_date__year=d.year)
             counts.append(dict(date=d, count=qs.count()))
 
         return counts
-        
+
     def unassigned_speeches(self):
         """All speeches that do not have a speaker assigned"""
         return self.filter(
@@ -35,7 +35,7 @@ class EntryQuerySet(models.query.QuerySet):
 class EntryManager(models.Manager):
     def get_query_set(self):
         return EntryQuerySet(self.model)
-    
+
 
 class Entry(HansardModelBase):
     """Model for representing an entry in Hansard - speeches, headings etc"""
@@ -52,9 +52,9 @@ class Entry(HansardModelBase):
 
     # page_number is the page that this appeared on in the source.
     page_number   = models.IntegerField( blank=True )
-    
+
     # Doesn't really mean anything - just a counter so that for each sitting we
-    # can display the entries in the correct order. 
+    # can display the entries in the correct order.
     text_counter  = models.IntegerField()
 
     # Speakers only apply to the 'speech' type. For those we should always have
@@ -71,7 +71,7 @@ class Entry(HansardModelBase):
 
     def __unicode__(self):
         return "%s: %s" % (self.type, self.content[:100])
-    
+
     def get_absolute_url(self):
         sitting_url = self.sitting.get_absolute_url()
         return "%s#entry-%u" % (sitting_url, self.id)
@@ -83,13 +83,13 @@ class Entry(HansardModelBase):
         ordering = ['sitting', 'text_counter']
         app_label = 'hansard'
         verbose_name_plural = 'entries'
-        
+
     @classmethod
     def assign_speakers(cls):
         """Go through all entries and assign speakers"""
-        
+
         entries = cls.objects.all().unassigned_speeches()
-        
+
         # create an in memory cache of speaker names and the sitting dates, to
         # avoid hitting the db as badly with all the repeated requests
         cache = {}
@@ -108,8 +108,8 @@ class Entry(HansardModelBase):
             if len(speakers) == 1:
                 speaker = speakers[0]
                 entry.speaker = speaker
-                entry.save()                
-                
+                entry.save()
+
 
     def possible_matching_speakers(self, update_aliases=False):
         """
@@ -122,11 +122,11 @@ class Entry(HansardModelBase):
 
         name = self.speaker_name
         name = Alias.clean_up_name( name )
-        
+
         # First check for a matching alias that is not ignored
         try:
             alias = Alias.objects.get( alias=name )
-            
+
             if alias.ignored:
                 # if the alias is ignored we should not match anything
                 return []
@@ -142,10 +142,10 @@ class Entry(HansardModelBase):
 
         except Alias.DoesNotExist:
             alias = None
-        
+
         # drop the prefix
         stripped_name = re.sub( r'^\w+\.\s', '', name )
-        
+
         person_search = (
             Person
             .objects
@@ -154,15 +154,15 @@ class Entry(HansardModelBase):
             .filter(legal_name__icontains=stripped_name)
             .distinct()
         )
-        
+
         results = person_search.all()[0:]
-        
+
         found_one_result = len(results) == 1
 
         # If there is a single matching speaker and an unassigned alias delete it
         if found_one_result and alias and alias.is_unassigned:
             alias.delete()
-            
+
         # create an entry in the aliases table if one is needed
         if not alias and update_aliases and not found_one_result and not Alias.can_ignore_name(name):
             Alias.objects.create(
@@ -170,7 +170,5 @@ class Entry(HansardModelBase):
                 ignored = False,
                 person  = None,
             )
-        
+
         return results
-
-

--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -152,6 +152,7 @@ class Entry(HansardModelBase):
             .all()
             .is_politician( when=self.sitting.start_date )
             .filter(legal_name__icontains=stripped_name)
+            .exclude(hidden=True)
             .distinct()
         )
 

--- a/pombola/hansard/tests/test_entry.py
+++ b/pombola/hansard/tests/test_entry.py
@@ -147,3 +147,22 @@ class HansardEntryTest(TestCase):
             self.mp,
             possible_speakers[0]
         )
+
+    def test_exclude_hidden_profiles(self):
+        self.senator.hidden = True
+        self.senator.save()
+
+        entry = Entry(
+            sitting       = self.senate_sitting,
+            type          = 'text',
+            page_number   = 12,
+            text_counter  = 4,
+            speaker_name  = 'Jones',
+            speaker_title = 'Hon.',
+            content       = 'test',
+        )
+
+        self.assertEqual(
+            self.mp,
+            entry.possible_matching_speakers()[0]
+        )

--- a/pombola/hansard/tests/test_entry.py
+++ b/pombola/hansard/tests/test_entry.py
@@ -1,0 +1,149 @@
+from datetime import date
+
+from django.test import TestCase
+from pombola.core.models import Person, Place, PlaceKind, Position, PositionTitle
+from pombola.hansard.models import Source, Sitting, Venue, Entry
+
+class HansardEntryTest(TestCase):
+
+    def setUp(self):
+        self.source = Source.objects.create(
+            date = date(2011, 11, 15),
+            name = 'test source'
+        )
+        na = Venue.objects.create(
+            name='National Assembly',
+            slug='national-assembly'
+        )
+        senate = Venue.objects.create(
+            name='Senate',
+            slug='senate'
+        )
+
+        self.na_sitting = Sitting(
+            source     = self.source,
+            venue      = na,
+            start_date = date(2011, 11, 15),
+        )
+
+        self.senate_sitting = Sitting(
+            source     = self.source,
+            venue      = senate,
+            start_date = date(2011, 11, 15),
+        )
+
+        na_member_title = PositionTitle.objects.create(
+            name='Member of the National Assembly',
+            slug='member-national-assembly',
+        )
+
+        senate_member_title = PositionTitle.objects.create(
+            name='Senator',
+            slug='senator'
+        )
+
+        place_kind_test = PlaceKind.objects.create(
+            name='Test',
+        )
+
+        test_place = Place.objects.create(
+            name="Some Place",
+            slug='some_place',
+            kind=place_kind_test,
+        )
+
+        self.senator = Person.objects.create(
+            legal_name='Tom Jones',
+            slug='tom-jones'
+        )
+        self.mp = Person.objects.create(
+            legal_name='Paul Jones',
+            slug='paul-jones'
+        )
+
+        senate_position = Position.objects.create(
+                              person=self.senator,
+                              place=test_place,
+                              category='political',
+                              title=senate_member_title,
+        )
+
+        na_position = Position.objects.create(
+                          person=self.mp,
+                          place=test_place,
+                          category='political',
+                          title=na_member_title,
+        )
+
+    def test_multiple_politician_name_matches_na(self):
+        entry = Entry(
+            sitting       = self.na_sitting,
+            type          = 'text',
+            page_number   = 12,
+            text_counter  = 4,
+            speaker_name  = 'Jones',
+            speaker_title = 'Hon.',
+            content       = 'test',
+        )
+        possible_speakers = entry.possible_matching_speakers()
+
+        self.assertEqual(1, len(possible_speakers))
+        self.assertEqual(
+            self.mp,
+            possible_speakers[0]
+        )
+
+    def test_multiple_politician_name_matches_senate(self):
+        entry = Entry(
+            sitting       = self.senate_sitting,
+            type          = 'text',
+            page_number   = 12,
+            text_counter  = 4,
+            speaker_name  = 'Jones',
+            speaker_title = 'Hon.',
+            content       = 'test',
+        )
+        possible_speakers = entry.possible_matching_speakers()
+
+        self.assertEqual(1, len(possible_speakers))
+        self.assertEqual(
+            self.senator,
+            possible_speakers[0]
+        )
+
+    def test_multiple_politician_name_matches_joint_sitting(self):
+        self.source.name = "Joint Sitting of the Parliament"
+        self.source.save()
+
+        entry = Entry(
+            sitting       = self.na_sitting,
+            type          = 'text',
+            page_number   = 12,
+            text_counter  = 4,
+            speaker_name  = 'Jones',
+            speaker_title = 'Hon.',
+            content       = 'test',
+        )
+        possible_speakers = entry.possible_matching_speakers()
+        self.assertEqual(2, len(possible_speakers))
+
+    def test_exclude_hidden_profiles(self):
+        self.senator.hidden = True
+        self.senator.save()
+
+        entry = Entry(
+            sitting       = self.senate_sitting,
+            type          = 'text',
+            page_number   = 12,
+            text_counter  = 4,
+            speaker_name  = 'Jones',
+            speaker_title = 'Hon.',
+            content       = 'test',
+        )
+        possible_speakers = entry.possible_matching_speakers()
+
+        self.assertEqual(1, len(possible_speakers))
+        self.assertEqual(
+            self.mp,
+            possible_speakers[0]
+        )


### PR DESCRIPTION
Attempts to deal with ambiguous speaker names such as "Hon. Nanok" which will match 2 current Kenyan politicians (the parser happens to be consistently picking the "wrong" one) by attempting to add a 'member of current house' restriction if more than 1 name is matched

Fixes #1743 