### PR TITLE
1857 more positions in tagline

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -807,11 +807,6 @@ class Place(ModelBase, ScorecardMixin, BudgetsMixin):
         positions = self.all_related_positions().current_politician_positions()
         return Person.objects.filter(position__in=positions).distinct()
 
-    def all_related_former_politicians(self):
-        """Return a query set of all the former politicians for this place, and all parent places."""
-        positions = self.all_related_positions().former_politician_positions()
-        return Person.objects.filter(position__in=positions).distinct()
-
     def child_places_by_kind(self):
         """Return all concurrent child places, grouped by their PlaceKind
 
@@ -1092,10 +1087,6 @@ class PositionQuerySet(models.query.GeoQuerySet):
     def current_politician_positions(self, when=None):
         """Filter down to only positions which are those of current politicians."""
         return self.politician_positions().currently_active(when)
-
-    def former_politician_positions(self, when=None):
-        """Filter down to only positions which are those of former politicians."""
-        return self.politician_positions().currently_inactive(when)
 
     def political(self):
         """Filter down to only the political category"""

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1066,6 +1066,16 @@ class PositionQuerySet(models.query.GeoQuerySet):
 
         return qs
 
+    def previous(self, when=None):
+        """Filter end dates to limit to positions which are already over."""
+
+        when = when or datetime.date.today()
+
+        when_approx = repr(ApproximateDate(year=when.year, month=when.month, day=when.day))
+
+        end_criteria = Q(sorting_end_date_high__lt=when_approx) & ~Q(end_date='')
+
+        return self.filter(end_criteria)
 
     def aspirant_positions(self):
         """

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1078,15 +1078,9 @@ class PositionQuerySet(models.query.GeoQuerySet):
         """Filter down to only positions which are those of current aspirants."""
         return self.aspirant_positions().currently_active(when)
 
-    def politician_positions(self):
-        """Filter down to only positions which are one of the two kinds of
-        politician (those with constituencies, and nominated ones).
-        """
-        return self.filter(category='political')
-
     def current_politician_positions(self, when=None):
         """Filter down to only positions which are those of current politicians."""
-        return self.politician_positions().currently_active(when)
+        return self.political().currently_active(when)
 
     def political(self):
         """Filter down to only the political category"""

--- a/pombola/core/tests/test_positions.py
+++ b/pombola/core/tests/test_positions.py
@@ -329,6 +329,7 @@ class PositionTest(TestCase):
         # check that we match by default
         self.assertEqual( pos_qs.currently_active().count(), 1 )
         self.assertEqual( pos_qs.currently_inactive().count(), 0 )
+        self.assertEqual( pos_qs.previous().count(), 0 )
 
         # check valid date ranges
         self.assertEqual( pos_qs.currently_active( earlier ).count(), 1 )
@@ -337,14 +338,18 @@ class PositionTest(TestCase):
         self.assertEqual( pos_qs.currently_inactive( earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( now     ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( later   ).count(), 0 )
+        self.assertEqual( pos_qs.previous( earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( now     ).count(), 0 )
+        self.assertEqual( pos_qs.previous( later   ).count(), 0 )
 
         # check that much earlier or much later don't match
         self.assertEqual( pos_qs.currently_active( much_earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_active( much_later   ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( much_earlier ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_later   ).count(), 1 )
+        self.assertEqual( pos_qs.previous( much_earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( much_later   ).count(), 1 )
         
-
         # check future dates
         position.start_date = ApproximateDate( year=earlier.year, month=earlier.month, day=earlier.day )
         position.end_date = ApproximateDate(future=True)
@@ -353,6 +358,7 @@ class PositionTest(TestCase):
         # check that we match by default
         self.assertEqual( pos_qs.currently_active().count(), 1 )
         self.assertEqual( pos_qs.currently_inactive().count(), 0 )
+        self.assertEqual( pos_qs.previous().count(), 0 )
 
         # check valid date ranges
         self.assertEqual( pos_qs.currently_active( earlier ).count(), 1 )
@@ -361,13 +367,17 @@ class PositionTest(TestCase):
         self.assertEqual( pos_qs.currently_inactive( earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( now     ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( later   ).count(), 0 )
+        self.assertEqual( pos_qs.previous( earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( now     ).count(), 0 )
+        self.assertEqual( pos_qs.previous( later   ).count(), 0 )
 
         # check that much earlier or much later don't match
         self.assertEqual( pos_qs.currently_active( much_earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_active( much_later   ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_earlier ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_later   ).count(), 0 )
-
+        self.assertEqual( pos_qs.previous( much_earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( much_later   ).count(), 0 )
 
         # check absent end dates
         position.start_date = ApproximateDate( year=earlier.year, month=earlier.month, day=earlier.day )
@@ -377,6 +387,7 @@ class PositionTest(TestCase):
         # check that we match by default
         self.assertEqual( pos_qs.currently_active().count(), 1 )
         self.assertEqual( pos_qs.currently_inactive().count(), 0 )
+        self.assertEqual( pos_qs.previous().count(), 0 )
 
         # check valid date ranges
         self.assertEqual( pos_qs.currently_active( earlier ).count(), 1 )
@@ -385,14 +396,17 @@ class PositionTest(TestCase):
         self.assertEqual( pos_qs.currently_inactive( earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( now     ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( later   ).count(), 0 )
+        self.assertEqual( pos_qs.previous( earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( now     ).count(), 0 )
+        self.assertEqual( pos_qs.previous( later   ).count(), 0 )
 
         # check that much earlier or much later don't match
         self.assertEqual( pos_qs.currently_active( much_earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_active( much_later   ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_earlier ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_later   ).count(), 0 )
-
-
+        self.assertEqual( pos_qs.previous( much_earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( much_later   ).count(), 0 )
 
         # check absent start and end dates
         position.start_date = None
@@ -402,6 +416,7 @@ class PositionTest(TestCase):
         # check that we match by default
         self.assertEqual( pos_qs.currently_active().count(), 1 )
         self.assertEqual( pos_qs.currently_inactive().count(), 0 )
+        self.assertEqual( pos_qs.previous().count(), 0 )
 
         # check valid date ranges
         self.assertEqual( pos_qs.currently_active( earlier ).count(), 1 )
@@ -410,14 +425,17 @@ class PositionTest(TestCase):
         self.assertEqual( pos_qs.currently_inactive( earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( now     ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( later   ).count(), 0 )
+        self.assertEqual( pos_qs.previous( earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( now     ).count(), 0 )
+        self.assertEqual( pos_qs.previous( later   ).count(), 0 )
 
         # check that much earlier or much later don't match
         self.assertEqual( pos_qs.currently_active( much_earlier ).count(), 1 )
         self.assertEqual( pos_qs.currently_active( much_later   ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( much_later   ).count(), 0 )
-
-
+        self.assertEqual( pos_qs.previous( much_earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( much_later   ).count(), 0 )
 
         # check future start dates
         position.start_date = ApproximateDate(future=1)
@@ -427,6 +445,7 @@ class PositionTest(TestCase):
         # check that we match by default
         self.assertEqual( pos_qs.currently_active().count(), 0 )
         self.assertEqual( pos_qs.currently_inactive().count(), 1 )
+        self.assertEqual( pos_qs.previous().count(), 0 )
 
         # check valid date ranges
         self.assertEqual( pos_qs.currently_active( earlier ).count(), 0 )
@@ -435,14 +454,17 @@ class PositionTest(TestCase):
         self.assertEqual( pos_qs.currently_inactive( earlier ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( now     ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( later   ).count(), 1 )
+        self.assertEqual( pos_qs.previous( earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( now     ).count(), 0 )
+        self.assertEqual( pos_qs.previous( later   ).count(), 0 )
 
         # check that much earlier or much later don't match
         self.assertEqual( pos_qs.currently_active( much_earlier ).count(), 0 )
         self.assertEqual( pos_qs.currently_active( much_later   ).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive( much_earlier ).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive( much_later   ).count(), 1 )
-
-
+        self.assertEqual( pos_qs.previous( much_earlier ).count(), 0 )
+        self.assertEqual( pos_qs.previous( much_later   ).count(), 0 )
 
         # check partial dates
         mid_2010 = datetime.date(year=2010, month=6, day=1)
@@ -462,11 +484,18 @@ class PositionTest(TestCase):
         self.assertEqual( pos_qs.currently_active(mid_2011).count(), 1 )
         self.assertEqual( pos_qs.currently_active(mid_2012).count(), 1 )
         self.assertEqual( pos_qs.currently_active(mid_2013).count(), 0 )
+        self.assertEqual( pos_qs.currently_active(mid_2012).count(), 1 )
+        self.assertEqual( pos_qs.currently_active(mid_2013).count(), 0 )
 
         self.assertEqual( pos_qs.currently_inactive(mid_2010).count(), 1 )
         self.assertEqual( pos_qs.currently_inactive(mid_2011).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive(mid_2012).count(), 0 )
         self.assertEqual( pos_qs.currently_inactive(mid_2013).count(), 1 )
+
+        self.assertEqual( pos_qs.previous(mid_2010).count(), 0 )
+        self.assertEqual( pos_qs.previous(mid_2011).count(), 0 )
+        self.assertEqual( pos_qs.previous(mid_2012).count(), 0 )
+        self.assertEqual( pos_qs.previous(mid_2013).count(), 1 )
 
     def test_position_title_no_redirect(self):
         response = self.client.get(

--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -7,12 +7,23 @@
 
 {% block object_tagline %}
     <div class="important-positions">
-      <p>
-        {% for position in positions %}
-          <span class="position-title">{{ position.organisation.name }}</span>
-        {% if not forloop.last %}and{% endif %}
-        {% endfor %}
-      </p>
+      {% if positions %}
+        <p>
+          {% for position in positions %}
+            <span class="position-title">{{ position.organisation.name }}</span>
+          {% if not forloop.last %}and{% endif %}
+          {% endfor %}
+        </p>
+      {% endif %}
+      {% if former_positions %}
+        <p>
+          Formerly:
+          {% for position in former_positions %}
+            <span class="position-title">{{ position.organisation.name }}</span>
+          {% if not forloop.last %}and{% endif %}
+          {% endfor %}
+        </p>
+      {% endif %}
     </div>
 
     <div class="contact-actions">

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -604,26 +604,6 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
         )
         return models.Organisation.objects.filter(position__in=former_party_memberships).distinct()
 
-    def get_former_positions(self, person):
-        return (
-            person
-            .position_set
-            .all()
-            .political()
-            .currently_inactive()
-            .filter(
-                (
-                    # select positions within important organisations
-                    Q(organisation__slug__in=self.important_organisations)
-
-                    |
-                    # select election-list positions
-                    Q(organisation__kind__slug='election-list')
-                )
-            )
-            .order_by('-end_date','-start_date')
-        )
-
     def store_or_get_pmg_member_id(self, scheme='za.org.pmg.api/member'):
         identifier = self.object.get_identifier(scheme)
 
@@ -774,9 +754,6 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
         context['fax_contacts'] = self.list_contacts(('fax',))
         context['address_contacts'] = self.list_contacts(('address',))
         context['positions'] = self.object.politician_positions().filter(organisation__slug__in=self.important_organisations)
-
-        if len(self.object.position_set.all().political().currently_active()) < 2:
-            context['former_positions'] = self.get_former_positions(self.object)
 
         # FIXME - the titles used here will need to be checked and fixed.
         context['hansard']   = self.get_recent_speeches_for_section(('hansard',), limit=2)

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -506,8 +506,7 @@ class SAOrganisationDetailSubPeople(SAOrganisationDetailSub):
             context['membertitle'] = 'member'
 
 class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
-
-    important_organisations = ('ncop', 'national-assembly', 'national-executive')
+    important_org_kind_slugs = ('national-executive', 'parliament', 'provincial-legislature')
 
     def get_recent_speeches_for_section(self, tags, limit=5):
         pombola_person = self.object
@@ -753,7 +752,8 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
         context['phone_contacts'] = self.list_contacts(('cell', 'voice'))
         context['fax_contacts'] = self.list_contacts(('fax',))
         context['address_contacts'] = self.list_contacts(('address',))
-        context['positions'] = self.object.politician_positions().filter(organisation__slug__in=self.important_organisations)
+        context['positions'] = self.object.politician_positions().filter(
+            organisation__kind__slug__in=self.important_org_kind_slugs)
 
         # FIXME - the titles used here will need to be checked and fixed.
         context['hansard']   = self.get_recent_speeches_for_section(('hansard',), limit=2)

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -755,6 +755,14 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
         context['positions'] = self.object.politician_positions().filter(
             organisation__kind__slug__in=self.important_org_kind_slugs)
 
+        context['former_positions'] = (
+            self.object.position_set
+            .all()
+            .political()
+            .previous()
+            .filter(organisation__kind__slug__in=self.important_org_kind_slugs)
+            )
+
         # FIXME - the titles used here will need to be checked and fixed.
         context['hansard']   = self.get_recent_speeches_for_section(('hansard',), limit=2)
         context['committee'] = self.get_recent_speeches_for_section(('committee',), limit=5)


### PR DESCRIPTION
Add memberships of Provincial Legislatures to the tagline on a person page (closes #1857). This is done by changing how we decide which positions are important to work off the slug of the organization kind rather than off the organization. In future we could make this piece of configuration data by having a table of ids of org kinds which are this sort of important in the database and editable by the Django Admin.

Also adds former memberships of important organizations (closes #1856).

Finally, I've removed some of odd bits of code which weren't used anywhere else.

I suggest we don't actually put this live until we've added some better testing of the person detail page and also fixed the problem in #1878.

