### PR TITLE
1838 important orgs

### DIFF
--- a/pombola/kenya/templates/core/person_base.html
+++ b/pombola/kenya/templates/core/person_base.html
@@ -52,7 +52,7 @@
           </ul>
       {% endif %}
 
-      {% regroup object.constituencies|dictsort:"kind" by kind as constituency_groups %}
+      {% regroup constituencies|dictsort:"kind" by kind as constituency_groups %}
       {% for entry in constituency_groups %}
       <h3>{{ entry.grouper }}</h3>
       <ul>

--- a/pombola/kenya/tests.py
+++ b/pombola/kenya/tests.py
@@ -4,11 +4,25 @@ import re
 import urllib
 import urlparse
 
+from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
+from django.test import TestCase, RequestFactory
 
 from pombola.experiments.models import Event, Experiment
 from pombola.feedback.models import Feedback
+from pombola.core.models import (
+    Person,
+    Place,
+    PlaceKind,
+    Position,
+    PositionTitle,
+    Organisation,
+    OrganisationKind,
+    )
+from pombola.kenya.views import KEPersonDetail
+
 from .views import EXPERIMENT_DATA, CountyPerformanceView
+
 
 from django_webtest import WebTest
 
@@ -234,3 +248,111 @@ class CountyPerformancePageTests(WebTest):
         parsed_facebook_url = urlparse.urlparse(facebook_url)
         self.assertEqual(parsed_facebook_url.path, self.url)
         self.assertTrue(re.search(r'^via=[a-f0-9]+$', parsed_facebook_url.query))
+
+
+@attr(country='kenya')
+class PersonDetailPageTest(TestCase):
+    """The membership data we have has a tendency to gradually move
+    away from the ideal of the only positions associated with NA
+    constituencies being being those linking assembly members with their
+    constituencies.
+
+    While we work out how to keep the data tidier, we're going to handle
+    this problem by only displaying the memberships we actually want to
+    see.
+    """
+    def setUp(self):
+        county_kind = PlaceKind.objects.create(name='County', slug='county')
+        constituency_kind = PlaceKind.objects.create(name='Constituency', slug='constituency')
+
+        self.county = Place.objects.create(kind=county_kind, name='Test County', slug='test-county')
+        self.constituency = Place.objects.create(kind=constituency_kind, name='Test Constituency', slug='test-constituency')
+
+        self.na_member_title = PositionTitle.objects.create(name='NA Member', slug='member-national-assembly')
+        self.senator_title = PositionTitle.objects.create(name='Senator', slug='senator')
+        self.party_member_title = PositionTitle.objects.create(name='Party Member', slug='party-member')
+
+        self.governmental = OrganisationKind.objects.create(name='Governmental', slug='governmental')
+        self.party_orgkind = OrganisationKind.objects.create(name='Political Party', slug='party')
+
+        self.na = Organisation.objects.create(kind=self.governmental, name='National Assembly', slug='national-assembly')
+        self.senate = Organisation.objects.create(kind=self.governmental, name='Senate', slug='senate')
+
+        self.party = Organisation.objects.create(kind=self.party_orgkind, name='Test Party', slug='test-party')
+
+        self.person = Person.objects.create(legal_name='Test Person', slug='test-person')
+
+    def test_mp_with_county(self):
+        Position.objects.create(
+            category='political',
+            person=self.person,
+            place=self.constituency,
+            organisation=self.na,
+            title=self.na_member_title,
+            )
+
+        Position.objects.create(
+            category='political',
+            person=self.person,
+            place=self.county,
+            )
+
+        request = RequestFactory().get('/person/test-person/')
+        request.user = AnonymousUser()
+        response = KEPersonDetail.as_view()(request, slug='test-person')
+
+        self.assertEqual(len(response.context_data['constituencies']), 1)
+        self.assertEqual(response.context_data['constituencies'][0], self.constituency)
+
+    def test_mp_with_party_membership_linked_to_constituency(self):
+        Position.objects.create(
+            category='political',
+            person=self.person,
+            place=self.constituency,
+            organisation=self.na,
+            title=self.na_member_title,
+            )
+
+        Position.objects.create(
+            category='political',
+            person=self.person,
+            place=self.constituency,
+            organisation=self.party,
+            title=self.party_member_title,
+            )
+
+        request = RequestFactory().get('/person/test-person/')
+        request.user = AnonymousUser()
+        response = KEPersonDetail.as_view()(request, slug='test-person')
+
+        self.assertEqual(len(response.context_data['constituencies']), 1)
+        self.assertEqual(response.context_data['constituencies'][0], self.constituency)
+
+    def test_senator_with_party_membership_linked_to_constituency(self):
+        Position.objects.create(
+            category='political',
+            person=self.person,
+            place=self.county,
+            organisation=self.senate,
+            title=self.senator_title,
+            )
+
+        Position.objects.create(
+            category='political',
+            person=self.person,
+            place=self.constituency,
+            organisation=self.party,
+            title=self.party_member_title,
+            )
+
+        request = RequestFactory().get('/person/test-person/')
+        request.user = AnonymousUser()
+        response = KEPersonDetail.as_view()(request, slug='test-person')
+
+        self.assertEqual(len(response.context_data['constituencies']), 1)
+        self.assertEqual(response.context_data['constituencies'][0], self.county)
+
+    def test_mp_with_two_constituencies(self):
+        # We should check that if someone has two constituencies we always get
+        # just one, and the same one, back.
+        pass

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -139,6 +139,17 @@ class KEPersonDetail(HansardPersonMixin, PersonDetail):
             if shujaaz.FINALISTS_DICT[year].get(self.object.pk)
         ]
 
+        political_positions = self.object.position_set.all().political().currently_active()
+
+        if political_positions.filter(title__slug='member-national-assembly').exists():
+            constituencies = self.object.constituencies().constituencies()
+        elif political_positions.filter(title__slug='senator').exists():
+            constituencies = self.object.constituencies().counties()
+        else:
+            constituencies = []
+
+        context['constituencies'] = constituencies
+
         return context
 
 

--- a/pombola/kenya/views.py
+++ b/pombola/kenya/views.py
@@ -116,7 +116,7 @@ class KEPersonDetail(HansardPersonMixin, PersonDetail):
         context = super(KEPersonDetail, self).get_context_data(**kwargs)
         context['hansard_entries_to_show'] = ":3"
 
-        constituencies = self.object.constituencies().filter(
+        cdf_constituencies = self.object.constituencies().filter(
             budget_entries__organisation='Constituencies Development Fund'
         ).select_related()
 
@@ -124,7 +124,7 @@ class KEPersonDetail(HansardPersonMixin, PersonDetail):
         # latest. budgets() are default sorted by date of the budget session.
         cdf_budget_constituencies = [
             {'constituency': c, 'budget': c.budgets()[0]}
-            for c in constituencies
+            for c in cdf_constituencies
         ]
 
         context['cdf_budget_constituencies'] = cdf_budget_constituencies


### PR DESCRIPTION
These changes should hopefully stop duplicate constituencies/counties appearing on the sidebar on the person detail page (#1838). There should now be at most one constituency for NA members, and one county for senators.

This is currently done in the view and template layers for KE only. It would be good in the long run to have a system for storing which combinations of organisation, organisationkind, positiontitle, etc should be considered important enough to display here, and storing that in the database rather than the code.