### PR TITLE
Update Hot Topics menu.

### DIFF
--- a/pombola/south_africa/templates/menu_entries.html
+++ b/pombola/south_africa/templates/menu_entries.html
@@ -46,10 +46,8 @@
     <ul id="blog-overview">
       <li><a href="{% url 'info_blog_category' slug='week-parliament' %}">That Week In Parliament</a></li>
       <li><a href="{% url 'info_blog_category' slug='impressions' %}">Impressions</a></li>
-      <li><a href="{% url 'info_blog_category' slug='advocacy-campaigns' %}">Advocacy Campaigns</a></li>
       <li><a href="{% url 'info_blog_category' slug='commentary' %}">Commentary</a></li>
       <li><a href="{% url 'info_blog_category' slug='elections-2014' %}">Elections 2014</a></li>
-      <li><a href="{% url 'info_blog_category' slug='mp-corner' %}">MP Corner</a></li>
     </ul>
   {% endif %}
 </li>
@@ -62,10 +60,6 @@
       <li><a href="https://pmg.org.za/bills">Bill Tracker</a></li>
       <li><a href="http://www.pmg.org.za/committees">Committees</a></li>
       <li><a href="{% url "section-list-hansard" %}">Hansard</a></li>
-      <li><a href="{% url "sa-interests-index" %}">Members' Interests</a></li>
-
-
-
     </ul>
   {% endif %}
 </li>
@@ -88,7 +82,13 @@
 <li><a href="{% url "info_page" slug="hot-topics" %}" class="has-dropdown">Hot Topics</a>
   {% if include_sub_menu_entries %}
     <ul id="extras-overview">
-      <li><a href="{% url "info_page" slug="infographics" %}">Infographics</a></li>
+      <li><a href="{% url 'mp-attendance' %}">MP attendance</a></li>
+      <li><a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name">MP profiles</a></li>
+      <li><a href="{% url 'sa-interests-index' %}">MP assets</a></li>
+      <li><a href="{% url 'info_blog_category' slug='mp-corner' %}">MP Corner</a></li>
+      <li><a href="{% url 'ward-councillor-lookup' %}">Find your councillor</a></li>
+      <li><a href="{% url 'info_page' slug="infographics" %}">Infographics</a></li>
+      <li><a href="{% url 'info_blog_category' slug='advocacy-campaigns' %}">Campaigns</a></li>
     </ul>
   {% endif %}
 </li>


### PR DESCRIPTION
Move MP Corner and Advocacy Campaigns from Blogs to Hot Topics.
Move MP Interests from Democracy Resources to Hot Topics.
Add MP profiles and Find Your Councillor to Hot Topics.

Rename Advocacy Campaigns to Campaigns, and MP Interests to MP assets.

Reorder column to match Gaile's comment.

I'm not sure what 'MP Comments' means is Gaile's comment on the ticket,
so I've put 'MP profiles' there.

Fixes #1918 