### PR TITLE
Flake8ify

### DIFF
--- a/bin/deskew-and-unpaper.py
+++ b/bin/deskew-and-unpaper.py
@@ -7,7 +7,7 @@
 # "convert -deskew '40%'" and then "unpaper" to remove scanning
 # artefacts.  (ImageMagick does better than unpaper on large skews.)
 
-import os, re, sys
+import os, re
 from subprocess import check_call
 
 original_page_re = re.compile('^(page-[0-9]+)\.png')

--- a/bin/name_matcher.py
+++ b/bin/name_matcher.py
@@ -19,7 +19,6 @@
 # for the intended purpose (matching LGA names in Nigeria) so development
 # stopped.
 
-from collections import defaultdict
 import csv
 import re
 import sys

--- a/fab/__init__.py
+++ b/fab/__init__.py
@@ -1,4 +1,4 @@
-import server
-import postgres
-import nginx
-import webapp
+import server  # noqa
+import postgres  # noqa
+import nginx  # noqa
+import webapp  # noqa

--- a/fab/nginx.py
+++ b/fab/nginx.py
@@ -1,5 +1,4 @@
-import os
-from fabric.api import *
+from fabric.api import cd, require, settings, sudo
 
 
 ENABLED = '/etc/nginx/sites-enabled'

--- a/fab/postgres.py
+++ b/fab/postgres.py
@@ -9,8 +9,7 @@ from __future__ import with_statement
 
 import re
 
-from fabric.api import *
-from fabric.contrib.files import exists
+from fabric.api import cd, env, hide, require, run, settings, sudo
 
 
 def setup_postgis():

--- a/fab/server.py
+++ b/fab/server.py
@@ -1,5 +1,8 @@
-from fabric.api import *
+import os.path
+
+from fabric.api import env, hide, put, require, run, settings, sudo
 from fabric.contrib.files import exists
+
 
 def add_ssh_key(path, password=None, user=None):
     require('hosts')

--- a/fab/webapp.py
+++ b/fab/webapp.py
@@ -1,9 +1,9 @@
-from fabric.api import *
-from fabric.contrib.files import exists
 import os
-import sys
-
 import random
+
+from fabric.api import cd, env, local, prefix, put, require, sudo
+from fabric.contrib.files import exists
+
 
 CHARS = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^*(-_=+)"
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -5,14 +5,12 @@
 Odekro deployment script
 """
 
-import os, re , time
-#, getpass, fileinput, shutil
+import os, time
 from fabric.api import task
-from fabric.api import hide, settings, cd, env, prefix, put, get, require
+from fabric.api import cd, env, put, get, require
 from fabric.api import local, run, sudo
 from fabric.contrib.files import exists
 
-import fab
 from fab import postgres as pg
 from fab import server, nginx, webapp
 
@@ -234,7 +232,7 @@ def configure_webapp(db=env.dbname, dbuser=env.dbuser, dbpasswd='', email_passwd
     webapp.configure(db=db, dbuser=dbuser, dbpasswd=dbpasswd, email_passwd=email_passwd)
 
 try:
-    from local_fabfile import *
+    from local_fabfile import *  # noqa
 except ImportError as e:
     pass
 

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,6 @@ import os
 import sys
 import yaml
 
-from django import get_version
 from django.core.management import LaxOptionParser, BaseCommand
 
 # Make the default settings file one that corresponds to the country

--- a/pombola/budgets/management/commands/budgets_import_place_budgets.py
+++ b/pombola/budgets/management/commands/budgets_import_place_budgets.py
@@ -1,21 +1,16 @@
-import re
-
 import unicodecsv as csv
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.exceptions import MultipleObjectsReturned
 from django.core.management.base import LabelCommand
 from django.db import IntegrityError
-
 from django.utils.text import slugify
-
-from django_date_extensions.fields import ApproximateDate
 
 from pombola.core.models import (
     Place, ContentType
 )
 
 from pombola.budgets.models import Budget, BudgetSession
+
 
 # Pretty colours to make it easier to spot things.
 HEADER = '\033[95m'

--- a/pombola/budgets/models.py
+++ b/pombola/budgets/models.py
@@ -2,11 +2,12 @@ import datetime
 
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+from django_date_extensions.fields import ApproximateDateField
 from django.db import models
 
 import babel.numbers
 import decimal
+
 
 class BudgetSession(models.Model):
     created = models.DateTimeField(auto_now_add=True, default=datetime.datetime.now)

--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -2,7 +2,6 @@ from django import forms
 from django.contrib import admin
 from django.contrib.gis import db
 from django.contrib.contenttypes.generic import GenericTabularInline
-from django.core.exceptions import ValidationError
 
 from ajax_select import make_ajax_form
 from ajax_select.admin import AjaxSelectAdmin
@@ -11,6 +10,7 @@ from pombola.core import models
 from pombola.scorecards import models as scorecard_models
 from pombola.images.admin import ImageAdminInline
 from pombola.slug_helpers.admin import StricterSlugFieldMixin
+
 
 def create_admin_link_for(obj, link_text):
     return u'<a href="%s">%s</a>' % (obj.get_admin_url(), link_text)

--- a/pombola/core/context_processors.py
+++ b/pombola/core/context_processors.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-import logging
+
 
 def add_settings( request ):
     """Add some selected settings values to the context"""

--- a/pombola/core/kenya_import_scripts/import_cdf_data_from_csv.py
+++ b/pombola/core/kenya_import_scripts/import_cdf_data_from_csv.py
@@ -19,13 +19,12 @@ sys.path.append(
 import csv
 import pprint
 import re
-import warnings
 
 from pombola.projects.models import Project
 from pombola.core.models import Place
 
-import django.core.exceptions
 from django.contrib.gis.geos import Point
+
 
 def main():
     pi = ProjectImporter()

--- a/pombola/core/kenya_import_scripts/import_committees_csv.py
+++ b/pombola/core/kenya_import_scripts/import_committees_csv.py
@@ -10,10 +10,9 @@ sys.path.append(
 )
 
 
-
-from haystack.query import SearchQuerySet
 from pombola.core.models import Person, Organisation, OrganisationKind, PositionTitle, Position
 from django.utils.text import slugify
+
 
 reader = csv.DictReader( open(sys.argv[1], 'r') )
 

--- a/pombola/core/kenya_import_scripts/import_contacts_from_tuples.py
+++ b/pombola/core/kenya_import_scripts/import_contacts_from_tuples.py
@@ -11,16 +11,14 @@ sys.path.append(
 )
 
 
-
-from pprint import pprint
 from pombola.core import models
-from django.contrib.contenttypes.models import ContentType, ContentTypeManager
+from django.contrib.contenttypes.models import ContentType
 
 import mp_contacts
 
+
 phone_kind   = models.ContactKind.objects.get(slug='phone')
 email_kind   = models.ContactKind.objects.get(slug='email')
-
 
 for row in mp_contacts.entries:
     

--- a/pombola/core/kenya_import_scripts/import_contituencies_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_contituencies_from_json.py
@@ -16,7 +16,7 @@ from pprint import pprint
 from django.utils.text import slugify
 
 from pombola.core import models
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+
 
 constituency_kind = models.PlaceKind.objects.get(slug="constituency")
 objects = simplejson.loads(sys.stdin.read())

--- a/pombola/core/kenya_import_scripts/import_member_comments_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_member_comments_from_json.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import re
 
 # Horrible boilerplate - there must be a better way :)
 sys.path.append(
@@ -17,11 +16,12 @@ import simplejson
 from pprint import pprint
 from pombola.core.models import Person
 
-from django.contrib.contenttypes.models import ContentType, ContentTypeManager
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
 from django.utils.text import slugify
 
 from comments2.models import Comment
+
 
 comments = simplejson.loads( sys.stdin.read() )
 

--- a/pombola/core/kenya_import_scripts/import_member_photos.py
+++ b/pombola/core/kenya_import_scripts/import_member_photos.py
@@ -11,15 +11,14 @@ sys.path.append(
 )
 
 
-
 import simplejson
 import time
 import urllib
 
-from pprint import pprint
 from django.core.files.base import ContentFile
 from pombola.core import models
 from pombola.images.models import Image
+
 
 constituency_kind = models.PlaceKind.objects.get(slug="constituency")
 

--- a/pombola/core/kenya_import_scripts/import_members_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_members_from_json.py
@@ -14,16 +14,16 @@ sys.path.append(
 
 
 import simplejson
-from pprint import pprint
 
 from django.utils.text import slugify
-from django.contrib.contenttypes.models import ContentType, ContentTypeManager
+from django.contrib.contenttypes.models import ContentType
 
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+from django_date_extensions.fields import ApproximateDate
 
 from pombola.core import models
 
 import name_to_first_last
+
 
 mp_job_title      = models.PositionTitle.objects.get(slug="mp")
 member_job_title  = models.PositionTitle.objects.get(slug="member")

--- a/pombola/core/kenya_import_scripts/import_parties_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_parties_from_json.py
@@ -17,9 +17,10 @@ from pprint import pprint
 
 from django.utils.text import slugify
 
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+from django_date_extensions.fields import ApproximateDate
 
 from pombola.core import models
+
 
 party_kind = models.OrganisationKind.objects.get(slug="party")
 parties = simplejson.loads(sys.stdin.read())

--- a/pombola/core/kenya_import_scripts/import_positions_from_json.py
+++ b/pombola/core/kenya_import_scripts/import_positions_from_json.py
@@ -12,16 +12,14 @@ sys.path.append(
 )
 
 
-
 import simplejson
-from pprint import pprint
-from warnings import warn
 
 from django.utils.text import slugify
 
 from django_date_extensions.fields import ApproximateDate
 
 from pombola.core import models
+
 
 json_filename = '/home/evdb/Mzalendo_Educational_Positions.json'
 

--- a/pombola/core/kenya_import_scripts/update_names.py
+++ b/pombola/core/kenya_import_scripts/update_names.py
@@ -11,12 +11,9 @@ sys.path.append(
 ),
 
 
-
-from pprint import pprint
 from django.utils.text import slugify
 
 from pombola.core import models
-
 
 
 constituency_renames = [

--- a/pombola/core/management/commands/core_check_mp_aspirants.py
+++ b/pombola/core/management/commands/core_check_mp_aspirants.py
@@ -1,6 +1,7 @@
-from pombola.core.models import *
+from django.core.management.base import NoArgsCommand
 
-from django.core.management.base import NoArgsCommand, CommandError
+from pombola.core.models import ParliamentarySession, Person
+
 
 class Command(NoArgsCommand):
 

--- a/pombola/core/management/commands/core_create_elected_positions.py
+++ b/pombola/core/management/commands/core_create_elected_positions.py
@@ -8,12 +8,12 @@
 # This script takes arguments are passed in on the command line.
 
 from optparse import make_option
-import sys
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django_date_extensions.fields import ApproximateDate
 
 from pombola.core.models import Person, Position, PositionTitle, Place, Organisation
+
 
 def yyyymmdd_to_approx(yyyymmdd):
     year, month, day = map(int, yyyymmdd.split('-'))

--- a/pombola/core/management/commands/core_end_positions.py
+++ b/pombola/core/management/commands/core_end_positions.py
@@ -1,10 +1,10 @@
 from optparse import make_option
-import sys
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django_date_extensions.fields import ApproximateDate
 
-from pombola.core.models import Person, Position, PositionTitle, Place, Organisation
+from pombola.core.models import Position
+
 
 def yyyymmdd_to_approx(yyyymmdd):
     year, month, day = map(int, yyyymmdd.split('-'))

--- a/pombola/core/management/commands/core_export_to_popolo_json.py
+++ b/pombola/core/management/commands/core_export_to_popolo_json.py
@@ -4,15 +4,12 @@
 import json
 from optparse import make_option
 from os.path import exists, isdir, join
-import slumber
-import sys
 import urlparse
 
 from pombola.core.popolo import get_popolo_data
 
 from django.core.management.base import BaseCommand, CommandError
 
-from popit_api import PopIt
 
 ideal_collection_order = ('organizations', 'persons', 'posts', 'memberships')
 

--- a/pombola/core/management/commands/core_extend_areas_to_generation_2.py
+++ b/pombola/core/management/commands/core_extend_areas_to_generation_2.py
@@ -7,7 +7,8 @@
 # every area where it was set to generation 2.
 
 from django.core.management.base import NoArgsCommand
-from mapit.models import Area, Generation, Type, NameType, Country, CodeType
+from mapit.models import Area, Generation
+
 
 class Command(NoArgsCommand):
     help = 'Change all genertion_high=1 to generation_high=2'

--- a/pombola/core/management/commands/core_extend_party_memberships.py
+++ b/pombola/core/management/commands/core_extend_party_memberships.py
@@ -17,11 +17,12 @@ from optparse import make_option
 
 import sys
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 
 from django_date_extensions.fields import ApproximateDate
 
 from pombola.core.models import Person
+
 
 class Command(NoArgsCommand):
     help = 'Change party memberships that end in 2012 to end in "future".'

--- a/pombola/core/management/commands/core_find_stale_elasticsearch_documents.py
+++ b/pombola/core/management/commands/core_find_stale_elasticsearch_documents.py
@@ -1,11 +1,12 @@
 import sys
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from haystack import connections as haystack_connections
 from haystack.exceptions import NotHandled
 from haystack.query import SearchQuerySet
 from haystack.utils.app_loading import get_models, load_apps
+
 
 def get_all_indexed_models():
 

--- a/pombola/core/management/commands/core_fix_ward_names.py
+++ b/pombola/core/management/commands/core_fix_ward_names.py
@@ -1,12 +1,13 @@
 import re
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 
 from django.utils.text import slugify
 
 from optparse import make_option
 
 from pombola.core.models import PlaceKind, Place
+
 
 def slugify_place_name(place_name):
     return 'ward-' + slugify(place_name)

--- a/pombola/core/management/commands/core_import_basic_positions_csv.py
+++ b/pombola/core/management/commands/core_import_basic_positions_csv.py
@@ -22,14 +22,20 @@
 
 import csv
 
-from django.core.management.base import LabelCommand, CommandError
+from django.core.management.base import LabelCommand
 
 from django.utils.text import slugify
 
-from pombola.core.models import (Organisation, OrganisationKind, Identifier,
-                         PlaceKind, Person,
-                         PositionTitle, Position,
-                         Place, PlaceKind)
+from pombola.core.models import (
+    Organisation,
+    OrganisationKind,
+    Person,
+    Place,
+    PlaceKind,
+    Position,
+    PositionTitle,
+    )
+
 
 def get_or_create(model, name, field="name", defaults={}):
 

--- a/pombola/core/management/commands/core_import_keynan_boundaries_2013.py
+++ b/pombola/core/management/commands/core_import_keynan_boundaries_2013.py
@@ -1,13 +1,8 @@
 # This script imports the boundaries for the 2013 Kenyan election into
 # MapIt - it uses the generic mapit_import script.
 
-import json
-import os
 import string
 import sys
-import urllib
-
-from tempfile import NamedTemporaryFile
 
 from optparse import make_option
 
@@ -15,6 +10,7 @@ from django.core.management import call_command
 from django.core.management.base import NoArgsCommand, CommandError
 
 from mapit.models import Generation, Area
+
 
 def map_county_name(original_name):
     # Then title-case the string, being careful to use string.capwords

--- a/pombola/core/management/commands/core_import_popolo.py
+++ b/pombola/core/management/commands/core_import_popolo.py
@@ -1,22 +1,30 @@
 import json
 import re
-import sys
 import time
 import unicodedata
 import urllib
-from urlparse import urlsplit, urlunsplit
 from optparse import make_option
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
-from django.core.management.base import LabelCommand, CommandError
+from django.core.management.base import LabelCommand
 from django.utils.text import slugify
 
-from pombola.core.models import (Organisation, OrganisationKind, Identifier,
-                         PlaceKind, Person, Contact, ContactKind, Position,
-                         PositionTitle, Place, PlaceKind)
+from pombola.core.models import (
+    Contact,
+    ContactKind,
+    Identifier,
+    Organisation,
+    OrganisationKind,
+    Person,
+    Place,
+    PlaceKind,
+    Position,
+    PositionTitle,
+    )
 from pombola.images.models import Image
 from mapit.models import Area, Generation
+
 
 VERBOSE = False
 

--- a/pombola/core/management/commands/core_list_malformed_slugs.py
+++ b/pombola/core/management/commands/core_list_malformed_slugs.py
@@ -78,7 +78,7 @@ class Command(BaseCommand):
         """
 
         # Models that will always be available
-        from pombola import core, file_archive, info, tasks
+        from pombola import core, info, tasks
         models_to_check = (
             (core.models.ContactKind, False),
             (core.models.Person, True),

--- a/pombola/core/management/commands/core_match_places_to_mapit_areas.py
+++ b/pombola/core/management/commands/core_match_places_to_mapit_areas.py
@@ -1,12 +1,9 @@
-from optparse import make_option
-from pprint import pprint
-
 from django.core.management.base import NoArgsCommand
 from django.utils.text import slugify
-from django.conf import settings
 
 from pombola.core import models
 from mapit import models as mapit_models
+
 
 class Command(NoArgsCommand):
     help = 'Link places to areas in mapit'

--- a/pombola/core/management/commands/core_match_places_to_mapit_areas_2013.py
+++ b/pombola/core/management/commands/core_match_places_to_mapit_areas_2013.py
@@ -1,14 +1,13 @@
 import sys
 
 from optparse import make_option
-from pprint import pprint
 
 from django.core.management.base import NoArgsCommand
 from django.utils.text import slugify
-from django.conf import settings
 
 from pombola.core import models
 from mapit import models as mapit_models
+
 
 class Command(NoArgsCommand):
     help = 'Link places to areas in mapit for the new 2013 places'

--- a/pombola/core/management/commands/core_merge_people.py
+++ b/pombola/core/management/commands/core_merge_people.py
@@ -17,8 +17,6 @@ from django.conf import settings
 
 from optparse import make_option
 
-from django.core.exceptions import ObjectDoesNotExist
-
 
 def check_basic_fields(basic_fields, to_keep, to_delete):
     """Return False if any data might be lost on merging"""

--- a/pombola/core/management/commands/core_move_profile_url_to_parliament_url.py
+++ b/pombola/core/management/commands/core_move_profile_url_to_parliament_url.py
@@ -1,11 +1,7 @@
-import sys
-
-from pprint import pprint
-
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
-from pombola.core.models import *
+from pombola.core.models import Contact, ContactKind
+
 
 class Command(BaseCommand):
     help = 'Deduplicate the position entries'

--- a/pombola/core/management/commands/core_output_constituency_party_affiliation.py
+++ b/pombola/core/management/commands/core_output_constituency_party_affiliation.py
@@ -1,13 +1,10 @@
-# from optparse import make_option
-# from pprint import pprint
 import csv
 import StringIO
-# import re
-# 
+
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 from pombola.core import models
+
 
 class Command(BaseCommand):
     help = """

--- a/pombola/core/management/commands/core_output_mp_contact_csv.py
+++ b/pombola/core/management/commands/core_output_mp_contact_csv.py
@@ -1,13 +1,11 @@
-from optparse import make_option
-from pprint import pprint
 import csv
 import StringIO
 import re
 
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 from pombola.core import models
+
 
 class Command(BaseCommand):
     help = 'Output CSV of all MPs and their contact details'

--- a/pombola/core/management/commands/core_output_mp_scorecard_csv.py
+++ b/pombola/core/management/commands/core_output_mp_scorecard_csv.py
@@ -1,14 +1,10 @@
-from optparse import make_option
-from pprint import pprint
 import csv
 import StringIO
-import re
 
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 from pombola.core import models
-from pombola.scorecards.models import Entry
+
 
 class Command(BaseCommand):
     help = 'Output CSV of all MPs and their scorecard ratings'

--- a/pombola/core/management/commands/core_position_deduplicate.py
+++ b/pombola/core/management/commands/core_position_deduplicate.py
@@ -1,9 +1,6 @@
 from optparse import make_option
-from pprint import pprint
 
 from django.core.management.base import BaseCommand
-from django.utils.text import slugify
-from django.conf import settings
 
 from pombola.core import models
 

--- a/pombola/core/management/commands/core_send_people_to_popit.py
+++ b/pombola/core/management/commands/core_send_people_to_popit.py
@@ -1,17 +1,17 @@
 # This command creates a new PopIt instance based on the Person,
 # Position and Organisation models in Pombola.
 
-import json
 from optparse import make_option
 import slumber
 import sys
 import urlparse
 
-from pombola.core.popolo import get_popolo_data, create_organisations, create_people
+from pombola.core.popolo import create_organisations, create_people
 
 from django.core.management.base import BaseCommand, CommandError
 
 from popit_api import PopIt
+
 
 class Command(BaseCommand):
     args = 'MZALENDO-URL'

--- a/pombola/core/management/commands/core_send_people_to_popit_api.py
+++ b/pombola/core/management/commands/core_send_people_to_popit_api.py
@@ -1,23 +1,13 @@
 # This command creates a new PopIt instance based on the Person,
 # Position and Organisation models in Pombola.
 
-import re
 import sys
-import os
 import slumber
-import json
-import datetime
 import urlparse
-from collections import defaultdict
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
 
-from django_date_extensions.fields import ApproximateDate
-
-from pombola.core.models import Person, Organisation, Position
-
-# from popit import PopIt
+from pombola.core.models import Person
 
 from optparse import make_option
 

--- a/pombola/core/management/commands/core_set_area_parents.py
+++ b/pombola/core/management/commands/core_set_area_parents.py
@@ -19,13 +19,13 @@
 # the "Related Places" tab on Places pages.
 
 import re
-import sys
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
-from mapit.models import Area, Generation, Type
+from mapit.models import Area
 from pombola.core.models import Place, PlaceKind
+
 
 PROPORTION_OVERLAP_REQUIRED = 0.98
 

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -7,8 +7,6 @@ import itertools
 import random
 from collections import defaultdict
 
-from django.conf import settings
-
 from django.core import exceptions
 from django.core.urlresolvers import reverse
 

--- a/pombola/core/popolo.py
+++ b/pombola/core/popolo.py
@@ -5,15 +5,13 @@ import datetime
 from collections import defaultdict
 from urlparse import urljoin
 
-from django.core.management.base import BaseCommand, CommandError
 from django.core.urlresolvers import reverse
-from django.db import transaction
-from django_date_extensions.fields import ApproximateDate
 
 from mapit.views.areas import area
 
 from pombola.core.models import Person, Organisation, Position
 from pombola import country
+
 
 extra_popolo_person_fields = (
     'email',
@@ -64,6 +62,7 @@ def get_area_information(place, base_url):
 
 def date_to_partial_iso8601(approx_date):
     """Get a (possibly partial) ISO 8601 representation of an ApproximateDate
+    >>> from django_date_extensions.fields import ApproximateDate
 
     >>> date_to_partial_iso8601(ApproximateDate(2012, 6, 2))
     '2012-06-02'

--- a/pombola/core/seltests/__init__.py
+++ b/pombola/core/seltests/__init__.py
@@ -1,2 +1,2 @@
-from basics import *
-from admin_autocomplete import *
+from basics import *  # noqa
+from admin_autocomplete import *  # noqa

--- a/pombola/core/templatetags/hidden.py
+++ b/pombola/core/templatetags/hidden.py
@@ -1,4 +1,4 @@
-from django.template import Node, Variable, Library
+from django.template import Library, Node, TemplateSyntaxError, Variable
 
 register = Library()
 

--- a/pombola/core/tests/smoke_tests.py
+++ b/pombola/core/tests/smoke_tests.py
@@ -1,8 +1,5 @@
 from django_webtest import WebTest
-from django.test.client import Client
-from django.test import TestCase
 
-from pombola.core import models
 
 class SmokeTests(WebTest):
     def testFront(self):

--- a/pombola/core/tests/test_commands.py
+++ b/pombola/core/tests/test_commands.py
@@ -9,7 +9,6 @@ from pombola.core.models import (
     Contact, ContactKind, Organisation, OrganisationKind, Person,
     Position, PositionTitle
 )
-from pombola.slug_helpers.models import SlugRedirect
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command

--- a/pombola/core/tests/test_models.py
+++ b/pombola/core/tests/test_models.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
-from django.test.utils import override_settings
 from django_date_extensions.fields import ApproximateDate
 from django.contrib.contenttypes.models import ContentType
 

--- a/pombola/core/tests/test_persons.py
+++ b/pombola/core/tests/test_persons.py
@@ -1,17 +1,13 @@
-import re
 import datetime
 
-from django.conf import settings
-from django.core import mail
 from django_webtest import WebTest
-from django.test.client import Client
 from django.test import TestCase
 
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 
 from pombola.core import models
 import pombola.scorecards.models
+
 
 class PersonTest(WebTest):
     def test_naming(self):        

--- a/pombola/core/tests/test_popolo.py
+++ b/pombola/core/tests/test_popolo.py
@@ -1,5 +1,4 @@
 from datetime import date
-import json
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile

--- a/pombola/core/tests/test_views.py
+++ b/pombola/core/tests/test_views.py
@@ -1,4 +1,4 @@
-from BeautifulSoup import Tag, NavigableString
+from BeautifulSoup import NavigableString
 from contextlib import contextmanager
 from django_webtest import TransactionWebTest
 from django.contrib.auth.models import User
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from pombola.core import models
 from pombola.slug_helpers.models import SlugRedirect
+
 
 class HomeViewTest(TestCase):
 

--- a/pombola/experiments/tests.py
+++ b/pombola/experiments/tests.py
@@ -1,4 +1,4 @@
-from .models import Experiment, Event
+from .models import Experiment
 
 from django.test import TestCase
 

--- a/pombola/feedback/forms.py
+++ b/pombola/feedback/forms.py
@@ -1,16 +1,6 @@
-import time
-import datetime
-
 from django import forms
-from django.forms.util import ErrorDict
-from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
-from django.utils.crypto import salted_hmac, constant_time_compare
-from django.utils.encoding import force_unicode
-from django.utils.text import get_text_list
-from django.utils.translation import ungettext, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
-from pombola.feedback.models import Feedback
 
 class FeedbackForm(forms.Form):
     """

--- a/pombola/feedback/management/commands/feedback_report_pending.py
+++ b/pombola/feedback/management/commands/feedback_report_pending.py
@@ -1,9 +1,8 @@
-import datetime
-
 from django.core.management.base import NoArgsCommand
 from django.contrib.sites.models import Site
 
 from pombola.feedback.models import Feedback
+
 
 class Command(NoArgsCommand):
     help = 'Report all the feedbac that needs attention'

--- a/pombola/feedback/seltests/__init__.py
+++ b/pombola/feedback/seltests/__init__.py
@@ -1,1 +1,1 @@
-from feedback_dialog import *
+from feedback_dialog import *  # noqa

--- a/pombola/feedback/urls.py
+++ b/pombola/feedback/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('pombola.feedback.views',
     url( r'^$',       'add',    name='feedback_add'    ),

--- a/pombola/file_archive/urls.py
+++ b/pombola/file_archive/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 import views
+
 
 urlpatterns = patterns('',
     url( r'^(?P<slug>[\w\-]+)$', views.redirect_to_file, name='file_archive' ),

--- a/pombola/file_archive/views.py
+++ b/pombola/file_archive/views.py
@@ -1,6 +1,7 @@
-from django.shortcuts  import render_to_response, get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect
 
 from models import File
+
 
 def redirect_to_file(request, slug):
     """Find the file and redirect ot it, or 404"""

--- a/pombola/ghana/context_processors.py
+++ b/pombola/ghana/context_processors.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse, resolve
+from django.core.urlresolvers import resolve
 
 from models import MP
 from pombola.core.models import Person

--- a/pombola/ghana/data.py
+++ b/pombola/ghana/data.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import time
 import base64
 import json
 from datetime import datetime
 
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.contrib.contenttypes.models import ContentType, ContentTypeManager
 from django.template.defaultfilters import slugify
 
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+from django_date_extensions.fields import ApproximateDate
 
 from pombola.images.models import Image
 from pombola.core.models import PlaceKind, OrganisationKind, PositionTitle

--- a/pombola/ghana/management/commands/add_hansard.py
+++ b/pombola/ghana/management/commands/add_hansard.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from django.core.management.base import BaseCommand, CommandError
 

--- a/pombola/ghana/management/commands/add_infopage.py
+++ b/pombola/ghana/management/commands/add_infopage.py
@@ -1,10 +1,4 @@
-import re 
-import csv
-import sys
-
 import os
-
-from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 from pombola.ghana import data

--- a/pombola/ghana/management/commands/load_info_pages.py
+++ b/pombola/ghana/management/commands/load_info_pages.py
@@ -1,8 +1,8 @@
 import os
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
-from pombola.ghana.management.hansard_parser import parse
 from pombola.ghana.management.commands import add_infopage
+
 
 class Command(BaseCommand):
     """Import Hansard"""

--- a/pombola/ghana/management/commands/validate_hansard.py
+++ b/pombola/ghana/management/commands/validate_hansard.py
@@ -1,13 +1,10 @@
 import os
 import traceback
+import sys
 
 from django.core.management.base import BaseCommand, CommandError
 
 from pombola.ghana.management.hansard_parser import parse
-from pombola.ghana.management.hansard_parser import parse
-from pombola.ghana import data
-
-
 
 
 class Command(BaseCommand):

--- a/pombola/ghana/management/document_parser.py
+++ b/pombola/ghana/management/document_parser.py
@@ -2,10 +2,9 @@ import sys
 import re
 import datetime
 import os
-import pymongo
 from pymongo import MongoClient
 from collections import defaultdict
-from collections import Counter
+
 
 # Constants for various types of line that might be found in the transcript
 BLANK            = 'blank'

--- a/pombola/ghana/management/feedparser.py
+++ b/pombola/ghana/management/feedparser.py
@@ -150,13 +150,12 @@ import datetime
 import re
 import struct
 import time
-import types
 import urllib
 import urllib2
 import urlparse
 import warnings
 
-from htmlentitydefs import name2codepoint, codepoint2name, entitydefs
+from htmlentitydefs import name2codepoint, entitydefs
 
 try:
     from io import BytesIO as _StringIO
@@ -260,14 +259,6 @@ else:
         def start(self, n):
             return self.match.end(n)
     endbracket = _EndBracketRegEx()
-
-
-# iconv_codec provides support for more character encodings.
-# It's available from http://cjkpython.i18n.org/
-try:
-    import iconv_codec
-except ImportError:
-    pass
 
 # chardet library auto-detects character encodings
 # Download from http://chardet.feedparser.org/

--- a/pombola/ghana/views.py
+++ b/pombola/ghana/views.py
@@ -1,11 +1,8 @@
-import logging
-from django.http import HttpResponse
-from django.core.urlresolvers import reverse
 from django.shortcuts import render
 
 from . import forms
-from pombola.info.models import InfoPage
 import data
+
 
 def info_page_upload(request):
     if request.POST:

--- a/pombola/hansard/admin.py
+++ b/pombola/hansard/admin.py
@@ -1,22 +1,13 @@
-from django.contrib import admin
-import models
-
 from ajax_select import make_ajax_form
-from ajax_select.admin import AjaxSelectAdmin
 
-import datetime
-
-# from django import forms
-from django.conf.urls import patterns
-# from django.contrib import admin
-from django.utils.decorators import method_decorator
+from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
-from django.core.urlresolvers import reverse
-from django.shortcuts  import  redirect
-from django.template   import RequestContext
+from django.shortcuts import redirect, render_to_response
+from django.conf.urls import patterns
+from django.template import RequestContext
+from django.utils.decorators import method_decorator
 
 import models
-from pprint import pprint
 
 # from django.contrib.gis import db
 # from django.core.urlresolvers import reverse

--- a/pombola/hansard/kenya_parser.py
+++ b/pombola/hansard/kenya_parser.py
@@ -1,17 +1,15 @@
-import httplib2
 import os
 import re
 import subprocess
-import tempfile
 import datetime
 
-from django.db import models
 from django.conf import settings
 from django.db import transaction
 
-from BeautifulSoup import BeautifulSoup, BeautifulStoneSoup, NavigableString, Tag
+from BeautifulSoup import BeautifulSoup, BeautifulStoneSoup, Tag
 
-from pombola.hansard.models import Source, Sitting, Entry, Venue
+from pombola.hansard.models import Sitting, Entry, Venue
+
 
 # EXCEPTIONS
 class KenyaParserCouldNotParseTimeString(Exception):

--- a/pombola/hansard/management/commands/hansard_check_for_new_sources.py
+++ b/pombola/hansard/management/commands/hansard_check_for_new_sources.py
@@ -1,4 +1,3 @@
-
 # This script was first changed extensively when the Kenyan Parliament website
 # changed after the 2013 Election.
 #
@@ -13,12 +12,10 @@
 #
 #    https://github.com/mysociety/pombola/blob/ec4a44f7d7e0743426aff87b59e4bfa54250ec1c/pombola/hansard/management/commands/hansard_check_for_new_sources.py
 
-import pprint
 import httplib2
 import re
 import datetime
 from optparse import make_option
-import sys
 import parsedatetime as pdt
 from warnings import warn
 from urlparse import urlsplit, urlunsplit

--- a/pombola/hansard/management/commands/hansard_list_unmatched_speakers.py
+++ b/pombola/hansard/management/commands/hansard_list_unmatched_speakers.py
@@ -1,8 +1,7 @@
-import datetime
-
 from django.core.management.base import NoArgsCommand
 
 from pombola.hansard.models import Alias
+
 
 class Command(NoArgsCommand):
     help = 'List all the speaker names that have not been matched up to a real person'

--- a/pombola/hansard/management/commands/hansard_reattribute_entries.py
+++ b/pombola/hansard/management/commands/hansard_reattribute_entries.py
@@ -3,11 +3,7 @@
 # safe - when there are more than one or two of them
 
 from dateutil import parser
-import sys
 
-from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 

--- a/pombola/hansard/models/__init__.py
+++ b/pombola/hansard/models/__init__.py
@@ -1,5 +1,7 @@
-from alias   import Alias
-from source  import Source, SourceUrlCouldNotBeRetrieved, SourceCouldNotParseTimeString
-from venue   import Venue
+# flake8: noqa
+
+from alias import Alias
+from source import Source, SourceUrlCouldNotBeRetrieved, SourceCouldNotParseTimeString
+from venue import Venue
 from sitting import Sitting
-from entry   import Entry, NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH
+from entry import Entry, NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH

--- a/pombola/hansard/models/sitting.py
+++ b/pombola/hansard/models/sitting.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 
 from django.db import models

--- a/pombola/hansard/models/source.py
+++ b/pombola/hansard/models/source.py
@@ -1,5 +1,4 @@
 import os
-import re
 import httplib2
 
 from django.db import models

--- a/pombola/hansard/tests/smoke_tests.py
+++ b/pombola/hansard/tests/smoke_tests.py
@@ -1,8 +1,7 @@
 from django_webtest import WebTest
-from django.test.client import Client
-from django.test import TestCase
 
 from pombola.core import models
+
 
 class SmokeTests(WebTest):
 

--- a/pombola/hansard/tests/test_kenya_parser.py
+++ b/pombola/hansard/tests/test_kenya_parser.py
@@ -1,10 +1,6 @@
 import datetime
 import os
-import re
-import time
 import json
-import tempfile
-import subprocess
 
 from django.test import TestCase
 from django.utils import unittest

--- a/pombola/hansard/tests/test_sitting.py
+++ b/pombola/hansard/tests/test_sitting.py
@@ -1,10 +1,8 @@
-import os
-import datetime
-
 from datetime import date, time
 
 from django.test import TestCase
 from pombola.hansard.models import Source, Sitting, Venue
+
 
 class HansardSittingTest(TestCase):
 

--- a/pombola/hansard/urls.py
+++ b/pombola/hansard/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 from pombola.hansard.views import IndexView, SittingView, PersonAllAppearancesView
+
 
 urlpatterns = patterns('pombola.hansard.views',
     url( r'^$', IndexView.as_view(), name="index" ),

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -1,7 +1,7 @@
 import re
 import datetime
 
-from django.shortcuts  import render_to_response, get_object_or_404, redirect
+from django.shortcuts  import render_to_response, get_object_or_404
 from django.http import Http404
 from django.template   import RequestContext
 from django.views.generic import TemplateView, DetailView, ListView

--- a/pombola/images/models.py
+++ b/pombola/images/models.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes import generic
 
 from sorl.thumbnail import ImageField
 
-from warnings import warn
 
 class Image(models.Model):
 

--- a/pombola/info/migration_helpers.py
+++ b/pombola/info/migration_helpers.py
@@ -1,11 +1,11 @@
 from os.path import join
-import re
 from urlparse import urlsplit
 
 from bs4 import BeautifulSoup
 from markdown import markdown
 
 from django.conf import settings
+
 
 def get_first_image_file(file_archive_file_class, info_page):
     """Return the first image in the post, if it's a file_archive image

--- a/pombola/info/urls/blog.py
+++ b/pombola/info/urls/blog.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, include, url, handler404
+from django.conf.urls import patterns, url, handler404
 
 from ..views import InfoBlogView, InfoBlogList, InfoBlogFeed, InfoBlogCategory, InfoBlogTag
+
 
 urlpatterns = patterns('',
     url(r'^$', InfoBlogList.as_view(), name='info_blog_list'),

--- a/pombola/info/urls/pages.py
+++ b/pombola/info/urls/pages.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, include, url, handler404
+from django.conf.urls import patterns, url, handler404
 
 from ..views import InfoPageView
+
 
 urlpatterns = patterns('',
     url(r'^$',                  InfoPageView.as_view(), { 'slug': 'index' } ),

--- a/pombola/interests_register/management/commands/interests_register_delete_existing.py
+++ b/pombola/interests_register/management/commands/interests_register_delete_existing.py
@@ -1,7 +1,7 @@
-import sys
 from optparse import make_option
 from django.core.management.base import NoArgsCommand
 from ...models import Release, Category, Entry, EntryLineItem
+
 
 class Command(NoArgsCommand):
     help = 'Delete existing declarations of members interests - allows for subsequent re-importing of data.'

--- a/pombola/interests_register/management/commands/interests_register_import_from_json.py
+++ b/pombola/interests_register/management/commands/interests_register_import_from_json.py
@@ -1,12 +1,11 @@
 import json
-import sys
-from datetime import date
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.management.base import LabelCommand, CommandError
+from django.core.management.base import LabelCommand
 
 from pombola.core.models import Person, InformationSource
 from ...models import Release, Category, Entry, EntryLineItem
+
 
 release_content_type = ContentType.objects.get_for_model(Release)
 

--- a/pombola/kenya/forms.py
+++ b/pombola/kenya/forms.py
@@ -1,6 +1,8 @@
-from django import forms
-from django.forms.widgets import Textarea, Select
 import datetime
+
+from django import forms
+from django.forms.widgets import Textarea
+
 from pombola.core.models import Place
 
 

--- a/pombola/kenya/management/commands/core_set_iebc_api_ids.py
+++ b/pombola/kenya/management/commands/core_set_iebc_api_ids.py
@@ -3,17 +3,12 @@
 # positions), to be run after core_import_aspirants_from_iebc - it has
 # the same shape as that script, but just sets the external_id.
 
-from collections import defaultdict
 import csv
 import datetime
-import errno
 import hmac
 import hashlib
-import itertools
-import json
 import os
 import re
-import requests
 import sys
 from optparse import make_option
 
@@ -24,9 +19,19 @@ from django_date_extensions.fields import ApproximateDate
 
 from django.conf import settings
 
-from pombola.core.models import Place, PlaceKind, Person, ParliamentarySession, Position, PositionTitle, Organisation, OrganisationKind
+from pombola.core.models import Place, Person, Position, PositionTitle, Organisation, OrganisationKind
+from pombola.core.utils import mkdir_p
 
-from iebc_api import *
+from iebc_api import (
+    get_data,
+    get_data_with_cache,
+    get_person_from_names,
+    known_race_type_mapping,
+    make_api_token_url,
+    make_api_url,
+    parse_race_name,
+    )
+
 
 new_data_date = datetime.date(2013, 2, 8)
 new_data_approximate_date = ApproximateDate(new_data_date.year,

--- a/pombola/kenya/management/commands/iebc_api.py
+++ b/pombola/kenya/management/commands/iebc_api.py
@@ -1,6 +1,5 @@
 import csv
 import datetime
-import errno
 import hmac
 import hashlib
 import json
@@ -10,12 +9,12 @@ import requests
 import sys
 import time
 
-from django.conf import settings
 from django.utils.text import slugify
 
 from django_date_extensions.fields import ApproximateDate
 
-from pombola.core.models import Person, Place, PlaceKind, ParliamentarySession, Position, PositionTitle
+from django.core.management.base import CommandError
+from pombola.core.models import Person, PlaceKind, ParliamentarySession, Position, PositionTitle
 
 from django.core.files.base import ContentFile
 from pombola.images.models import Image

--- a/pombola/kenya/management/commands/kenya_apply_updates.py
+++ b/pombola/kenya/management/commands/kenya_apply_updates.py
@@ -1,25 +1,14 @@
-from collections import defaultdict
 import csv
-import datetime
-import errno
-import hmac
-import hashlib
-import itertools
-import json
 import os
-import re
-import requests
 import sys
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
-from django.utils.text import slugify
+from django.core.management.base import NoArgsCommand
 
-from django_date_extensions.fields import ApproximateDate
+from pombola.core.models import Person, Position
 
-from pombola.core.models import Place, PlaceKind, Person, ParliamentarySession, Position, PositionTitle, Organisation, OrganisationKind
+from iebc_api import maybe_save, yesterday_approximate_date
 
-from iebc_api import *
 
 data_directory = os.path.join(sys.path[0], 'kenya', '2013-election-data')
 

--- a/pombola/kenya/management/commands/kenya_assign_aspirants_to_coalitions.py
+++ b/pombola/kenya/management/commands/kenya_assign_aspirants_to_coalitions.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-import re
-import sys
-
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from pombola.core import models
+
 
 class Command(BaseCommand):
     """

--- a/pombola/kenya/management/commands/kenya_create_coalition_entries.py
+++ b/pombola/kenya/management/commands/kenya_create_coalition_entries.py
@@ -1,10 +1,6 @@
-import re 
-import sys
-
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 from pombola.core import models
+
 
 class Command(BaseCommand):
     """

--- a/pombola/kenya/management/commands/kenya_get_possible_matches_from_iebc.py
+++ b/pombola/kenya/management/commands/kenya_get_possible_matches_from_iebc.py
@@ -6,28 +6,31 @@
 # possible matches that can be uploaded to Google Spreadsheets for
 # manual correction.
 
-from collections import defaultdict
 import csv
-import datetime
+import hashlib
+import hmac
 import itertools
-import json
 import os
-import re
-import requests
 import sys
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
-from django.utils.text import slugify
-
-from django_date_extensions.fields import ApproximateDate
+from django.core.management.base import NoArgsCommand
 
 from django.conf import settings
 
-from pombola.core.models import Place, PlaceKind, Person, ParliamentarySession, Position, PositionTitle, Organisation, OrganisationKind
+from pombola.core.models import Place, Organisation
 from pombola.core.utils import mkdir_p
 
-from iebc_api import *
+from iebc_api import (
+    get_data,
+    make_api_token_url,
+    make_api_url,
+    get_data_with_cache,
+    parse_race_name,
+    known_race_type_mapping,
+    get_person_from_names,
+    )
+
 
 data_directory = os.path.join(sys.path[0], 'kenya', '2013-election-data')
 

--- a/pombola/kenya/management/commands/kenya_hide_people.py
+++ b/pombola/kenya/management/commands/kenya_hide_people.py
@@ -1,9 +1,10 @@
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django.db.models import Q
 
-from pombola.core.models import Person, Position
+from pombola.core.models import Person
+
 
 class Command(NoArgsCommand):
 

--- a/pombola/kenya/management/commands/kenya_matchup_coords_to_place.py
+++ b/pombola/kenya/management/commands/kenya_matchup_coords_to_place.py
@@ -2,12 +2,11 @@ import re
 import csv
 import sys
 
-from optparse import make_option
-
 from django.core.management.base import LabelCommand
 from django.contrib.gis.geos import Point
 
-from mapit.models import Area, Generation, Type, NameType, Country
+from mapit.models import Area
+
 
 class Command(LabelCommand):
     """Read a file in, extract coordinates and lookup the constituency.

--- a/pombola/kenya/management/commands/kenya_normalize_person_names.py
+++ b/pombola/kenya/management/commands/kenya_normalize_person_names.py
@@ -1,21 +1,12 @@
-from collections import defaultdict
-import csv
-import datetime
-import errno
-import hmac
-import hashlib
-import itertools
-import json
-import os
-import re
-import requests
 import sys
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
-from django.utils.text import slugify
+from django.core.management.base import NoArgsCommand
 
-from iebc_api import *
+from pombola.core.models import Person
+
+from iebc_api import maybe_save, normalize_name
+
 
 class Command(NoArgsCommand):
     help = 'Normalize the legal_name and other_names for each Person'

--- a/pombola/kenya/management/commands/kenya_remove_duplicate_aspirants.py
+++ b/pombola/kenya/management/commands/kenya_remove_duplicate_aspirants.py
@@ -5,32 +5,32 @@
 from collections import defaultdict
 import csv
 import datetime
-import errno
 import hmac
 import hashlib
-import itertools
-import json
 import os
 import re
-import requests
 import sys
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django.utils.text import slugify
 from django.contrib.contenttypes.models import ContentType
 
-from django_date_extensions.fields import ApproximateDate
-
 from django.conf import settings
 
-from pombola.core.models import (Place, PlaceKind, Person,
-    ParliamentarySession, Position, PositionTitle, Organisation,
-    OrganisationKind)
+from pombola.core.models import Place, Person, Position
 from pombola.core.utils import mkdir_p
 from pombola.slug_helpers.models import SlugRedirect
 
-from iebc_api import *
+from iebc_api import (
+    get_data,
+    get_data_with_cache,
+    known_race_type_mapping,
+    make_api_token_url,
+    make_api_url,
+    maybe_save,
+    )
+
 
 before_import_date = datetime.datetime(2013, 2, 7, 0, 0, 0)
 

--- a/pombola/kenya/management/commands/kenya_set_election_results_from_gazette.py
+++ b/pombola/kenya/management/commands/kenya_set_election_results_from_gazette.py
@@ -12,9 +12,8 @@ import sys
 
 from optparse import make_option
 
-from django.conf import settings
 from django.core.management import call_command
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django.utils.text import slugify
 
 from pombola.core.models import (

--- a/pombola/kenya/management/commands/kenya_update_aspirants_from_iebc.py
+++ b/pombola/kenya/management/commands/kenya_update_aspirants_from_iebc.py
@@ -5,28 +5,38 @@
 from collections import defaultdict
 import csv
 import datetime
-import errno
 import hmac
 import hashlib
-import itertools
-import json
 import os
 import re
-import requests
 import sys
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django.utils.text import slugify
 
 from django_date_extensions.fields import ApproximateDate
 
 from django.conf import settings
 
-from pombola.core.models import Place, PlaceKind, Person, ParliamentarySession, Position, PositionTitle, Organisation, OrganisationKind
+from pombola.core.models import Place, Person, Position, PositionTitle, Organisation, OrganisationKind
 from pombola.core.utils import mkdir_p
 
-from iebc_api import *
+from iebc_api import (
+    get_data,
+    maybe_save,
+    normalize_name,
+    yesterday_approximate_date,
+    today_approximate_date,
+    get_person_from_names,
+    make_api_token_url,
+    make_api_url,
+    SamePersonChecker,
+    get_data_with_cache,
+    known_race_type_mapping,
+    update_picture_for_candidate,
+    )
+
 
 before_import_date = datetime.date(2013, 2, 7)
 

--- a/pombola/kenya/models.py
+++ b/pombola/kenya/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pombola/libya/models.py
+++ b/pombola/libya/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pombola/libya/urls.py
+++ b/pombola/libya/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns
 
 urlpatterns = patterns('',
     # There are no overridden urls for Libya, yet....

--- a/pombola/map/models.py
+++ b/pombola/map/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pombola/map/urls.py
+++ b/pombola/map/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('pombola.map.views',
     url(r'^$', 'home', name='map-home'),

--- a/pombola/nigeria/data/name_helper.py
+++ b/pombola/nigeria/data/name_helper.py
@@ -3,7 +3,7 @@
 import sys
 import csv
 import os
-import re
+
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pombola.settings'
 

--- a/pombola/nigeria/initial_import/extract_positions_from_json_to_csv.py
+++ b/pombola/nigeria/initial_import/extract_positions_from_json_to_csv.py
@@ -2,8 +2,8 @@
 
 import json
 import sys
-import re
 import csv
+
 
 csv_columns = (
     "slug",

--- a/pombola/nigeria/initial_import/import_people_from_json.py
+++ b/pombola/nigeria/initial_import/import_people_from_json.py
@@ -3,9 +3,7 @@
 import json
 import sys
 import re
-import csv
 import os
-import pprint
 import urllib2
 
 from django.core.files import File
@@ -24,7 +22,7 @@ sys.path.append(
     )
 )
 
-from django.contrib.contenttypes.models import ContentType, ContentTypeManager
+from django.contrib.contenttypes.models import ContentType
 
 from pombola.core import models
 from pombola.images.models import Image

--- a/pombola/nigeria/initial_import/import_positions_from_csv.py
+++ b/pombola/nigeria/initial_import/import_positions_from_csv.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import json
 import sys
 import re
 import csv

--- a/pombola/nigeria/initial_import/representative_page_to_json.py
+++ b/pombola/nigeria/initial_import/representative_page_to_json.py
@@ -6,7 +6,7 @@ import sys
 import json
 import re
 import unidecode
-import fileinput
+
 
 # where the original html came from, use to resolve relative urls
 base_url = 'http://www.nassnig.org/nass2/portfolio/profile.php'

--- a/pombola/nigeria/initial_import/senator_page_to_json.py
+++ b/pombola/nigeria/initial_import/senator_page_to_json.py
@@ -6,7 +6,7 @@ import sys
 import json
 import re
 import unidecode
-import fileinput
+
 
 # where the original html came from, use to resolve relative urls
 base_url = 'http://www.nassnig.org/nass/portfolio/profile.php'

--- a/pombola/nigeria/management/commands/nigeria_fix_place_mapit_matches.py
+++ b/pombola/nigeria/management/commands/nigeria_fix_place_mapit_matches.py
@@ -1,12 +1,12 @@
 import csv
 import os
-import sys
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 
-from pombola.core.models import Place, PlaceKind, ParliamentarySession
+from pombola.core.models import Place, PlaceKind
 from mapit.models import Area, Generation
+
 
 class Command(NoArgsCommand):
 

--- a/pombola/nigeria/management/commands/nigeria_update_governors.py
+++ b/pombola/nigeria/management/commands/nigeria_update_governors.py
@@ -1,5 +1,3 @@
-import re
-
 import unicodecsv as csv
 
 from django.core.exceptions import ObjectDoesNotExist

--- a/pombola/nigeria/models.py
+++ b/pombola/nigeria/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pombola/nigeria/urls.py
+++ b/pombola/nigeria/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 from .views import NGHomeView, NGSearchView
+
 
 urlpatterns = patterns('',
     url(r'^$', NGHomeView.as_view(), name='home'),

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -1,12 +1,12 @@
 import re
 
-from django.views.generic import ListView, TemplateView
-
 from mapit.models import Area
+
 from pombola.core.models import Place
 from pombola.core.views import HomeView
 from pombola.info.models import InfoPage
 from pombola.search.views import SearchBaseView
+
 
 class NGHomeView(HomeView):
 

--- a/pombola/projects/models.py
+++ b/pombola/projects/models.py
@@ -1,7 +1,6 @@
 import datetime
 
 from django.contrib.gis.db import models
-from django.contrib.gis.geos import Point
 
 from pombola.core.models import Place
 

--- a/pombola/projects/urls.py
+++ b/pombola/projects/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 import views
 

--- a/pombola/projects/views.py
+++ b/pombola/projects/views.py
@@ -1,8 +1,7 @@
-import models
-import pombola.core.models
+from django.template import RequestContext
+from django.shortcuts import render_to_response, get_object_or_404
 
-from django.template   import RequestContext
-from django.shortcuts  import render_to_response, get_object_or_404, redirect
+import pombola.core.models
 
 
 def in_place(request, slug):

--- a/pombola/scorecards/admin.py
+++ b/pombola/scorecards/admin.py
@@ -1,10 +1,11 @@
 from django import forms
 from django.contrib import admin
-from django.shortcuts  import render_to_response, get_object_or_404, redirect
-from django.template   import RequestContext
+from django.shortcuts import render_to_response
+from django.template import RequestContext
 
 from pombola.scorecards import models
 from pombola.slug_helpers.admin import StricterSlugFieldMixin
+
 
 class CategoryAdmin(StricterSlugFieldMixin, admin.ModelAdmin):
     prepopulated_fields = {"slug": ["name"] }

--- a/pombola/scorecards/models.py
+++ b/pombola/scorecards/models.py
@@ -4,11 +4,11 @@ import csv
 
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.humanize.templatetags.humanize import intcomma
 from django.core.exceptions import ValidationError
 from django.db import models
 
 from markitup.fields import MarkupField
+
 
 class Category(models.Model):
     created = models.DateTimeField( auto_now_add=True, default=datetime.datetime.now, )

--- a/pombola/scorecards/tests.py
+++ b/pombola/scorecards/tests.py
@@ -2,15 +2,8 @@
 Test that the scorecards works as expected
 """
 
-import datetime
-import pprint
-import tempfile
-import csv
-
 from django.test import TestCase
 
-from pombola.core.models import Place, PlaceKind
-from models import Category, Entry
 
 class DataTest(TestCase):
     pass

--- a/pombola/search/models.py
+++ b/pombola/search/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pombola/search/tests/autocomplete.py
+++ b/pombola/search/tests/autocomplete.py
@@ -1,7 +1,6 @@
 import json
 import re
 
-from django.conf import settings
 from django.test.client import Client
 from django.utils import unittest
 from django.utils.text import slugify
@@ -9,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.core.management import call_command
 
 from pombola.core.models import Person
+
 
 class AutocompleteTest(unittest.TestCase):
 

--- a/pombola/search/tests/geocoder.py
+++ b/pombola/search/tests/geocoder.py
@@ -1,14 +1,14 @@
 import json
 import os
 
-from django.conf import settings
 from django.utils import unittest
 
 from ..geocoder import geocoder
 
 import pygeocoder
 
-from mock import patch, Mock, MagicMock
+from mock import patch, Mock
+
 
 test_data_directory = os.path.abspath(
     os.path.join(

--- a/pombola/search/urls.py
+++ b/pombola/search/urls.py
@@ -1,9 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 from django.conf import settings
 
-from pombola.core    import models as core_models
-
 from .views import SearchBaseView, GeocoderView
+
 
 urlpatterns = patterns('pombola.search.views',
 
@@ -25,7 +24,6 @@ urlpatterns = patterns('pombola.search.views',
 
 # Hansard search - only loaded if hansard is enabled
 if settings.ENABLED_FEATURES['hansard']:
-    from pombola.hansard import models as hansard_models
     from .views import HansardSearchView
     urlpatterns += patterns('pombola.search.views',
         url(

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -2,12 +2,12 @@ import os
 import re
 import yaml
 
-from .apps import *
+from .apps import *  # noqa
 
 from django.template.defaultfilters import slugify
 
 from pombola.core.logging_filters import skip_unreadable_post
-from pombola.hansard.constants import NAME_SUBSTRING_MATCH, NAME_SET_INTERSECTION_MATCH
+from pombola.hansard.constants import NAME_SET_INTERSECTION_MATCH
 
 IN_TEST_MODE = False
 

--- a/pombola/settings/ghana.py
+++ b/pombola/settings/ghana.py
@@ -1,9 +1,9 @@
-import re
 import os
 import yaml
 
-from .base import *
-from .ghana_base import *
+from .base import *  # noqa
+from .ghana_base import *  # noqa
+
 
 # load the mySociety config
 config_file = os.path.join( base_dir, 'conf', 'general.yml' )

--- a/pombola/settings/ghana_base.py
+++ b/pombola/settings/ghana_base.py
@@ -1,6 +1,3 @@
-import os
-from .base import root_dir
-
 COUNTRY_APP = 'ghana'
 
 MAPIT_COUNTRY = 'GH'

--- a/pombola/settings/kenya.py
+++ b/pombola/settings/kenya.py
@@ -1,7 +1,6 @@
-import re
+from .base import *  # noqa
+from .kenya_base import *  # noqa
 
-from .base import *
-from .kenya_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/libya.py
+++ b/pombola/settings/libya.py
@@ -1,7 +1,5 @@
-import re
-
-from .base import *
-from .libya_base import *
+from .base import *  # noqa
+from .libya_base import *  # noqa
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/nigeria.py
+++ b/pombola/settings/nigeria.py
@@ -1,7 +1,6 @@
-import re
+from .base import *  # noqa
+from .nigeria_base import *  # noqa
 
-from .base import *
-from .nigeria_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/no_country.py
+++ b/pombola/settings/no_country.py
@@ -1,6 +1,4 @@
-import re
-
-from .base import *
+from .base import *  # noqa
 
 MAPIT_COUNTRY = 'Global'
 

--- a/pombola/settings/south_africa.py
+++ b/pombola/settings/south_africa.py
@@ -1,9 +1,9 @@
 import errno
 import os
-import re
 
-from .base import *
-from .south_africa_base import *
+from .base import *  # noqa
+from .south_africa_base import *  # noqa
+
 
 HAYSTACK_CONNECTIONS['default']['EXCLUDED_INDEXES'] = [
     'pombola.search.search_indexes.PlaceIndex',

--- a/pombola/settings/south_africa_base.py
+++ b/pombola/settings/south_africa_base.py
@@ -1,4 +1,4 @@
-from .apps import *
+from .apps import *  # noqa
 
 COUNTRY_APP = 'south_africa'
 

--- a/pombola/settings/tests.py
+++ b/pombola/settings/tests.py
@@ -1,8 +1,7 @@
-import re
+from .base import *  # noqa
 
-from .base import *
+from .tests_base import *  # noqa
 
-from .tests_base import *
 
 # Make sure that FakeInstanceMiddleware is present since we'll add
 # speeches to INSTALLED_APPS for testing:

--- a/pombola/settings/tests_kenya.py
+++ b/pombola/settings/tests_kenya.py
@@ -1,8 +1,7 @@
-import re
+from .base import *  # noqa
+from .tests_base import *  # noqa
+from .kenya_base import *  # noqa
 
-from .base import *
-from .tests_base import *
-from .kenya_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/tests_libya.py
+++ b/pombola/settings/tests_libya.py
@@ -1,8 +1,7 @@
-import re
+from .base import *  # noqa
+from .tests_base import *  # noqa
+from .libya_base import *  # noqa
 
-from .base import *
-from .tests_base import *
-from .libya_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/tests_nigeria.py
+++ b/pombola/settings/tests_nigeria.py
@@ -1,8 +1,7 @@
-import re
+from .base import *  # noqa
+from .tests_base import *  # noqa
+from .nigeria_base import *  # noqa
 
-from .base import *
-from .tests_base import *
-from .nigeria_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/tests_south_africa.py
+++ b/pombola/settings/tests_south_africa.py
@@ -1,8 +1,7 @@
-import re
+from .base import *  # noqa
+from .tests_base import *  # noqa
+from .south_africa_base import *  # noqa
 
-from .base import *
-from .tests_base import *
-from .south_africa_base import *
 
 HAYSTACK_CONNECTIONS['default']['EXCLUDED_INDEXES'] = [
     'pombola.search.search_indexes.PlaceIndex',

--- a/pombola/settings/tests_zimbabwe.py
+++ b/pombola/settings/tests_zimbabwe.py
@@ -1,8 +1,7 @@
-import re
+from .base import *  # noqa
+from .tests_base import *  # noqa
+from .zimbabwe_base import *  # noqa
 
-from .base import *
-from .tests_base import *
-from .zimbabwe_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/settings/zimbabwe.py
+++ b/pombola/settings/zimbabwe.py
@@ -1,7 +1,6 @@
-import re
+from .base import *  # noqa
+from .zimbabwe_base import *  # noqa
 
-from .base import *
-from .zimbabwe_base import *
 
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',

--- a/pombola/south_africa/bin/people-json/committees.py
+++ b/pombola/south_africa/bin/people-json/committees.py
@@ -1,7 +1,9 @@
 import csv
 import re
 import unicodedata
-from utils import *
+
+from utils import add_membership, data_path, idFactory
+
 
 def initialise(name):
     return re.sub('[^A-Z]', '', name)

--- a/pombola/south_africa/bin/people-json/manual.py
+++ b/pombola/south_africa/bin/people-json/manual.py
@@ -1,4 +1,5 @@
-from utils import *
+from utils import add_membership, idFactory, PROVINCES
+
 
 def parse(data):
     for person in data['persons'].values():

--- a/pombola/south_africa/bin/people-json/myreps.py
+++ b/pombola/south_africa/bin/people-json/myreps.py
@@ -1,7 +1,9 @@
 import csv
 import re
 import xml.etree.ElementTree as ET
-from utils import *
+
+from utils import add_membership, data_path, idFactory, REASONS, PROVINCES
+
 
 def FixingDictReader(data):
     for row in csv.DictReader(data):

--- a/pombola/south_africa/bin/people-json/parl.py
+++ b/pombola/south_africa/bin/people-json/parl.py
@@ -3,7 +3,9 @@ import requests
 import requests_cache
 import urllib
 import urlparse
-from utils import *
+
+from utils import add_membership, idFactory, PROVINCES
+
 
 requests_cache.install_cache()
 

--- a/pombola/south_africa/data/legislature_members/apply_changes_to_popolo.py
+++ b/pombola/south_africa/data/legislature_members/apply_changes_to_popolo.py
@@ -1,7 +1,5 @@
-from warnings import warn
 import json
 import re
-import sys
 
 from django.utils.text import slugify
 

--- a/pombola/south_africa/data/members-interests/convert_to_import_json.py
+++ b/pombola/south_africa/data/members-interests/convert_to_import_json.py
@@ -16,7 +16,6 @@ app_path = os.path.abspath(base_dir)
 sys.path.append(app_path)
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pombola.settings.south_africa'
 
-from django.conf import settings
 from django.utils.text import slugify
 from django.db.models import Q
 

--- a/pombola/south_africa/data/mp_bios/apply_bios_from_json_onto_popolo.py
+++ b/pombola/south_africa/data/mp_bios/apply_bios_from_json_onto_popolo.py
@@ -1,4 +1,3 @@
-from warnings import warn
 import json
 import re
 import sys

--- a/pombola/south_africa/management/commands/south_africa_fix_position_titles.py
+++ b/pombola/south_africa/management/commands/south_africa_fix_position_titles.py
@@ -7,7 +7,7 @@
 
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django.db import transaction
 
 from pombola.core.models import PositionTitle, Position, OrganisationKind

--- a/pombola/south_africa/management/commands/south_africa_import_boundaries.py
+++ b/pombola/south_africa/management/commands/south_africa_import_boundaries.py
@@ -21,16 +21,13 @@ import os
 import re
 import sys
 
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from optparse import make_option
 
-from django.conf import settings
-from django.contrib.gis.gdal import DataSource
-from django.contrib.gis.geos import MultiPolygon
 from django.core.management import call_command
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 
-from mapit.models import Area, Code, CodeType, Generation, Type, NameType, Country
+from mapit.models import Generation, NameType, Country
 
 
 class Command(NoArgsCommand):

--- a/pombola/south_africa/management/commands/south_africa_import_election_candidates.py
+++ b/pombola/south_africa/management/commands/south_africa_import_election_candidates.py
@@ -6,21 +6,16 @@ IEC spreadsheet format.
 import os
 import sys
 import unicodecsv
-import json
 import string
 import datetime
 from optparse import make_option
 from pombola.core.models import (Organisation, OrganisationKind,
                          Person, Position,
                          PositionTitle, AlternativePersonName)
-from django.core.management import call_command
-from django.core.management.base import NoArgsCommand, CommandError
-from django.utils import encoding
+from django.core.management.base import NoArgsCommand
 from django.db.models import Q
 
-from django.core.exceptions import ObjectDoesNotExist
-
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+from django_date_extensions.fields import ApproximateDate
 
 from haystack.query import SearchQuerySet
 

--- a/pombola/south_africa/management/commands/south_africa_import_popolo_json.py
+++ b/pombola/south_africa/management/commands/south_africa_import_popolo_json.py
@@ -1,20 +1,14 @@
-import os
 import sys
 import re
-from optparse import make_option
 
 import json
 
-from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import LabelCommand
-
-from django.utils.text import slugify
 
 from django_date_extensions.fields import ApproximateDate
 
-from pombola.core.models import ( ContentType, ContactKind, Identifier,
-    Organisation, Person, Contact )
+from pombola.core.models import Organisation, Person
+
 
 def parse_approximate_date(s):
     """Take a partial ISO 8601 date, and return an ApproximateDate for it

--- a/pombola/south_africa/management/commands/south_africa_restart_constituency_contacts.py
+++ b/pombola/south_africa/management/commands/south_africa_restart_constituency_contacts.py
@@ -1,7 +1,7 @@
 from datetime import date
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import NoArgsCommand
 from django_date_extensions.fields import ApproximateDate
 
 from pombola.core.models import PositionTitle

--- a/pombola/south_africa/management/commands/south_africa_set_da_office_locations.py
+++ b/pombola/south_africa/management/commands/south_africa_set_da_office_locations.py
@@ -36,14 +36,11 @@ import re
 # from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.geos import Point
 # from django.core.exceptions import ObjectDoesNotExist
-from django.core.management.base import LabelCommand, CommandError
+from django.core.management.base import LabelCommand
 # from django.db.models import Q
 from django.utils.text import slugify
 #
-from pombola.core.models import (OrganisationKind, Organisation, PlaceKind,
-                         ContactKind, OrganisationRelationshipKind,
-                         OrganisationRelationship, Identifier, Position,
-                         PositionTitle, Person)
+from pombola.core.models import OrganisationKind
 #
 # from mapit.models import Generation, Area, Code
 

--- a/pombola/south_africa/templatetags/za_speeches.py
+++ b/pombola/south_africa/templatetags/za_speeches.py
@@ -1,9 +1,5 @@
-import datetime
-
 from django import template
 from django.template import loader, Context
-
-from speeches.models import Section
 
 register = template.Library()
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -6,7 +6,6 @@ from datetime import date, time
 from StringIO import StringIO
 from tempfile import mkdtemp
 from urlparse import urlparse
-from BeautifulSoup import Tag, NavigableString
 
 from mock import patch
 

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -7,12 +7,9 @@ from pombola.south_africa import views
 from pombola.south_africa.views import (SAHomeView, LatLonDetailNationalView,
     LatLonDetailLocalView, SAPlaceDetailSub, SAOrganisationDetailView,
     SAPersonDetail, SASearchView, SANewsletterPage, SAPlaceDetailView,
-    SASpeakerRedirectView, SAHansardIndex, SACommitteeIndex,
-    SAPersonAppearanceView, SAQuestionIndex,
+    SAPersonAppearanceView,
     SAOrganisationDetailSubPeople, SAOrganisationDetailSubParty,
-    OldSectionRedirect, OldSpeechRedirect, SASpeechView, SASectionView,
     SAGeocoderView)
-from speeches.views import SectionView, SpeechView, SectionList
 from pombola.core.urls import (
     organisation_patterns,
     organisation_patterns_path,

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -17,7 +17,6 @@ from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.http import Http404
 from django.db.models import Count, Min, Max
-from django.conf import settings
 from django.core.cache import get_cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import redirect
@@ -30,7 +29,7 @@ from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
 
 import mapit
-from haystack.query import RelatedSearchQuerySet, SearchQuerySet, SQ
+from haystack.query import RelatedSearchQuerySet, SQ
 from haystack.inputs import AutoQuery
 from haystack.forms import SearchForm
 
@@ -50,9 +49,9 @@ from pombola.slug_helpers.views import SlugRedirect
 
 from pombola.south_africa.models import ZAPlace
 
-from pombola.interests_register.models import Release, Category, Entry, EntryLineItem
+from pombola.interests_register.models import Release, Category, Entry
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django_date_extensions.fields import ApproximateDateField, ApproximateDate
+from django_date_extensions.fields import ApproximateDate
 
 
 logger = logging.getLogger('django.request')

--- a/pombola/tasks/admin.py
+++ b/pombola/tasks/admin.py
@@ -1,20 +1,17 @@
 import datetime
 
-from django import forms
 from django.conf.urls import patterns
 from django.contrib import admin
 from django.utils.decorators import method_decorator
 from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.contenttypes.generic import GenericTabularInline
-from django.contrib.gis import db
 from django.core.urlresolvers import reverse
-from django.shortcuts  import render_to_response, get_object_or_404, redirect
+from django.shortcuts  import render_to_response, redirect
 from django.template   import RequestContext
 
 import models
-from pprint import pprint
 
 from pombola.slug_helpers.admin import StricterSlugFieldMixin
+
 
 def create_admin_url_for(obj):
     return reverse(

--- a/pombola/tasks/tests.py
+++ b/pombola/tasks/tests.py
@@ -5,7 +5,7 @@ Test the tasks
 from django.test import TestCase
 from django.contrib.sites.models import Site
 from models import TaskCategory, Task
-from pprint import pprint
+
 
 class TaskTest(TestCase):
 

--- a/pombola/testing/__init__.py
+++ b/pombola/testing/__init__.py
@@ -1,1 +1,2 @@
-from selenium import PombolaSeleniumTestCase
+from selenium import PombolaSeleniumTestCase  # noqa
+

--- a/pombola/testing/selenium.py
+++ b/pombola/testing/selenium.py
@@ -1,15 +1,7 @@
 from __future__ import absolute_import
 
-import urllib
-from time import sleep
-
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command 
-from django.core.urlresolvers import reverse
-from django.utils import unittest
-
-from selenium.common.exceptions import NoSuchElementException
 
 from django_selenium.testcases import SeleniumTestCase
 

--- a/pombola/votematch/urls.py
+++ b/pombola/votematch/urls.py
@@ -1,9 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 from django.views.generic import ListView, TemplateView
 
-from .models import Quiz, Submission
-
+from .models import Quiz
 
 
 urlpatterns = patterns( 'pombola.votematch.views',

--- a/pombola/wsgi_monitor.py
+++ b/pombola/wsgi_monitor.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import time
 import signal
 import threading
 import atexit

--- a/pombola/zimbabwe/models.py
+++ b/pombola/zimbabwe/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pombola/zimbabwe/urls.py
+++ b/pombola/zimbabwe/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns
 
 urlpatterns = patterns('',
     # There are no overridden urls for Zimbabwe, yet....


### PR DESCRIPTION
This is the very start of what I expect to be a fairly long running task to make the whole of the codebase PEP8 compliant. In this PR I've just run flake8 with the tests for unneeded imports etc. We should add a check for each PEP8 test once we have it passing and make that part of the continuous integration so that we never go backwards.

There are two sets of changes here which I think are worth considering.

1) Does `from fabric.api import *` do any magic? We don't appear to use anything that's imported that way.

2) Should we just put `# flake8: noqa` on `pombola/ghana/management/feedparser.py`, which is vendored? Better still, can we include it from PyPI instead (#1882)