### PR TITLE
Don't send emails on UnreadablePostData errors

### DIFF
--- a/pombola/core/logging_filters.py
+++ b/pombola/core/logging_filters.py
@@ -1,0 +1,11 @@
+from django.http import UnreadablePostError
+
+# This is taken from the Django documentation:
+#   https://docs.djangoproject.com/en/1.6/topics/logging/#django.utils.log.CallbackFilter
+
+def skip_unreadable_post(record):
+    if record.exc_info:
+        exc_type, exc_value = record.exc_info[:2]
+        if isinstance(exc_value, UnreadablePostError):
+            return False
+    return True

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -6,6 +6,7 @@ from .apps import *
 
 from django.template.defaultfilters import slugify
 
+from pombola.core.logging_filters import skip_unreadable_post
 from pombola.hansard.constants import NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH
 
 IN_TEST_MODE = False
@@ -221,11 +222,15 @@ LOGGING = {
     'filters': {
          'require_debug_false': {
              '()': 'django.utils.log.RequireDebugFalse'
-         }
+         },
+        'skip_unreadable_posts': {
+            '()': 'django.utils.log.CallbackFilter',
+            'callback': skip_unreadable_post,
+        },
      },
     'handlers': {
         'mail_admins': {
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'skip_unreadable_posts'],
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler'
         },

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -220,9 +220,9 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'filters': {
-         'require_debug_false': {
-             '()': 'django.utils.log.RequireDebugFalse'
-         },
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        },
         'skip_unreadable_posts': {
             '()': 'django.utils.log.CallbackFilter',
             'callback': skip_unreadable_post,


### PR DESCRIPTION
We get quite a lot of UnreadablePostData errors by email from Pombola
sites.  We believe that these represent POST requests (often large
updates) that were interrupted by network problems of one kind or
another, in which case this is just email noise and we should suppress
them.

My only concern about suppressing these emails is that we also got a lot
of these error emails from AJAX POST requests that were a "heartbeat" to
measure how long people spent on the MIT experiment pages (e.g. POSTs to
/youth-employment/youth-employment/time-on-page) - these might be
problems with AJAX on particular browsers, but we never figured that
out at the time, and suppressing these error emails might means we're
less likely to notice them and investigate in the future.

Fixes #1433