### PR TITLE
Fixes for admin link generation errors

### DIFF
--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -23,8 +23,12 @@ def create_admin_link_for(obj, link_text):
 class ContentTypeModelAdmin(admin.ModelAdmin):
 
     def show_foreign(self, obj):
-        return create_admin_link_for(
-            obj.content_object, unicode(obj.content_object))
+        if obj.content_object:
+            return create_admin_link_for(
+                obj.content_object,
+                unicode(obj.content_object)
+            )
+        return ''
 
     show_foreign.allow_tags = True
 

--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib import admin
 from django.contrib.gis import db
 from django.contrib.contenttypes.generic import GenericTabularInline
+from django.utils.html import escape
 
 from ajax_select import make_ajax_form
 from ajax_select.admin import AjaxSelectAdmin
@@ -13,7 +14,10 @@ from pombola.slug_helpers.admin import StricterSlugFieldMixin
 
 
 def create_admin_link_for(obj, link_text):
-    return u'<a href="%s">%s</a>' % (obj.get_admin_url(), link_text)
+    return u'<a href="{url}">{link_text}</a>'.format(
+        url=obj.get_admin_url(),
+        link_text=escape(link_text)
+    )
 
 
 class ContentTypeModelAdmin(admin.ModelAdmin):


### PR DESCRIPTION
This was prompted by an error email we were getting, and includes
a fix for some missing HTML-escaping in the link generation.