### PR TITLE
Pluralize is/are in organisation contact details in overview.

### DIFF
--- a/pombola/core/templates/core/organisation_detail.html
+++ b/pombola/core/templates/core/organisation_detail.html
@@ -35,7 +35,7 @@
       <h2>Contact Details</h2>
 
       <p>
-        There are {{ contact_detail_count }}
+        There {{ contact_detail_count|pluralize:"is,are" }} {{ contact_detail_count }}
         way{{ contact_detail_count|pluralize }} to
         <a href="{% url "organisation_contact_details" slug=object.slug %}">get in touch</a>
         with {{ object.name }}.


### PR DESCRIPTION
Fixes #1985

![2016-03-02-113557_1366x768_scrot](https://cloud.githubusercontent.com/assets/56265/13459418/57a5e288-e06b-11e5-8192-ce22429571f8.png)
![2016-03-02-113636_1366x768_scrot](https://cloud.githubusercontent.com/assets/56265/13459421/5ba880de-e06b-11e5-9805-733bab40e384.png)

