### PR TITLE
Remove PU search logic from Nigeria views

### DIFF
--- a/pombola/nigeria/tests.py
+++ b/pombola/nigeria/tests.py
@@ -164,13 +164,13 @@ class NGSearchViewTest(WebTest):
     def test_matching_state(self):
         response = self.app.get("/search/?q=28/04454/09")
         self.assertIn(
-            'Best match is the state "ONDO" with poll unit number \'ON\'',
+            'Best match is the state "Ondo" with poll unit number \'ON\'',
             response.content
         )
 
     def test_matching_lga(self):
         response = self.app.get("/search/?q=28/04/09")
         self.assertIn(
-            'Best match is the local government area "AKOKO SOUTH WEST" with poll unit number \'ON:4\'',
+            'Best match is the local government area "Akoko South-West" with poll unit number \'ON:4\'',
             response.content
         )

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -1,5 +1,7 @@
 import re
 
+import requests
+
 from mapit.models import Area
 
 from pombola.core.models import Place
@@ -28,100 +30,6 @@ class NGHomeView(HomeView):
             context['editable_content'] = None
         return context
 
-# These are hardcoded here rather than being introduced into the database to
-# avoid having a huge number of duplicated codes in MapIt. As it is largely a
-# presentation thing though I don't think it is too big an issue.
-state_number_to_letter_mappings = {
-    "1": "AB",
-    "2": "AD",
-    "3": "AK",
-    "4": "AN",
-    "5": "BA",
-    "6": "BY",
-    "7": "BE",
-    "8": "BO",
-    "9": "CR",
-    "10": "DE",
-    "11": "EB",
-    "12": "ED",
-    "13": "EK",
-    "14": "EN",
-    "15": "GO",
-    "16": "IM",
-    "17": "JI",
-    "18": "KD",
-    "19": "KN",
-    "20": "KT",
-    "21": "KE",
-    "22": "KO",
-    "23": "KW",
-    "24": "LA",
-    "25": "NA",
-    "26": "NI",
-    "27": "OG",
-    "28": "ON",
-    "29": "OS",
-    "30": "OY",
-    "31": "PL",
-    "32": "RI",
-    "33": "SO",
-    "34": "TA",
-    "35": "YO",
-    "36": "ZA",
-    "37": "FC",
-}
-
-def tidy_up_pun(pun):
-    """
-    Tidy up the query into something that looks like PUNs we are expecting
-
-    # None returns empty string
-    >>> tidy_up_pun(None)
-    ''
-
-    # Tidy up and strip as expected
-    >>> tidy_up_pun("AB:01:23:45")
-    'AB:1:23:45'
-    >>> tidy_up_pun("AB--01::23 45")
-    'AB:1:23:45'
-    >>> tidy_up_pun("  AB--01::23 45  ")
-    'AB:1:23:45'
-
-    # Convert state numbers to state code, if found
-    >>> tidy_up_pun("01:01:23:45")
-    'AB:1:23:45'
-    >>> tidy_up_pun("01")
-    'AB'
-    >>> tidy_up_pun("99:01:23:45")
-    '99:1:23:45'
-    """
-
-    if not pun:
-        pun = ""
-
-    pun = pun.strip().upper()
-    pun = re.sub(r'[^A-Z\d]+', ':', pun ) # separators to ':'
-    pun = re.sub(r'^0+', '',  pun ) # trim leading zeros at start of string
-    pun = re.sub(r':0+', ':', pun ) # trim leading zeros for each component
-
-    # PUNs starting with a number shoud be converted to start with a state code
-    if re.match(r'^\d', pun):
-        state_number = pun.split(':')[0]
-        state_code = state_number_to_letter_mappings.get(state_number, state_number)
-        pun = re.sub(r'^' + state_number, state_code, pun)
-
-    return pun
-
-# A regular expression to match any PUN after it's been tidied
-pun_re = re.compile('''
-    ^(
-       [A-Z]{2}|
-       [A-Z]{2}:\d+|
-       [A-Z]{2}:\d+:\d+|
-       [A-Z]{2}:\d+:\d+:\d+
-    )$
-''', re.VERBOSE)
-
 
 class NGSearchView(SearchBaseView):
 
@@ -138,7 +46,7 @@ class NGSearchView(SearchBaseView):
             return context
 
         # So now we know that the query is a PUN:
-        query = tidy_up_pun(self.request.GET.get('q'))
+        query = self.request.GET.get('q')
         context['raw_query'] = query
         context['query'] = query
         context['area'] = self.get_area_from_pun(query)
@@ -148,8 +56,8 @@ class NGSearchView(SearchBaseView):
             area = context['area']
 
             # Get the area PUN and name to store in context for template
-            context['area_pun_code'] = area.codes.filter(type__code="poll_unit")[0].code
-            context['area_pun_name'] = area.names.filter(type__code="poll_unit")[0].name
+            context['area_pun_code'] = area['codes']['poll_unit']
+            context['area_pun_name'] = area['name']
 
             # Get the place object for the containing state
             context['state'] = self.get_state(
@@ -164,29 +72,24 @@ class NGSearchView(SearchBaseView):
             context['governor'] = self.find_governor(context['state'])
 
             # work out the polygons to match to, may need to go up tree to parents.
-            area_for_polygons = self.find_containing_area(area)
-            if area_for_polygons:
-                area_polygons = area_for_polygons.polygons.collect()
+            # area_for_polygons = self.find_containing_area(area)
+            # if area_for_polygons:
+            #     area_polygons = area_for_polygons.polygons.collect()
 
-                context['federal_constituencies'] = self.get_district_data(
-                    self.find_matching_places("FED", area_polygons),
-                    "representative"
-                )
+            #     context['federal_constituencies'] = self.get_district_data(
+            #         self.find_matching_places("FED", area_polygons),
+            #         "representative"
+            #     )
 
-                context['senatorial_districts']  = self.get_district_data(
-                    self.find_matching_places("SEN", area_polygons),
-                    "senator"
-                )
+            #     context['senatorial_districts']  = self.get_district_data(
+            #         self.find_matching_places("SEN", area_polygons),
+            #         "senator"
+            #     )
         return context
 
     def parse_params(self):
         super(NGSearchView, self).parse_params()
-        tidied_as_if_pun = tidy_up_pun(self.query)
-        # Check if this is a known form of PUN:
-        if pun_re.search(tidied_as_if_pun):
-            self.pun = tidied_as_if_pun
-        else:
-            self.pun = None
+        self.pun = self.query
 
     def get(self, request, *args, **kwargs):
         query = self.request.GET.get('q')
@@ -239,7 +142,7 @@ class NGSearchView(SearchBaseView):
 
     def convert_area_to_place(self, area):
         try:
-            return Place.objects.get(mapit_area=area)
+            return Place.objects.get(mapit_area_id=area['id'])
         except Place.DoesNotExist:
             return None
 
@@ -252,14 +155,7 @@ class NGSearchView(SearchBaseView):
         forgiving in case of input error.
         """
 
-        while pun:
-            try:
-                area = Area.objects.get(codes__code=pun)
-                return area
-            except Area.DoesNotExist:
-                # strip off last component
-                pun = re.sub(r'[^:]+$', '', pun)
-                pun = re.sub(r':$', '', pun)
+        return requests.get('https://pu-lookup.herokuapp.com/lookup/{}'.format(pun)).json()
 
     def get_state(self, matched_pun, state_code, area):
         if ":" in matched_pun:

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -45,8 +45,11 @@ class NGSearchView(SearchBaseView):
 
         query = self.request.GET.get('q')
         response = requests.get(settings.PU_SEARCH_API_URL, params={'lookup': query})
-        if response.status_code is not 200:
+        if response.status_code == 400:
             self.pun = False
+            return context
+
+        if response.status_code == 404:
             return context
 
         pu_result = response.json()

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -71,7 +71,7 @@ class NGSearchView(SearchBaseView):
                 area)
 
             # work out what level of the PUN we've matched
-            context['area_pun_type'] = self.get_pun_type(context['area_pun_code'])
+            context['area_pun_type'] = area['type_name']
 
             # attempt to populate governor info
             context['governor'] = self.find_governor(context['state'])
@@ -168,18 +168,6 @@ class NGSearchView(SearchBaseView):
         while area_for_polygons and not area_for_polygons.polygons.exists():
             area_for_polygons = area_for_polygons.parent_area
         return area_for_polygons
-
-    def get_pun_type(self, pun):
-        # use the length of the matched PUN to determine whether
-        # we've matched a ward, an lga or a state
-        # ref: http://www.inecnigeria.org/?page_id=20
-        pun_level = pun.count(':')
-        if pun_level == 2:
-            return 'ward'
-        elif pun_level == 1:
-            return 'local government area'
-        else:
-            return 'state'
 
     def get_district_data(self, districts, role):
         district_list = []

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -155,7 +155,7 @@ class NGSearchView(SearchBaseView):
         forgiving in case of input error.
         """
 
-        return requests.get('https://pu-lookup.herokuapp.com/lookup/{}'.format(pun)).json()
+        return requests.get('https://pu-lookup.herokuapp.com/', params={'lookup': pun}).json()
 
     def get_state(self, matched_pun, state_code, area):
         if ":" in matched_pun:

--- a/pombola/nigeria/views.py
+++ b/pombola/nigeria/views.py
@@ -4,6 +4,8 @@ import requests
 
 from mapit.models import Area
 
+from django.conf import settings
+
 from pombola.core.models import Place
 from pombola.core.views import HomeView
 from pombola.info.models import InfoPage
@@ -155,7 +157,7 @@ class NGSearchView(SearchBaseView):
         forgiving in case of input error.
         """
 
-        return requests.get('https://pu-lookup.herokuapp.com/', params={'lookup': pun}).json()
+        return requests.get(settings.PU_SEARCH_API_URL, params={'lookup': pun}).json()
 
     def get_state(self, matched_pun, state_code, area):
         if ":" in matched_pun:

--- a/pombola/settings/nigeria_base.py
+++ b/pombola/settings/nigeria_base.py
@@ -14,6 +14,8 @@ MAP_BOUNDING_BOX_WEST = 2.5
 
 MAPIT_COUNTRY = 'NG'
 
+PU_SEARCH_API_URL = 'https://pu-lookup.herokuapp.com'
+
 COUNTRY_CSS = {
     'nigeria': {
         'source_filenames': (

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ Markdown==2.5.1
 django-markitup==2.3.0
 
 requests==2.6.0
+requests-mock==0.7.0
 elasticsearch==0.4.5
 django-haystack==2.4.1
 # Required (but not a declared requirement) of elasticsearch


### PR DESCRIPTION
As part of the migration to running ShineYourEye as a static site (https://github.com/theyworkforyou/shineyoureye) we need to extract the PU search, which is a dynamic component, into a separate API.

This change is the incremental step that switches the existing Pombola site to use the new API.

![screen shot 2016-02-23 at 19 31 15](https://cloud.githubusercontent.com/assets/22996/13262228/0d22cf30-da64-11e5-8421-d4daa78eea49.png)

Part of https://github.com/mysociety/pombola/issues/1914
