### PR TITLE
hansard: Fix for it being possible to create aliases to hidden people

### DIFF
--- a/pombola/core/lookups.py
+++ b/pombola/core/lookups.py
@@ -1,0 +1,11 @@
+from ajax_select import LookupChannel
+
+from .models import Person
+
+
+class PersonLookup(LookupChannel):
+
+    model = Person
+
+    def get_query(self, q, requests):
+        return Person.objects.filter(hidden=False, legal_name__icontains=q)

--- a/pombola/hansard/models/alias.py
+++ b/pombola/hansard/models/alias.py
@@ -43,7 +43,9 @@ class Alias(HansardModelBase):
     updated = models.DateTimeField( auto_now=True,     default=datetime.datetime.now, )
 
     alias   = models.CharField( max_length=200, unique=True )
-    person  = models.ForeignKey( Person, blank=True, null=True )
+    person  = models.ForeignKey(
+        Person, blank=True, null=True, limit_choices_to={'hidden': False}
+    )
     ignored = models.BooleanField( default=False )
     
     objects = AliasManager()

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -298,7 +298,7 @@ HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
 # Admin autocomplete
 AJAX_LOOKUP_CHANNELS = {
-    'person_name'       : dict(model='core.person',        search_field='legal_name'),
+    'person_name'       : ('pombola.core.lookups', 'PersonLookup'),
     'organisation_name' : dict(model='core.organisation',  search_field='name'),
     'place_name'        : dict(model='core.place',         search_field='name'),
     'title_name'        : dict(model='core.positiontitle', search_field='name'),


### PR DESCRIPTION
People who have 'hidden' set to True are people who have stood for an
election but essentially zero chance of ever having appeared as a
speaker in Hansard.  Since there were Alias objects referring to hidden
people, let's prevent this from being possible.