### PR TITLE
Open Graph tags

### DIFF
--- a/pombola/core/context_processors.py
+++ b/pombola/core/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.sites.models import Site
 
 
 def add_settings( request ):
@@ -23,3 +24,7 @@ def add_settings( request ):
             'FACEBOOK_APP_ID':              settings.FACEBOOK_APP_ID,
         }
     }
+
+
+def site_processor(request):
+    return {'site': Site.objects.get_current()}

--- a/pombola/core/templates/core/_person_open_graph.html
+++ b/pombola/core/templates/core/_person_open_graph.html
@@ -1,0 +1,21 @@
+{% load absolute_url %}
+
+<meta property="og:title" content="{{ object.name }}" />
+<meta property="og:site_name" content="{{ site.name }}" />
+<meta property="og:type" content="profile" />
+{% if object.primary_image %}
+<meta property="og:image" content="{{ object.primary_image.url|absolute_url:request }}" />
+{% endif %}
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+{% if object.summary %}
+<meta property="og:description" content="{{ object.summary|striptags }}" />
+{% endif %}
+{% if object.given_name %}
+<meta property="profile:first_name" content="{{ object.given_name }}" />
+{% endif %}
+{% if object.family_name %}
+<meta property="profile:last_name" content="{{ object.family_name }}" />
+{% endif %}
+{% if object.gender %}
+<meta property="profile:gender" content="{{ object.gender }}" />
+{% endif %}

--- a/pombola/core/templates/core/organisation_base.html
+++ b/pombola/core/templates/core/organisation_base.html
@@ -1,5 +1,6 @@
 {% extends 'core/object_base.html' %}
 {% load thumbnail %}
+{% load absolute_url %}
 
 {% block title %}{{ object.name }}{% endblock %}
 
@@ -12,6 +13,19 @@
     <![endif]-->
   {% endif %}
 {% endblock%}
+
+{% block open_graph %}
+<meta property="og:title" content="{{ object.name }}" />
+<meta property="og:site_name" content="{{ site.name }}" />
+<meta property="og:type" content="website" />
+{% if object.primary_image %}
+<meta property="og:image" content="{{ object.primary_image.url|absolute_url:request }}" />
+{% endif %}
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+{% if object.summary %}
+<meta property="og:description" content="{{ object.summary|striptags }}" />
+{% endif %}
+{% endblock %}
 
 {% block object_menu_links %}
 

--- a/pombola/core/templates/core/person_base.html
+++ b/pombola/core/templates/core/person_base.html
@@ -1,6 +1,5 @@
 {% extends 'core/object_base.html' %}
 {% load thumbnail %}
-{% load absolute_url %}
 
 {% block title %}{{ object.name }}{% endblock %}
 
@@ -14,16 +13,7 @@
   {% endif %}
 {% endblock%}
 
-{% block open_graph %}
-<meta property="og:title" content="{{ object.name }}" />
-<meta property="og:type" content="profile" />
-<meta property="og:image" content="{{ object.primary_image.url|absolute_url:request }}" />
-<meta property="og:url" content="{{ request.build_absolute_uri }}" />
-<meta property="og:description" content="{{ object.summary|striptags }}" />
-<meta property="profile:first_name" content="{{ object.first_name }}" />
-<meta property="profile:last_name" content="{{ object.last_name }}" />
-<meta property="profile:gender" content="{{ object.gender }}" />
-{% endblock %}
+{% block open_graph %}{% include 'core/_person_open_graph.html' %}{% endblock %}
 
 {% block object_menu_links %}
   {% include 'core/person_menu.html' %}

--- a/pombola/core/templates/core/place_base.html
+++ b/pombola/core/templates/core/place_base.html
@@ -4,6 +4,7 @@
 {% load humanize %}
 {% load hidden %}
 {% load pipeline %}
+{% load absolute_url %}
 
 {% block title %}{{ object.name }}{% endblock %}
 
@@ -16,6 +17,19 @@
     <![endif]-->
   {% endif %}
 {% endblock%}
+
+{% block open_graph %}
+<meta property="og:title" content="{{ object.name }}" />
+<meta property="og:site_name" content="{{ site.name }}" />
+<meta property="og:type" content="place" />
+{% if object.primary_image %}
+<meta property="og:image" content="{{ object.primary_image.url|absolute_url:request }}" />
+{% endif %}
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+{% if object.summary %}
+<meta property="og:description" content="{{ object.summary|striptags }}" />
+{% endif %}
+{% endblock %}
 
 {% block object_menu_links %}
   {% include 'core/_object_menu_link.html' with url_name='place' link_text='Overview' %}

--- a/pombola/core/tests/test_open_graph.py
+++ b/pombola/core/tests/test_open_graph.py
@@ -1,0 +1,86 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from pombola.core import models
+from pombola.info.models import InfoPage
+
+
+class OpenGraphTest(TestCase):
+    def test_open_graph_tags_on_homepage(self):
+        response = self.client.get('/')
+        self.assertContains(response, '<meta property="og:title" content="example.com" />')
+        self.assertContains(response, '<meta property="og:type" content="website" />')
+        self.assertContains(response, '<meta property="og:url" content="http://testserver/" />')
+
+    def test_open_graph_tags_for_person(self):
+        person = models.Person.objects.create(
+            slug='bob',
+            legal_name='Bob Test',
+            summary='Test summary',
+            given_name='Bob',
+            family_name='Test',
+            gender='male')
+
+        response = self.client.get(reverse('person', kwargs={'slug': person.slug}))
+
+        self.assertContains(response, '<meta property="og:title" content="Bob Test" />')
+        self.assertContains(response, '<meta property="og:site_name" content="example.com" />')
+        self.assertContains(response, '<meta property="og:type" content="profile" />')
+        self.assertContains(response, '<meta property="og:url" content="http://testserver/person/bob/" />')
+        self.assertContains(response, '<meta property="og:description" content="Test summary" />')
+        self.assertContains(response, '<meta property="profile:first_name" content="Bob" />')
+        self.assertContains(response, '<meta property="profile:last_name" content="Test" />')
+        self.assertContains(response, '<meta property="profile:gender" content="male" />')
+
+    def test_open_graph_tags_for_orgs(self):
+        organisation_kind = models.OrganisationKind.objects.create(
+            name='Political',
+            slug='political')
+
+        org = models.Organisation.objects.create(
+            slug='test-org',
+            name='Test Org',
+            summary='A Test Org.',
+            kind=organisation_kind)
+
+        response = self.client.get(reverse('organisation', kwargs={'slug': org.slug}))
+
+        self.assertContains(response, '<meta property="og:title" content="Test Org" />')
+        self.assertContains(response, '<meta property="og:site_name" content="example.com" />')
+        self.assertContains(response, '<meta property="og:type" content="website" />')
+        self.assertContains(response, '<meta property="og:url" content="http://testserver/organisation/test-org/" />')
+        self.assertContains(response, '<meta property="og:description" content="A Test Org." />')
+
+    def test_open_graph_tags_for_places(self):
+        place_kind = models.PlaceKind.objects.create(
+            name='Test Place',
+            slug='test-place')
+
+        place = models.Place.objects.create(
+            name='The Place',
+            slug='place',
+            kind=place_kind)
+
+        response = self.client.get(reverse('place', kwargs={'slug': place.slug}))
+
+        self.assertContains(response, '<meta property="og:title" content="The Place" />')
+        self.assertContains(response, '<meta property="og:site_name" content="example.com" />')
+        self.assertContains(response, '<meta property="og:type" content="place" />')
+        self.assertContains(response, '<meta property="og:url" content="http://testserver/place/place/" />')
+
+    def test_open_graph_tags_for_blog_posts(self):
+        post = InfoPage.objects.create(
+            slug='post',
+            title='Example title',
+            raw_content='Example content',
+            use_raw=True,
+            kind=InfoPage.KIND_BLOG,
+        )
+
+        response = self.client.get(reverse('info_blog', kwargs={'slug': post.slug}))
+
+        self.assertContains(response, '<meta property="og:title" content="Example title" />')
+        self.assertContains(response, '<meta property="og:site_name" content="example.com" />')
+        self.assertContains(response, '<meta property="og:type" content="article" />')
+        self.assertContains(response, '<meta property="og:url" content="http://testserver/blog/post" />')
+        self.assertContains(response, '<meta property="article:published_time" content="{}" />'.format(post.publication_date.isoformat()))

--- a/pombola/core/tests/test_views.py
+++ b/pombola/core/tests/test_views.py
@@ -133,7 +133,7 @@ class PositionViewTest(WebTest):
 
     def test_organisation_page(self):
         self.app.get('/organisation/missing-org/', status=404)
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             resp = self.app.get('/organisation/test-org/')
         resp.mustcontain('Test Org')
         resp = self.app.get('/organisation/test-org/people/')

--- a/pombola/info/templates/info/_blog_open_graph.html
+++ b/pombola/info/templates/info/_blog_open_graph.html
@@ -1,0 +1,10 @@
+{% load absolute_url %}
+
+<meta property="og:title" content="{{ object.title }}" />
+<meta property="og:site_name" content="{{ site.name }}" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+{% if object.featured_image_file %}
+<meta property="og:image" content="{{ object.featured_image_file.url|absolute_url:request }}" />
+{% endif %}
+<meta property="article:published_time" content="{{ object.publication_date|date:"c" }}" />

--- a/pombola/info/templates/info/blog_post.html
+++ b/pombola/info/templates/info/blog_post.html
@@ -4,6 +4,8 @@
     {{ object.title }}
 {% endblock %}
 
+{% block open_graph %}{% include 'info/_blog_open_graph.html' %}{% endblock %}
+
 {% block content %}
 
 

--- a/pombola/kenya/templates/core/person_base.html
+++ b/pombola/kenya/templates/core/person_base.html
@@ -4,6 +4,8 @@
 
 {% block title %}{{ object.name }}{% endblock %}
 
+{% block open_graph %}{% include 'core/_person_open_graph.html' %}{% endblock %}
+
 {% block object_menu_links %}{% endblock %}
 
 {% block object_tagline %}

--- a/pombola/nigeria/templates/info/blog_post.html
+++ b/pombola/nigeria/templates/info/blog_post.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block open_graph %}{% include 'info/_blog_open_graph.html' %}{% endblock %}
+
 {% block title %}
     {{ object.title }}
 {% endblock %}

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -206,6 +206,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.request",
     "django.contrib.messages.context_processors.messages",
     "pombola.core.context_processors.add_settings",
+    "pombola.core.context_processors.site_processor",
 )
 
 MAPIT_AREA_SRID = 4326

--- a/pombola/south_africa/templates/info/blog_post.html
+++ b/pombola/south_africa/templates/info/blog_post.html
@@ -14,6 +14,8 @@
   {% endif %}
 {% endblock%}
 
+{% block open_graph %}{% include 'info/_blog_open_graph.html' %}{% endblock %}
+
 {% block content %}
 
 {% include "disqus_javascript.html" %}

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1343,7 +1343,7 @@ class SAOrganisationDetailViewTestParliament(WebTest):
         )
 
     def test_counts_and_percentages(self):
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.app.get('/organisation/model-parliament/')
         ps_and_ps = response.context['parties_counts_and_percentages']
         self.assertEqual(2, len(ps_and_ps))

--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -24,6 +24,9 @@
         {% endblock%}
 
         {% block open_graph %}
+        <meta property="og:title" content="{{ site.name }}" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="{{ request.build_absolute_uri }}" />
         {% endblock %}
 
         {% block css_headers %}


### PR DESCRIPTION
This adds some default Open Graph tags to all pages on the website. It also adds specific Open Graph tags for Organizations, Places and blog posts.

Fixes https://github.com/mysociety/pombola/issues/2047
Fixes https://github.com/mysociety/pombola/issues/2048
Fixes https://github.com/mysociety/pombola/issues/1956
Fixes https://github.com/mysociety/pombola/issues/1955