### PR TITLE
ZA: Crop and compress homepage infographic previews

### DIFF
--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -98,7 +98,7 @@
         <div class="home__infographics__articles">
           {% for infographic in infographics %}
             <a href="{{ infographic.get_absolute_url }}" class="home__infographics__article">
-              {% thumbnail infographic.featured_image_file.file "220" as im %}
+              {% thumbnail infographic.featured_image_file.file "223x250" crop="top" quality=80 as im %}
                 <img src="{{ im.url }}">
               {% endthumbnail %}
             </a>


### PR DESCRIPTION
The four infographic previews on the homepage are cropped so that only the top 250px are included, and also given 80% JPEG compression (down from the default 95%).

On my VM, this represents a roughly 90% saving in file size (from 120KB each image, down to 14KB).