### PR TITLE
ZA Dedupe former organisations and don't include current ones.

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -15,11 +15,11 @@
           {% endfor %}
         </p>
       {% endif %}
-      {% if former_positions %}
+      {% if organizations_from_former_important_positions %}
         <p>
           Formerly:
-          {% for position in former_positions %}
-            <span class="position-title">{{ position.organisation.name }}</span>
+          {% for organisation in organizations_from_former_important_positions %}
+            <span class="position-title">{{ organisation.name }}</span>
           {% if not forloop.last %}and{% endif %}
           {% endfor %}
         </p>


### PR DESCRIPTION
On the ZA person page, get rid of duplicate organisations in the former
organisations bit, and also remove from there any organisations which
the person is a current member of.

Fixes #1885 and fixes #1887.