### PR TITLE
1886 ncop grouped as other

### DIFF
--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -247,12 +247,18 @@ class SAPlaceDetailView(PlaceDetailView):
         context = super(SAPlaceDetailView, self).get_context_data(**kwargs)
 
         for context_string, position_filter in (
-                ('national_assembly_people', {'organisation__slug': 'national-assembly'}),
-                ('ncop_people', {'organisation__slug': 'ncop'}),
-                ('legislature_people', {'organisation__kind__slug': 'provincial-legislature'}),
+                ('national_assembly_people',
+                 {'organisation__slug': 'national-assembly',
+                  'title__slug': 'member'}),
+                ('ncop_people',
+                 {'organisation__slug': 'ncop',
+                  'title__slug': 'delegate'}),
+                ('legislature_people',
+                 {'organisation__kind__slug': 'provincial-legislature',
+                  'title__slug': 'member'}),
         ):
             all_member_positions = self.object.all_related_positions(). \
-                filter(title__slug='member', **position_filter).select_related('person')
+                filter(**position_filter).select_related('person')
             current_positions = all_member_positions.currently_active()
             current_people = models.Person.objects.filter(position__in=current_positions).distinct()
             former_positions = all_member_positions.currently_inactive()


### PR DESCRIPTION

This sorts out NCOP delegates not appearing in the right place, which was caused by the position having title 'delegate' rather than member. The code has loads of places which make allowance for NCOP positions being delegates rather than members, so I don't really want to just switch it to member as it might well break some.

It would be nice to generally reduce the number of places the code refers to particular slugs.

At the moment this causes another test to fail. There is a check to make sure that if someone is both a member of the National Assembly and a delegate to NCOP that they don't appear on the list for the place twice. I would like to know if this is a real possibility, and if not, that test could be cut.

Fixes #1886.


![2016-01-11-162742_1366x768_scrot](https://cloud.githubusercontent.com/assets/56265/12239416/8e7f09fa-b880-11e5-9853-15a466ec2492.png)