### PR TITLE
Get rid of 'patterns' function from urls files.

### DIFF
--- a/pombola/bills/urls.py
+++ b/pombola/bills/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from pombola.bills.views import IndexView, BillListView
 
-urlpatterns = patterns('pombola.bills.views',
+
+urlpatterns = [
     url( r'^$', IndexView.as_view(), name="index" ),
     url( r'^(?P<session_slug>[\w\-]+)/$', BillListView.as_view(), name="list" ),
-)
+]

--- a/pombola/core/urls.py
+++ b/pombola/core/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.views.generic import TemplateView, ListView, RedirectView
 
@@ -7,9 +7,18 @@ from pombola.core import models
 from pombola.core.views import (HomeView, PlaceDetailView,
     OrganisationList, OrganisationKindList, PlaceKindList, PersonDetail,
     PersonDetailSub, PlaceDetailSub, OrganisationDetailSub,
-    OrganisationDetailView, HelpApiView)
+    OrganisationDetailView, HelpApiView,
+    featured_person,
+    parties,
+    memcached_status,
+    position_pt,
+    position_pt_ok,
+    position_pt_ok_o,
+    robots,
+    )
 
-person_patterns = patterns('pombola.core.views',
+
+person_patterns = [
     url(r'^all/',
         ListView.as_view(model=models.Person),
         name='person_list'),
@@ -25,37 +34,32 @@ person_patterns = patterns('pombola.core.views',
 
     # featured person ajax load
     url(r'^featured/((?P<direction>(before|after))/)?(?P<current_slug>[-\w]+)',
-        'featured_person',
+        featured_person,
         name='featured_person'),
 
     url(r'^(?P<slug>[-\w]+)/$', PersonDetail.as_view(), name='person'),
-
-  )
+]
 
 for sub_page in ['scorecard', 'comments', 'experience', 'appearances', 'contact_details']:
-    person_patterns += patterns(
-        'pombola.core.views',
+    person_patterns += (
         url(
             '^(?P<slug>[-\w]+)/%s/$' % sub_page,
             PersonDetailSub.as_view(sub_page=sub_page),
             name='person_%s' % sub_page,
-        )
+        ),
     )
 
 if settings.ENABLED_FEATURES['bills']:
-    person_patterns += patterns(
-        'pombola.core.views',
+    person_patterns += (
         url(
             '^(?P<slug>[-\w]+)/bills/',
             PersonDetailSub.as_view(sub_page='bills'),
             name='person_bills',
-        )
+        ),
     )
 
 
-
-place_patterns = patterns('pombola.core.views',
-
+place_patterns = [
     url( r'^all/', PlaceKindList.as_view(), name='place_kind_all' ),
     url( r'^is/(?P<slug>[-\w]+)/$', PlaceKindList.as_view(), name='place_kind'     ),
     url( r'^is/(?P<slug>[-\w]+)/(?P<session_slug>[-\w]+)/?', PlaceKindList.as_view(), name='place_kind'     ),
@@ -72,60 +76,58 @@ place_patterns = patterns('pombola.core.views',
         r'^(?P<slug>[-\w]+)/candidates/$',
         RedirectView.as_view(url='/place/%(slug)s/aspirants', permanent=True),
     ),
-)
+]
 
 for sub_page in ['aspirants', 'election', 'scorecard', 'comments', 'people', 'places', 'organisations', 'data', 'projects', 'budgets']:
-    place_patterns += patterns(
-        'pombola.core.views',
+    place_patterns += (
         url(
             '^(?P<slug>[-\w]+)/%s/' % sub_page,
             PlaceDetailSub.as_view(sub_page=sub_page),
             name='place_%s' % sub_page,
-        )
+        ),
     )
 
 
-organisation_patterns = patterns('pombola.core.views',
+organisation_patterns = [
     url(r'^all/', OrganisationList.as_view(), name='organisation_list'),
     url(r'^is/(?P<slug>[-\w]+)/', OrganisationKindList.as_view(), name='organisation_kind'),
     url(r'^(?P<slug>[-\w]+)/$', OrganisationDetailView.as_view(), name='organisation'),
-)
+]
 
 for sub_page in ['comments', 'contact_details', 'people']:
-    organisation_patterns += patterns(
-        'pombola.core.views',
+    organisation_patterns += (
         url(
             '^(?P<slug>[-\w]+)/%s/' % sub_page,
             OrganisationDetailSub.as_view(sub_page=sub_page),
             name='organisation_%s' % sub_page,
-        )
+        ),
     )
 
 organisation_patterns_path = r'^organisation/'
 person_patterns_path = r'^person/'
 place_patterns_path = r'^place/'
 
-urlpatterns = patterns('pombola.core.views',
+urlpatterns = [
     # Homepage
     url(r'^$', HomeView.as_view(), name='home'),
 
-    (person_patterns_path, include(person_patterns)),
-    (place_patterns_path, include(place_patterns)),
-    (organisation_patterns_path, include(organisation_patterns)),
+    url(person_patterns_path, include(person_patterns)),
+    url(place_patterns_path, include(place_patterns)),
+    url(organisation_patterns_path, include(organisation_patterns)),
 
-    url(r'^position/(?P<pt_slug>[-\w]+)/$', 'position_pt', name='position_pt'),
-    url(r'^position/(?P<pt_slug>[-\w]+)/(?P<ok_slug>[-\w]+)/$', 'position_pt_ok', name='position_pt_ok'),
-    url(r'^position/(?P<pt_slug>[-\w]+)/(?P<ok_slug>[-\w]+)/(?P<o_slug>[-\w]+)/$', 'position_pt_ok_o', name='position_pt_ok_o'),
+    url(r'^position/(?P<pt_slug>[-\w]+)/$', position_pt, name='position_pt'),
+    url(r'^position/(?P<pt_slug>[-\w]+)/(?P<ok_slug>[-\w]+)/$', position_pt_ok, name='position_pt_ok'),
+    url(r'^position/(?P<pt_slug>[-\w]+)/(?P<ok_slug>[-\w]+)/(?P<o_slug>[-\w]+)/$', position_pt_ok_o, name='position_pt_ok_o'),
 
     # specials
-    url(r'^parties', 'parties', name='parties'),
+    url(r'^parties', parties, name='parties'),
 
     # Ajax select
     url(r'^ajax_select/', include('ajax_select.urls')),
-)
+]
 
-urlpatterns += patterns('pombola.core.views',
-    url(r'^status/memcached/',       'memcached_status', name='memcached_status'),
+urlpatterns += (
+    url(r'^status/memcached/', memcached_status, name='memcached_status'),
 )
 
 if settings.POPIT_API_URL:
@@ -136,7 +138,7 @@ if settings.POPIT_API_URL:
 
 # Make it easy to see the various error pages without having to fiddle with the
 # STAGING settings.
-urlpatterns += patterns('',
+urlpatterns += (
     url(r'^status/down/', TemplateView.as_view(template_name='down.html') ),
     url(r'^status/404/',  TemplateView.as_view(template_name='404.html') ),
     url(r'^status/500/',  TemplateView.as_view(template_name='500.html') ),
@@ -146,11 +148,11 @@ urlpatterns += patterns('',
 # We handle the robots here rather than as a static file so that we can send
 # different content on a staging server. We don't use direct_to_template as we
 # want to set some caching headers too.
-urlpatterns += patterns('pombola.core.views',
-    url(r'robots.txt', 'robots' ),
+urlpatterns += (
+    url(r'robots.txt', robots),
 )
 
 # A URL for testing jQuery UI components:
-urlpatterns += patterns('pombola.core.views',
+urlpatterns += (
     url(r'^ui-test', TemplateView.as_view(template_name='ui-test.html')),
 )

--- a/pombola/feedback/urls.py
+++ b/pombola/feedback/urls.py
@@ -1,5 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('pombola.feedback.views',
-    url( r'^$',       'add',    name='feedback_add'    ),
-)
+from .views import add
+
+
+urlpatterns = [
+    url(r'^$', add, name='feedback_add'),
+]

--- a/pombola/file_archive/urls.py
+++ b/pombola/file_archive/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import views
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url( r'^(?P<slug>[\w\-]+)$', views.redirect_to_file, name='file_archive' ),
-)
+]

--- a/pombola/ghana/urls.py
+++ b/pombola/ghana/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from .views import data_upload, info_page_upload
 
-urlpatterns = patterns('',
+
+urlpatterns = [
     url(r'^data/upload/mps/$', data_upload, name='data_upload'),
     url(r'^data/upload/info-page/$', info_page_upload, name='info_page_upload'),
     url('', include('django.contrib.auth.urls')),
-)
+]

--- a/pombola/hansard/urls.py
+++ b/pombola/hansard/urls.py
@@ -1,8 +1,13 @@
-from django.conf.urls import patterns, url
-from pombola.hansard.views import IndexView, SittingView, PersonAllAppearancesView
+from django.conf.urls import url
+from pombola.hansard.views import (
+    IndexView,
+    person_summary,
+    PersonAllAppearancesView,
+    SittingView,
+    )
 
 
-urlpatterns = patterns('pombola.hansard.views',
+urlpatterns = [
     url( r'^$', IndexView.as_view(), name="index" ),
 
     # not the final URL structure - but something to start work with
@@ -21,7 +26,7 @@ urlpatterns = patterns('pombola.hansard.views',
 
 
     # views for a specific person
-    url( r'^person/(?P<slug>[\w\-]+)/summary/', 'person_summary', name='person_summary' ),
+    url(r'^person/(?P<slug>[\w\-]+)/summary/', person_summary, name='person_summary'),
     # url( r'^person/(?P<slug>[\w\-]+)/',         'person_entries', name='person_entries' ),
 
     # 'Show All' page for a specific person
@@ -29,6 +34,5 @@ urlpatterns = patterns('pombola.hansard.views',
         r'^person/(?P<slug>[\w\-]+)/appearances/',
         PersonAllAppearancesView.as_view(),
         name='person_appearances_all',
-    )
-
-)
+    ),
+]

--- a/pombola/kenya/urls.py
+++ b/pombola/kenya/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic.base import TemplateView, RedirectView
 from pombola.kenya.views import (
     KEPersonDetail,
@@ -17,7 +17,8 @@ from .views import (CountyPerformanceView, CountyPerformanceSenateSubmission,
     ShujaazFinalists2014View, ShujaazFinalists2015View
 )
 
-urlpatterns = patterns('',
+
+urlpatterns = [
     url(r'^shujaaz$',
         RedirectView.as_view(
             pattern_name='shujaaz-finalists-2015',
@@ -46,7 +47,7 @@ urlpatterns = patterns('',
             ),
         {'slug': 'party'},
         ),
-)
+]
 
 # Create the two County Performance pages:
 

--- a/pombola/libya/urls.py
+++ b/pombola/libya/urls.py
@@ -1,5 +1,2 @@
-from django.conf.urls import patterns
+# There are no overridden urls for Libya, yet....
 
-urlpatterns = patterns('',
-    # There are no overridden urls for Libya, yet....
-)

--- a/pombola/map/urls.py
+++ b/pombola/map/urls.py
@@ -1,5 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('pombola.map.views',
-    url(r'^$', 'home', name='map-home'),
-)
+from pombola.map.views import home
+
+
+urlpatterns = [
+    url(r'^$', home, name='map-home'),
+]

--- a/pombola/nigeria/urls.py
+++ b/pombola/nigeria/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import NGHomeView, NGSearchView
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', NGHomeView.as_view(), name='home'),
     url(r'^search/$', NGSearchView.as_view(), name='core_search'),
-)
+]

--- a/pombola/projects/urls.py
+++ b/pombola/projects/urls.py
@@ -1,7 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 import views
 
-urlpatterns = patterns('',
+
+urlpatterns = [
     url(r'^in/(?P<slug>[-\w]+)/', views.in_place, name='project_in_place'),
-)
+]

--- a/pombola/search/urls.py
+++ b/pombola/search/urls.py
@@ -1,13 +1,16 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.conf import settings
 
-from .views import SearchBaseView, GeocoderView
+from .views import (
+    autocomplete,
+    GeocoderView,
+    SearchBaseView,
+    )
 
 
-urlpatterns = patterns('pombola.search.views',
-
+urlpatterns = [
     # Haystack and other searches
-    url( r'^autocomplete/', 'autocomplete',           name="autocomplete"        ),
+    url(r'^autocomplete/', autocomplete, name="autocomplete"),
 
     url(r'^$',
         SearchBaseView.as_view(),
@@ -19,16 +22,15 @@ urlpatterns = patterns('pombola.search.views',
         GeocoderView.as_view(),
         name='core_geocoder_search'
     ),
-
-)
+]
 
 # Hansard search - only loaded if hansard is enabled
 if settings.ENABLED_FEATURES['hansard']:
     from .views import HansardSearchView
-    urlpatterns += patterns('pombola.search.views',
+    urlpatterns.append(
         url(
             r'^hansard/$',
             HansardSearchView.as_view(),
             name='hansard_search',
-        ),
-    )
+            )
+        )

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -1,6 +1,6 @@
 import copy
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.views.generic.base import RedirectView, TemplateView
 
 from pombola.south_africa import views
@@ -116,20 +116,18 @@ place_patterns.extend((
         name='latlon'),
     ))
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     # Include the overriden person, organisation paths
-    (person_patterns_path, include(person_patterns)),
-    (place_patterns_path, include(place_patterns)),
-    (organisation_patterns_path, include(organisation_patterns)),
+    url(person_patterns_path, include(person_patterns)),
+    url(place_patterns_path, include(place_patterns)),
+    url(organisation_patterns_path, include(organisation_patterns)),
 
     # Override the home view:
     url(r'^$', SAHomeView.as_view(), name='home'),
-    )
+    ]
 
 # This is for the Code4SA ward councillor widget lookup:
-urlpatterns += patterns('',
+urlpatterns += (
     url(r'^ward-councillor-lookup/$',
         TemplateView.as_view(template_name='south_africa/ward_councillor_lookup.html'),
         name='ward-councillor-lookup'
@@ -137,7 +135,7 @@ urlpatterns += patterns('',
 )
 
 # MP attendance overview
-urlpatterns += patterns('',
+urlpatterns += (
     url(r'^mp-attendance/$',
         views.SAMpAttendanceView.as_view(),
         name='mp-attendance'
@@ -145,8 +143,7 @@ urlpatterns += patterns('',
 )
 
 # Routing for election pages
-urlpatterns += patterns('',
-
+urlpatterns += (
     # Overview pages
     url(r'^election/$',
         RedirectView.as_view(
@@ -219,7 +216,7 @@ for index, pattern in enumerate(search_urlpatterns):
     if pattern.name == 'core_search':
         search_urlpatterns[index] = url(r'^$', SASearchView.as_view(), name='core_search')
 
-urlpatterns += patterns('pombola.south_africa.views',
+urlpatterns += (
     # We want to override the location search view, so that we can
     # redirect straight to the results page if there's a unique result
     # returned.
@@ -232,7 +229,7 @@ urlpatterns += patterns('pombola.south_africa.views',
 
 
 # Members' interests browser
-urlpatterns += patterns('',
+urlpatterns += (
     url(
         r'^interests/$',
         views.SAMembersInterestsIndex.as_view(),

--- a/pombola/spinner/urls.py
+++ b/pombola/spinner/urls.py
@@ -1,12 +1,12 @@
 # Commented out as unused, but possibly useful in future
 
-# from django.conf.urls import patterns, include, url
+# from django.conf.urls import include, url
 #
 # from django.views.generic import ListView, TemplateView
 #
 # from .views import SlideAfterView
 #
-# urlpatterns = patterns( '',
+# urlpatterns = [
 #     url( r'^random$', TemplateView.as_view(template_name='spinner/random.html'), name='spinner_random' ),
 #     url( r'^after$',  SlideAfterView.as_view(), name='spinner_slide_after' ),
-# )
+# ]

--- a/pombola/urls.py
+++ b/pombola/urls.py
@@ -1,10 +1,11 @@
 import re
 
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.views.static import serve
 
 from rest_framework import routers
 
@@ -19,8 +20,9 @@ urlpatterns = []
 # does not appear to support fallthrough from controllers:
 # http://stackoverflow.com/questions/4495763/fallthrough-in-django-urlconf
 if settings.COUNTRY_APP:
-    urlpatterns += patterns('',
-        (r'^', include('pombola.' + settings.COUNTRY_APP + '.urls')),)
+    urlpatterns += (
+        url(r'^', include('pombola.' + settings.COUNTRY_APP + '.urls')),
+    )
 
 # Add the API urls:
 api_router = routers.DefaultRouter()
@@ -33,13 +35,13 @@ if settings.ENABLED_FEATURES['hansard']:
     api_router.register(r'hansard/sources', SourceViewSet)
     api_router.register(r'hansard/venues', VenueViewSet)
 
-urlpatterns += [
+urlpatterns += (
     url(r'^api/(?P<version>v0.1)/', include(api_router.urls)),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-]
+)
 
 from ajax_select import urls as ajax_select_urls
-urlpatterns += patterns('',
+urlpatterns += (
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/lookups/', include(ajax_select_urls)),
     url(r'^admin/', include(admin.site.urls)),
@@ -47,42 +49,42 @@ urlpatterns += patterns('',
 )
 
 # mapit
-urlpatterns += patterns('',
-    (r'^mapit/', include('mapit.urls')),
+urlpatterns += (
+    url(r'^mapit/', include('mapit.urls')),
 )
 
 # Info pages
-urlpatterns += patterns('',
-    (r'^info/', include('pombola.info.urls.pages')),
-    (r'^blog/', include('pombola.info.urls.blog')),
+urlpatterns += (
+    url(r'^info/', include('pombola.info.urls.pages')),
+    url(r'^blog/', include('pombola.info.urls.blog')),
 )
 
 # File archive
-urlpatterns += patterns('',
-    (r'^file_archive/', include('pombola.file_archive.urls')),
+urlpatterns += (
+    url(r'^file_archive/', include('pombola.file_archive.urls')),
 )
 
 # SayIt - speeches
 #if settings.ENABLED_FEATURES['speeches']:
-#    urlpatterns += patterns('',
-#        (r'^speeches/', include('speeches.urls', namespace='speeches', app_name='speeches-default')),
+#    urlpatterns += (
+#        url(r'^speeches/', include('speeches.urls', namespace='speeches', app_name='speeches-default')),
 #    )
 
 # Hansard pages
 if settings.ENABLED_FEATURES['hansard']:
-    urlpatterns += patterns('',
-        (r'^hansard/', include('pombola.hansard.urls', namespace='hansard', app_name='hansard')),
+    urlpatterns += (
+        url(r'^hansard/', include('pombola.hansard.urls', namespace='hansard', app_name='hansard')),
     )
 
 # Project pages
 if settings.ENABLED_FEATURES['projects']:
-    urlpatterns += patterns('',
-        (r'^projects/', include('pombola.projects.urls')),
+    urlpatterns += (
+        url(r'^projects/', include('pombola.projects.urls')),
     )
 
 # ajax preview of the markdown
-urlpatterns += patterns('',
-    url(r'^markitup/', include('markitup.urls'))
+urlpatterns += (
+    url(r'^markitup/', include('markitup.urls')),
 )
 
 urlpatterns += staticfiles_urlpatterns()
@@ -91,64 +93,65 @@ urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # needed for the selenium tests.
 if settings.IN_TEST_MODE:
     static_url = re.escape(settings.STATIC_URL.lstrip('/'))
-    urlpatterns += patterns('',
-        url(r'^%s(?P<path>.*)$' % static_url, 'django.views.static.serve', {
+    urlpatterns += (
+        url(r'^%s(?P<path>.*)$' % static_url, serve, {
             'document_root': settings.STATIC_ROOT,
         }),
     )
 
 # search
-urlpatterns += patterns('',
-    (r'^search/', include('pombola.search.urls')),
+urlpatterns += (
+    url(r'^search/', include('pombola.search.urls')),
 )
 
 # wordcloud
 if settings.ENABLED_FEATURES['wordcloud']:
-    urlpatterns += patterns('',
-        (r'^wordcloud/', include('pombola.wordcloud.urls')),
+    urlpatterns += (
+        url(r'^wordcloud/', include('pombola.wordcloud.urls')),
 
         # Temporarily keep tagcloud version of the url as well.
-        (r'^tagcloud/', include('pombola.wordcloud.urls')),
+        url(r'^tagcloud/', include('pombola.wordcloud.urls')),
     )
 
 # feedback
-urlpatterns += patterns('',
-    (r'^feedback/', include('pombola.feedback.urls')),
+urlpatterns += (
+    url(r'^feedback/', include('pombola.feedback.urls')),
 )
 
 # map
-urlpatterns += patterns('',
-    (r'^map/', include('pombola.map.urls')),
+urlpatterns += (
+    url(r'^map/', include('pombola.map.urls')),
 )
 
 # votematch
 if settings.ENABLED_FEATURES['votematch']:
-    urlpatterns += patterns('',
-        (r'^votematch/', include('pombola.votematch.urls')),
+    urlpatterns += (
+        url(r'^votematch/', include('pombola.votematch.urls')),
     )
 
 
 # # spinner - uncomment if needed. Not needed just to display spinner on the
 # # homepage using carousel.
 # if settings.ENABLED_FEATURES['spinner']:
-#     urlpatterns += patterns('',
-#         (r'^spinner/', include('pombola.spinner.urls')),
+#     urlpatterns += (
+#         url(r'^spinner/', include('pombola.spinner.urls')),
 #     )
 
 # bills
 if settings.ENABLED_FEATURES['bills']:
-    urlpatterns += patterns('',
-        (r'^bills/', include('pombola.bills.urls', namespace='bills', app_name='bills')),
+    urlpatterns += (
+        url(r'^bills/', include('pombola.bills.urls', namespace='bills', app_name='bills')),
     )
 
 
 # Everything else goes to core
-urlpatterns += patterns('',
-    (r'^', include('pombola.core.urls')),
+urlpatterns += (
+    url(r'^', include('pombola.core.urls')),
 )
 
 # For South Africa, we need SayIt to catch any otherwise unmatched
 # URLs, so this has to come last:
 if settings.COUNTRY_APP and settings.COUNTRY_APP == 'south_africa':
-    urlpatterns += patterns('',
-        (r'^', include('pombola.south_africa.fallback_urls')),)
+    urlpatterns += (
+        url(r'^', include('pombola.south_africa.fallback_urls')),
+    )

--- a/pombola/votematch/urls.py
+++ b/pombola/votematch/urls.py
@@ -1,12 +1,15 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from django.views.generic import ListView, TemplateView
 
 from .models import Quiz
+from .views import (
+    quiz_detail,
+    submission_detail,
+    )
 
 
-urlpatterns = patterns( 'pombola.votematch.views',
-
+urlpatterns = [
     # .../                # list of quizzes
     url( r'^$', ListView.as_view(model=Quiz), name='votematch-quiz-list' ),
 
@@ -14,9 +17,9 @@ urlpatterns = patterns( 'pombola.votematch.views',
     url( r'^scoring/$', TemplateView.as_view(template_name='votematch/scoring.html'), name='votematch-scoring' ),
 
     # .../<slug>/         # individual quiz form (submit on POST)
-    url( r'^(?P<slug>[-\w]+)/$', 'quiz_detail', name='votematch-quiz' ),
+    url( r'^(?P<slug>[-\w]+)/$', quiz_detail, name='votematch-quiz' ),
 
     # .../<slug>/<token>/ # individual result
     # Can't use a detail view as that wants a pk or a slug. Does not like 'token'...
-    url( r'^(?P<slug>[-\w]+)/(?P<token>[-\w]+)/$', 'submission_detail', name='votematch-submission' ),
-)
+    url( r'^(?P<slug>[-\w]+)/(?P<token>[-\w]+)/$', submission_detail, name='votematch-submission' ),
+]

--- a/pombola/wordcloud/urls.py
+++ b/pombola/wordcloud/urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic.base import RedirectView
 
 from .views import wordcloud
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^wordcloud/$', wordcloud, name='wordcloud'),
     url(r'^wordcloud/(?P<max_entries>\d+)/$', wordcloud, name='wordcloud'),
 
@@ -13,4 +12,4 @@ urlpatterns = patterns(
         RedirectView.as_view(pattern_name='wordcloud', permanent=True)),
     url(r'^tagcloud/(?P<max_entries>\d+)/$',
         RedirectView.as_view(pattern_name='wordcloud', permanent=True)),
-    )
+]

--- a/pombola/zimbabwe/urls.py
+++ b/pombola/zimbabwe/urls.py
@@ -1,5 +1,2 @@
-from django.conf.urls import patterns
+# There are no overridden urls for Zimbabwe, yet....
 
-urlpatterns = patterns('',
-    # There are no overridden urls for Zimbabwe, yet....
-)


### PR DESCRIPTION
Calls to the patterns function can be replaced with just lists
from Django 1.8.

https://docs.djangoproject.com/es/1.9/releases/1.8/#django-conf-urls-patterns