### PR TITLE
Removing items from blog menu dropdown on pa.org.za

### DIFF
--- a/pombola/south_africa/templates/menu_entries.html
+++ b/pombola/south_africa/templates/menu_entries.html
@@ -45,9 +45,7 @@
   {% if include_sub_menu_entries %}
     <ul id="blog-overview">
       <li><a href="{% url 'info_blog_category' slug='week-parliament' %}">That Week In Parliament</a></li>
-      <li><a href="{% url 'info_blog_category' slug='impressions' %}">Impressions</a></li>
       <li><a href="{% url 'info_blog_category' slug='commentary' %}">Commentary</a></li>
-      <li><a href="{% url 'info_blog_category' slug='elections-2014' %}">Elections 2014</a></li>
     </ul>
   {% endif %}
 </li>


### PR DESCRIPTION
Removing Impressions and Elections 2014 from the Blog menu drop down items on people's assembly

Fixes #1919 