### PR TITLE
Add survey link for Indigo Trust impact survey to ZA.

### DIFF
--- a/pombola/core/static/js/survey.js
+++ b/pombola/core/static/js/survey.js
@@ -1,0 +1,80 @@
+(function() {
+
+    // Only do any of this if the survey wrapper is present
+    if (document.getElementById('ms_srv_wrapper')) {
+
+        // Get the wrapper element
+        var linkWrapper = document.getElementById('ms_srv_wrapper')
+
+        // Initialise various essentials
+        var percentage = parseFloat(linkWrapper.getAttribute('data-display-percentage')),
+            cookie_time = null,
+            cookie_array = document.cookie.split(';'),
+            i, cookie, time, site_time, link, data, query_string;
+
+        for(i=0;i < cookie_array.length;i++) {
+            cookie = cookie_array[i];
+            cookie = cookie.replace(/^\s+/, '')
+            if (cookie.indexOf('ms_srv_t=') == 0) {
+                // Cookie for time...
+                cookie_time = cookie.substring('ms_srv_t='.length,cookie.length);
+            }
+            if (cookie.indexOf('ms_srv_r=') == 0) {
+                // Cookie for referrer...
+                cookie_referrer = cookie.substring('ms_srv_r='.length,cookie.length);
+            }
+        }
+
+        if (cookie_time == null) {
+            // No cookie!
+            if (Math.random() < percentage) {
+                // Chosen to survey
+                // Set the cookie to current timestamp
+                time = Math.round(new Date().getTime() / 1000);
+                document.cookie = 'ms_srv_t='+time+'; path=/';
+                document.cookie = 'ms_srv_r='+document.referrer+'; path=/';
+                cookie_time = time;
+                cookie_referrer = document.referrer;
+
+            } else {
+                // Not chosen to survey
+                // Set cookie to X
+                document.cookie = 'ms_srv_t=X; path=/';
+                cookie_time = 'X'
+            }
+        }
+
+        // Only bother to do this if the cookie is not excluding the user from surveying
+        if (cookie_time != 'X') {
+
+            // Find the time on site thus far
+            site_time = Math.round(new Date().getTime() / 1000) - cookie_time;
+
+            // Find the URL on the page
+            link = document.getElementById('ms_srv_link');
+
+            data = {
+                'ms_time': site_time,
+                'ms_referrer': cookie_referrer || null
+            }
+
+            // Assemble the query string
+            query_string = [];
+            for (d in data) {
+               query_string.push(encodeURIComponent(d) + "=" + encodeURIComponent(data[d]));
+            }
+
+            // Append query string to the URL
+            link.href = link.href + '?' + query_string.join('&');
+
+            // Show the survey link element
+            linkWrapper.style.display = '';
+
+            // Bind a click event to the link so we can de-survey the user
+            link.onclick = function() { document.cookie = 'ms_srv_t=X; path=/'; }
+
+        }
+
+    }
+
+})();

--- a/pombola/core/static/sass/_header.scss
+++ b/pombola/core/static/sass/_header.scss
@@ -5,6 +5,23 @@
   .wrapper {
     overflow: hidden; } }
 
+#ms_srv_wrapper {
+  background-color: #444;
+  color: #FFF;
+  font-size: 12px;
+  line-height: 14px;
+  padding: 10px;
+  text-align: center;
+
+  a {
+    color: #EEE;
+
+    &:hover {
+      color: #FFF;
+    }
+  }
+}
+
 @media only all and (min-width: 640px), print {
   #site-header {
     height: 60px;

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -572,6 +572,12 @@ PIPELINE_JS = {
         'output_filename': 'js/hide-reveal.js',
         'template_name': 'pipeline/js-array.html',
     },
+    'survey': {
+        'source_filenames': (
+            'js/survey.js',
+        ),
+        'output_filename': 'js/survey.js',
+    },
 }
 
 for package_name, package in DYNAMICALLY_LOADED_PIPELINE_JS.items():

--- a/pombola/south_africa/templates/header.html
+++ b/pombola/south_africa/templates/header.html
@@ -2,4 +2,8 @@
 
 {% include 'site_header.html' %}
 
+<div id="ms_srv_wrapper" style="display:none" data-display-percentage="0.4">
+    <a href="https://www.surveygizmo.com/s3/2458850/People-s-Assembly-Indigo-Trust-Impact-Survey" id="ms_srv_link" target="_blank">We&rsquo;re running a short survey to help us understand how well People's Assembly works and how we can make it better. If you&rsquo;d like to take it, click here.</a>
+</div>
+
 {% include 'main_menu.html' %}


### PR DESCRIPTION
Displays [a new survey](https://www.surveygizmo.com/collab/2458850/People-s-Assembly-Indigo-Trust-Impact-Survey) (although identical in most regard to the previous one) to 40% of site users.

This is to track impact for Indigo Trust.