### PR TITLE
[NG] Don't show organization name unless there is one

### DIFF
--- a/pombola/search/templates/search/items/person.html
+++ b/pombola/search/templates/search/items/person.html
@@ -20,7 +20,10 @@
     <p>
 
       {% for position in pos_set|slice:":4" %}
-        <strong>{{ position.title.name }}</strong> of {{ position.organisation.name }};
+        <strong>{{ position.title.name }}</strong>
+        {% if position.organisation.name %}
+          of {{ position.organisation.name }};
+        {% endif %}
       {% empty %}
         No currently active positions found.
       {% endfor %}


### PR DESCRIPTION
Fixes #1981 

![screen shot 2016-03-02 at 11 25 34](https://cloud.githubusercontent.com/assets/22996/13459147/8b1fe73c-e069-11e5-9bbc-18625068b45b.png)
