### PR TITLE
[KE]: Fix misleading "No experience" claim

### DIFF
--- a/pombola/core/templates/core/person_position_section.html
+++ b/pombola/core/templates/core/person_position_section.html
@@ -38,6 +38,6 @@
         {% endif %}
     </li>
 {% empty %}
-    <li>No records found.</li>
+    <li>No current positions known.</li>
 {% endfor %}
 </ul>

--- a/pombola/kenya/templates/core/person_detail.html
+++ b/pombola/kenya/templates/core/person_detail.html
@@ -6,7 +6,7 @@
 {% block subcontent %}
 
   <div class="person-detail-experience">
-    <h2><a href="{% url "person_experience" slug=object.slug %}">Experience</a></h2>
+    <h2><a href="{% url "person_experience" slug=object.slug %}">Current positions</a></h2>
     {% include 'core/person_detail_experience_list.html' with positions=object.position_set.all.political.currently_active %}
     <a href="{% url "person_experience" slug=object.slug %}">See full experience</a>
   </div>

--- a/pombola/kenya/templates/core/person_detail_experience_list.html
+++ b/pombola/kenya/templates/core/person_detail_experience_list.html
@@ -31,6 +31,6 @@
         {% endif %}
     </li>
 {% empty %}
-    <li>No records found.</li>
+    <li>No current positions known.</li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
We were saying people had no experience when actually what we meant was
the person had no current positions that we know about. This changes the
text on person pages to make that clearer.

## Person page

![screen shot 2016-03-02 at 14 18 01](https://cloud.githubusercontent.com/assets/22996/13462934/c16de632-e081-11e5-8874-c250ee17e8d4.png)

## Person's experience page

![screen shot 2016-03-02 at 14 18 08](https://cloud.githubusercontent.com/assets/22996/13462941/cbb3e808-e081-11e5-82d9-08d03ce5117a.png)


Fixes #1983 (paired with @duncanparkes)