### PR TITLE
Link to a more descriptive page in the footer

### DIFF
--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -173,7 +173,7 @@
 
             <div class="attribution">
 
-              <p>This site runs on <a href="https://github.com/mysociety/pombola">open source code</a> written by <a href="http://www.mysociety.org">mySociety</a>.</p>
+              <p>This site runs on <a href="https://www.mysociety.org/projects/parliamentary-monitoring/pombola/">open source code</a> written by <a href="http://www.mysociety.org">mySociety</a>.</p>
 
               {% block extra_attribution %}
               {% endblock %}


### PR DESCRIPTION
Rather than linking to the GitHub repo link to the mySociety site which
has a better explanation of Pombola and the problems it solves.

Fixes https://github.com/mysociety/pombola/issues/1905