### PR TITLE
2044 clumsy wording no cdf

### DIFF
--- a/pombola/core/templates/core/place_detail.html
+++ b/pombola/core/templates/core/place_detail.html
@@ -69,18 +69,19 @@
     </p>
   {% endif %}
 
-
   {% if settings.ENABLED_FEATURES.projects and object.is_constituency %}
     {% with project_count=object.project_set.count %}
-      <h2>CDF Projects</h2>
+      {% if project_count %}
+        <h2>CDF Projects</h2>
 
-      <p>
-        We have information on
-        <a href="{% url "place_projects" slug=object.slug %}">
-          {{ project_count}} CDF Projects
-        </a>
-        in {{ object.name }}.
-      </p>
+        <p>
+          We have information on
+          <a href="{% url "place_projects" slug=object.slug %}">
+            {{ project_count}} CDF Project{{ project_count|pluralize }}
+          </a>
+          in {{ object.name }}.
+        </p>
+      {% endif %}
     {% endwith %}
   {% endif %}
 

--- a/pombola/south_africa/templates/core/place_detail.html
+++ b/pombola/south_africa/templates/core/place_detail.html
@@ -89,18 +89,4 @@
         </p>
     {% endif %}
 
-    {% if settings.ENABLED_FEATURES.projects and object.is_constituency %}
-        {% with project_count=object.project_set.count %}
-            <h2>CDF Projects</h2>
-
-            <p>
-            We have information on
-            <a href="{% url "place_projects" slug=object.slug %}">
-                {{ project_count}} CDF Projects
-            </a>
-            in {{ object.name }}.
-            </p>
-        {% endwith %}
-    {% endif %}
-
 {% endblock %}


### PR DESCRIPTION
Fixes #2044 (paired with @chrismytton)
Relates to #2061 

![2016-03-02-151936_1366x768_scrot](https://cloud.githubusercontent.com/assets/56265/13464844/e026ed72-e08a-11e5-845c-236d40c29cd8.png)

Manually adding a CDF project to kaiti-2013 to check the pluralization:
![2016-03-02-152342_1366x768_scrot](https://cloud.githubusercontent.com/assets/56265/13464848/e3c15b98-e08a-11e5-8df4-dc9715d892a8.png)
