### PR TITLE
ZA: Improve homepage spacing on short but wide screens

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -610,14 +610,9 @@ body.home {
 .home__section {
     padding: 1.25em 0.75em; // roughly 20px and 10px
 
-    @media (min-width: 640px) and (min-height: 700px) {
+    @media (min-width: 640px) and (min-height: 800px) {
         padding-top: 2em;
         padding-bottom: 2em;
-    }
-
-    @media (min-width: 640px) and (min-height: 900px) {
-        padding-top: 2.5em;
-        padding-bottom: 2.5em;
     }
 
     a {
@@ -727,6 +722,10 @@ body.home {
             font-size: (1em / 1.5); // get back to 1em, from 1.5em parent
             line-height: 1.4em; // 1.4 of this element's ems
             font-weight: normal;
+
+            @media (min-width: 640px) and (max-height: 700px) {
+                display: none;
+            }
         }
     }
 }

--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -32,7 +32,7 @@
                     </h2>
                     <p class="meta">{{ article.publication_date|date }}</p>
                     <p class="summary">
-                        {{ article.content_as_plain_text|truncatewords:32 }}
+                        {{ article.content_as_plain_text|truncatewords:24 }}
                         <a class="readmore" href="{{ article.get_absolute_url }}">More</a>
                     </p>
                 </div>


### PR DESCRIPTION
https://github.com/mysociety/pombola/issues/1670#issuecomment-136663910 raised the issue of the infographics on the homepage being too low down, and being cut off on short desktop screens.

To some extent this can't be helped for ultra-short screens (ie: 600px high or less) – the People's Assembly header and nav bar alone take up 150px.

But I've attempted to improve the situation for screens in the middling category – somewhere between 600px and 800px high. For a drastic comparison, here's before (left) and after (right), at 650px high:

![650](https://cloud.githubusercontent.com/assets/739624/9635081/792bfb18-518c-11e5-99bc-1f181a2699f2.png)

700px high:

![700](https://cloud.githubusercontent.com/assets/739624/9635082/7cb0104e-518c-11e5-9103-a8317c25fae7.png)

And 750px high:

![750](https://cloud.githubusercontent.com/assets/739624/9635086/804a9918-518c-11e5-81a2-98f91ca3ad53.png)

Note how more of each infographics is visible on page load, so people know they can scroll down.