### PR TITLE
Return None for admin url of missing foreign key.

### DIFF
--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -13,7 +13,8 @@ from pombola.slug_helpers.admin import StricterSlugFieldMixin
 
 
 def create_admin_link_for(obj, link_text):
-    return u'<a href="%s">%s</a>' % (obj.get_admin_url(), link_text)
+    if obj is not None:
+        return u'<a href="%s">%s</a>' % (obj.get_admin_url(), link_text)
 
 
 class ContentTypeModelAdmin(admin.ModelAdmin):


### PR DESCRIPTION
(instead of a traceback).

If for some reason the object that the generic foreign key on an identifier doesn't exist, show '(None)' on the admin page for all identifiers for the link to this foreign key, rather than giving a traceback.
![2016-02-10-091720_1366x768_scrot](https://cloud.githubusercontent.com/assets/56265/12943245/ec2ddf2c-cfd7-11e5-98e0-f7658aa07bba.png)

At the moment, this error makes it hard to edit the bad data from the admin interface. I guess it might be worth sending an email to admins anyway?
