### PR TITLE
ZA: Social media links in header

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -333,10 +333,11 @@ $logo-width-large: 184px;
     height: auto;
     background-image: none;
     background: $colour_main_background;
-    padding: .5em 0 0;
+    padding: 0.5em 0 0 0;
     position: relative;
+
     @media only all and (min-width: 640px), print {
-        padding: 0;
+        padding: 0 0.5em 0 0.5em; // stop children touching edges of window on narrow desktops
         height: 114px;
     }
 }
@@ -436,6 +437,13 @@ menu#mobile-top-tools,
 #main-menu {
     background: $colour_green;
 }
+
+#main-menu {
+    @media only all and (min-width: 640px) {
+        padding: 0 0.5em 0 0.5em; // stop children touching edges of window on narrow desktops
+    }
+}
+
 #main-menu nav{
     text-align: left;
     ul{
@@ -452,6 +460,12 @@ menu#mobile-top-tools,
                 &:hover,
                 &:focus {
                     background: mix($colour_green, #000, 80%);
+                }
+            }
+
+            &:first-child a {
+                @media only all and (min-width: 640px) {
+                    margin-left: -8px; // compensate for link padding so text lines up with site grid
                 }
             }
 

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -333,7 +333,6 @@ $logo-width-large: 184px;
     height: auto;
     background-image: none;
     background: $colour_main_background;
-    padding: 0.5em 0 0 0;
     position: relative;
 
     @media only all and (min-width: 640px), print {
@@ -542,29 +541,62 @@ menu#mobile-top-tools,
     position: absolute;
     top: .5em;
     right: .5em;
+    width: 9em;
+    text-align: right;
+
     @media only all and (min-width: 640px), print {
        top: .5em;
        right: 0;
+       width: auto;
     }
+
     ul {
         padding-left: 0;
     }
+
     li {
         list-style: none outside none;
         line-height: 1.1em;
-        text-align: right;
-        @media only all and (min-width: 640px), print {
-           display: inline-block;
-           margin-left: .5em;
-        }
+        display: inline-block;
+        margin-left: 0.5em;
     }
+
     a {
         font-size: 0.75em;
         color: $colour_blackish;
         text-decoration: none;
+
         &:hover {
             color: $colour-primary;
             text-decoration: underline;
+        }
+    }
+}
+
+@media only all and (min-width: 640px) {
+    .about-this-site-menu__facebook,
+    .about-this-site-menu__twitter {
+        position: absolute;
+        /* 114px is the header height and 38px is the icon height, so
+           this does vertical centring: */
+        top: (114px / 2) - (38px / 2);
+        right: 50px;
+
+        a {
+            display: block;
+            width: 38px;
+            height: 0;
+            padding-top: 38px;
+            overflow: hidden;
+            background: transparent url('/static/images/social-icons.png') 0 -1px no-repeat;
+        }
+    }
+
+    .about-this-site-menu__twitter {
+        right: 0;
+
+        a {
+            background-position: -51px -1px;
         }
     }
 }

--- a/pombola/south_africa/templates/site_header_logo.html
+++ b/pombola/south_africa/templates/site_header_logo.html
@@ -11,5 +11,7 @@
         <li><a href="{% url 'info_page' slug='for-representatives'%}">For Representatives</a></li>
         <li><a href="{% url 'info_page' slug='newsletter'%}">Subscribe</a></li>
         <li><a href="{% url 'info_page' slug='contact-us'%}">Contact us</a></li>
+        <li class="about-this-site-menu__facebook"><a href="https://www.facebook.com/peoplesassemblysa">Facebook</a></li>
+        <li class="about-this-site-menu__twitter"><a href="https://twitter.com/PeoplesAssem_SA">Twitter</a></li>
     </ul>
 </div>


### PR DESCRIPTION
Fixes #1849.

Also includes a few overdue fixes to the horizontal padding / gutter either side of the header elements on mid-size screens, and the overcomplicated layout that the "about-this-site" menu items used to have.

Large screen:

![screen shot 2016-01-04 at 12 44 22](https://cloud.githubusercontent.com/assets/739624/12090091/7b51c43c-b2e3-11e5-8913-dfcf83a00a48.png)

Mid-size screen: (this is at its absolute worst – 640px)

![screen shot 2016-01-04 at 12 45 54](https://cloud.githubusercontent.com/assets/739624/12090093/812da218-b2e3-11e5-9f98-687d829a3363.png)

Small screen:

![screen shot 2016-01-04 at 12 46 29](https://cloud.githubusercontent.com/assets/739624/12090098/86ffdcec-b2e3-11e5-83a3-27db391608e3.png)
