### PR TITLE
Display notification message on attendance page

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2775,6 +2775,14 @@ p.attendance__disclaimer {
 }
 
 .mp-attendance {
+    #warning-notice {
+        background-color: #e23d28;
+        color: #fff;
+        font-size: 14px;
+        padding: 10px;
+        margin-bottom: 10px;
+    }
+
     .dataTables_wrapper .ui-toolbar {
         padding: 12px 0;
     }

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -17,7 +17,10 @@
 {% block content %}
 <h1 class="page-title">MP Attendance</h1>
 <div class="major-column">
-  <p>Explore the commitee meeting attendance records for the members of parliament.</p>
+  <p>Explore the committee meeting attendance records for the members of parliament.</p>
+</div>
+<div id="warning-notice">
+    Please note: People's Assembly has suspended access to attendance of the MPs of small parties until it gets to grips with the framework under which small parties operate. It is also re-evaluating how to process the attendance of alternate members of committees.
 </div>
 
 <div class='mp-attendance-filter'>


### PR DESCRIPTION
This displays a temporary notice to users until it is determined how treat faulty attendance records for members of small parties.

The API has been updated to returns results as the notice stipulates.