### PR TITLE
ZA: fix the astonishingly slow display of blog pages

### DIFF
--- a/pombola/info/tests.py
+++ b/pombola/info/tests.py
@@ -222,7 +222,7 @@ class ViewCountsTest(TestCase):
         context = BlogMixin().get_context_data()
 
         self.assertListEqual(
-            [x.slug for x in context['popular_posts']],
+            [x['slug'] for x in context['popular_posts']],
             ['post', 'post2'],
             )
 

--- a/pombola/info/views.py
+++ b/pombola/info/views.py
@@ -42,6 +42,7 @@ class BlogMixin(ContextMixin):
                 .filter(kind=InfoPage.KIND_BLOG)
                 .filter(viewcount__count__gt=0)
                 .filter(viewcount__date__gte=date.today() - timedelta(days=28))
+                .values('title', 'slug')
                 .annotate(Sum('viewcount__count'))
                 .order_by(*order_args)
             )

--- a/pombola/info/views.py
+++ b/pombola/info/views.py
@@ -23,13 +23,18 @@ class BlogMixin(ContextMixin):
             .filter(kind=InfoPage.KIND_BLOG) \
             .order_by("-publication_date")
 
-        context['popular_posts'] = (
-            InfoPage.objects
-            .filter(kind=InfoPage.KIND_BLOG)
-            .filter(viewcount__count__gt=0)
-            .filter(viewcount__date__gte=date.today() - timedelta(days=28))
-            .annotate(Sum('viewcount__count'))
-            .order_by('-viewcount__count__sum', '?')
+        context['some_popular_posts'] = ViewCount.objects.filter(
+            page__kind=InfoPage.KIND_BLOG
+        ).exists()
+
+        if context['some_popular_posts']:
+            context['popular_posts'] = (
+                InfoPage.objects
+                .filter(kind=InfoPage.KIND_BLOG)
+                .filter(viewcount__count__gt=0)
+                .filter(viewcount__date__gte=date.today() - timedelta(days=28))
+                .annotate(Sum('viewcount__count'))
+                .order_by('-viewcount__count__sum')
             )
 
         return context

--- a/pombola/south_africa/templates/info/_blog_sidebar.html
+++ b/pombola/south_africa/templates/info/_blog_sidebar.html
@@ -14,12 +14,14 @@
       {% endfor %}
     </ul>
 
-    {% if popular_posts.exists %}
+    {% if some_popular_posts %}
       <h3>Popular posts</h3>
 
       <ul>
         {% for post in popular_posts|slice:":5" %}
           <li><a href="{% url 'info_blog' slug=post.slug %}">{{ post.title }}</a></li>
+        {% empty %}
+          <li>No recent popular posts found.</li>
         {% endfor %}
       </ul>
     {% endif %}


### PR DESCRIPTION
In combination, these commits take the time for the SQL on blog pages
down to 0.1 second from about 30 seconds.