### PR TITLE
"Update results" button on advanced search page

### DIFF
--- a/pombola/core/static/sass/_search.scss
+++ b/pombola/core/static/sass/_search.scss
@@ -125,17 +125,29 @@
   padding: 1em;
   background-color: $colour_lighter_grey;
   margin-top: 1em;
+
   .radio-button-columns {
-    width: 48%;
-    margin-right: 1%;
-    @media only all and (min-width: 640px) {
-       width: 30%;
-       margin-right: 2%;
-    }
-    display: inline-block;
+    display: block;
     margin-bottom: 0.75em;
     font-size: 0.875em;
+
+    @media (min-width: 480px) {
+      display: inline-block;
+      width: 48%;
+      margin-right: 1%;
+    }
+
+    @media (min-width: 640px) {
+      width: 30%;
+      margin-right: 2%;
+    }
+
+    @media (min-width: 960px) {
+      width: 22%;
+      margin-right: 2%;
+    }
   }
+
   .search-order-by-controls {
     font-size: 0.875em;
   }

--- a/pombola/core/static/sass/_search.scss
+++ b/pombola/core/static/sass/_search.scss
@@ -150,13 +150,17 @@
 
   .search-order-by-controls {
     font-size: 0.875em;
+    margin: 0.5em 0 1.5em 0;
   }
 
   .search-range-controls {
     font-size: 0.875em;
+    margin: 0.5em 0 1.5em 0;
+
     h4 {
       margin: 0.6em 0 0.5em;
     }
+
     input {
       width: 8em;
       margin-right: 1.5em;

--- a/pombola/search/templates/search/search_base.html
+++ b/pombola/search/templates/search/search_base.html
@@ -42,39 +42,51 @@
       {% endblock %}
 
         <div class="search-section-box">
-            {% block search_form %}
+
+          {% block search_form %}
             <div class="inline-search-box">
                 <label for="id_q">Search</label>
                 <input id="id_q" name="q" type="text" value="{{ query }}">
                 <input type="submit" value="Search" class="button">
             </div>
-            {% if settings.COUNTRY_APP == 'south_africa' %}
+
+          {% if settings.COUNTRY_APP == 'south_africa' %}
             <h4>Advanced search</h4>
-            {% else %}
+          {% else %}
             <a href="#advanced-search-options" class="js-hide-reveal-link open-advanced-search">Advanced search</a>
-            {% endif %}
+          {% endif %}
+
             <div class="advanced-search-options{% if settings.COUNTRY_APP != 'south_africa' %} js-hide-reveal{% endif %}" id="advanced-search-options">
+
               {% for search_section, title, selected in form_options %}
-                  <div class="radio-button-columns"><input type="radio" name="section" id="{{ search_section }}" value="{{ search_section }}"{% if selected %} checked{% endif %}><label for="{{ search_section }}">{{ title }}</label></div>
+                <div class="radio-button-columns">
+                    <label>
+                        <input type="radio" name="section" value="{{ search_section }}"{% if selected %} checked{% endif %}>
+                        {{ title }}
+                    </label>
+                </div>
               {% endfor %}
-              <div class="search-order-by-controls">
-                <label for="search-results-order">Order by</label>
-                  <select name="order" id="search-results-order">
-                    <option value="relevance"{% if order == 'relevance' %} selected{% endif %}>Relevance</option>
-                    <option value="date"{% if order == 'date' %} selected{% endif %}>Date</option>
-                  </select>
-              </div>
+
+                <div class="search-order-by-controls">
+                    <label for="search-results-order">Order by</label>
+                    <select name="order" id="search-results-order">
+                        <option value="relevance"{% if order == 'relevance' %} selected{% endif %}>Relevance</option>
+                        <option value="date"{% if order == 'date' %} selected{% endif %}>Date</option>
+                    </select>
+                </div>
+
               {% if settings.COUNTRY_APP == 'south_africa' %}
-              <div class="search-range-controls">
-                <h4>Date range</h4>
-                <label for="search-range-start">Start date</label>
-                <input type="text" name="start" id="search-range-start" value="{{ search_start_date_range }}" placeholder="YYYY-MM-DD" class="datepicker">
-                <label for="search-range-end">End date</label>
-                <input type="text" name="end" id="search-range-end" value="{{ search_end_date_range }}" placeholder="YYYY-MM-DD" class="datepicker">
-              </div>
+                <div class="search-range-controls">
+                    <h4>Date range</h4>
+                    <label for="search-range-start">Start date</label>
+                    <input type="text" name="start" id="search-range-start" value="{{ search_start_date_range }}" placeholder="YYYY-MM-DD" class="datepicker">
+                    <label for="search-range-end">End date</label>
+                    <input type="text" name="end" id="search-range-end" value="{{ search_end_date_range }}" placeholder="YYYY-MM-DD" class="datepicker">
+                </div>
               {% endif %}
+
             </div>
-            {% endblock %}
+          {% endblock %}
 
         </div>
 

--- a/pombola/search/templates/search/search_base.html
+++ b/pombola/search/templates/search/search_base.html
@@ -56,16 +56,18 @@
             <a href="#advanced-search-options" class="js-hide-reveal-link open-advanced-search">Advanced search</a>
           {% endif %}
 
-            <div class="advanced-search-options{% if settings.COUNTRY_APP != 'south_africa' %} js-hide-reveal{% endif %}" id="advanced-search-options">
+            <div class="advanced-search-options js-update-results-trigger {% if settings.COUNTRY_APP != 'south_africa' %} js-hide-reveal{% endif %}" id="advanced-search-options">
 
-              {% for search_section, title, selected in form_options %}
-                <div class="radio-button-columns">
-                    <label>
-                        <input type="radio" name="section" value="{{ search_section }}"{% if selected %} checked{% endif %}>
-                        {{ title }}
-                    </label>
+                <div class="search-category-controls">
+                  {% for search_section, title, selected in form_options %}
+                    <div class="radio-button-columns">
+                        <label>
+                            <input type="radio" name="section" value="{{ search_section }}"{% if selected %} checked{% endif %}>
+                            {{ title }}
+                        </label>
+                    </div>
+                  {% endfor %}
                 </div>
-              {% endfor %}
 
                 <div class="search-order-by-controls">
                     <label for="search-results-order">Order by</label>
@@ -77,13 +79,15 @@
 
               {% if settings.COUNTRY_APP == 'south_africa' %}
                 <div class="search-range-controls">
-                    <h4>Date range</h4>
+                    <h4>Limit to date range</h4>
                     <label for="search-range-start">Start date</label>
                     <input type="text" name="start" id="search-range-start" value="{{ search_start_date_range }}" placeholder="YYYY-MM-DD" class="datepicker">
                     <label for="search-range-end">End date</label>
                     <input type="text" name="end" id="search-range-end" value="{{ search_end_date_range }}" placeholder="YYYY-MM-DD" class="datepicker">
                 </div>
               {% endif %}
+
+              <button type="submit" class="button js-update-results-button">Update results</button>
 
             </div>
           {% endblock %}

--- a/pombola/south_africa/static/js/advanced-search.js
+++ b/pombola/south_africa/static/js/advanced-search.js
@@ -11,12 +11,20 @@ jQuery(function($) {
             $searchResultsOrder.val('relevance');
         }
     });
-});
 
-jQuery(function($) {
-  $('.datepicker').datepicker({
-      changeMonth: true,
-      changeYear: true,
-      dateFormat: "yy-mm-dd",
-  });
+    $('.datepicker').datepicker({
+        changeMonth: true,
+        changeYear: true,
+        dateFormat: "yy-mm-dd",
+    });
+
+    // The "Update results" button is disabled by default...
+    var $advancedUpdateButton = $('.js-update-results-button');
+    $advancedUpdateButton.prop('disabled', true);
+
+    // And then activated again once they change any of the settings...
+    var $advancedOptions = $('.js-update-results-trigger');
+    $('input, select', $advancedOptions).on('change', function(){
+        $advancedUpdateButton.prop('disabled', false);
+    });
 });

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -80,6 +80,14 @@ a {
 
         }
     }
+
+    &[disabled],
+    &[disabled]:hover,
+    &[disabled]:focus {
+        background-color: $colour_cream;
+        color: $colour_grey;
+        cursor: default;
+    }
 }
 
 .inline-search-box {
@@ -1382,6 +1390,61 @@ FOOTER
         color: $colour_blackish;
     }
 }
+
+.advanced-search-options {
+    background-color: $colour_cream;
+
+    .button[disabled],
+    .button[disabled]:hover,
+    .button[disabled]:focus {
+        background-color: darken($colour_cream, 10%);
+    }
+
+    .search-order-by-controls {
+        // Replicate h4 styling
+        label {
+            font-size: 14px;
+            font-weight: bold;
+            color: #222;
+            display: block;
+            margin: 0.6em 0 0.5em;
+        }
+    }
+
+    @media (min-width: 640px) {
+      .search-order-by-controls {
+          display: inline-block;
+          width: (30% + 2%);
+      }
+
+      .search-range-controls {
+          display: inline-block;
+          width: (30% + 2% + 30% + 2%);
+      }
+    }
+
+    @media (min-width: 960px) {
+        padding: 1.5em;
+        position: relative;
+
+        .button {
+            position: absolute;
+            bottom: 1.5em;
+            right: 1.5em;
+        }
+
+        .search-order-by-controls {
+            width: (22% + 2%);
+            margin-bottom: 0;
+        }
+
+        .search-range-controls {
+            width: (22% + 2% + 22% + 2%);
+            margin-bottom: 0;
+        }
+    }
+}
+
 
 /* Pagination controls */
 .step-pagination,


### PR DESCRIPTION
Fixes #1834.

Adds an "Update results" button to the advanced search form on all Pombolae, and improves the layout on People’s Assembly in particular by folding all the inputs onto just two lines in desktop view.

Here's a before and after:

![before-and-after](https://cloud.githubusercontent.com/assets/739624/11427733/2c6761d2-945d-11e5-8592-6b6888a755e2.gif)

The disabled "Update results" button is reactivated when any of the advanced inputs are changed:

![screen shot 2015-11-26 at 16 48 23](https://cloud.githubusercontent.com/assets/739624/11427769/8b18f06a-945d-11e5-8e3f-31c16031a768.png)

However, because the button is disabled by javascript, there is a noticeable period on pageload where it is bright red. Any ideas @mhl?

