### PR TITLE
Change 'Search' to 'Update Results' if there is a query.

### DIFF
--- a/pombola/search/templates/search/search_base.html
+++ b/pombola/search/templates/search/search_base.html
@@ -46,7 +46,7 @@
             <div class="inline-search-box">
                 <label for="id_q">Search</label>
                 <input id="id_q" name="q" type="text" value="{{ query }}">
-                <input type="submit" value="Search" class="button">
+                <input type="submit" value="{% if query %}Update Results{% else %}Search{% endif %}" class="button">
             </div>
             {% if settings.COUNTRY_APP == 'south_africa' %}
             <h4>Advanced search</h4>


### PR DESCRIPTION
The idea here is to make it more obvious that if you change
the things being searched for you have to press the button.

Fixes #1834.