### PR TITLE
Remove link on grid view to view past positions

### DIFF
--- a/pombola/core/templates/core/position_detail_grid.html
+++ b/pombola/core/templates/core/position_detail_grid.html
@@ -43,13 +43,5 @@
 
     <br clear="both" />
 
-    <br><br>
-
-    <div>
-        For past position holders please <a href="{% url "position_pt" pt_slug=object.slug %}">view as list</a>.
-    </div>
-
-
-
 {% endblock %}
 


### PR DESCRIPTION
![screen shot 2016-03-02 at 11 43 46](https://cloud.githubusercontent.com/assets/22996/13459507/0f37e068-e06c-11e5-8fc4-9ce969522893.png)

Fixes #1996 