### PR TITLE
WIP: 1984 nominated members inconsistency

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1357,7 +1357,7 @@ class Position(ModelBase, IdentifierMixin):
         self.sorting_end_date_high   = re.sub('-00', '-99', sorting_end_date)
 
     def is_nominated_politician(self):
-        return self.title.slug == 'nominated-member-parliament'
+        return self.subtitle == 'Nominated'
 
     def save(self, *args, **kwargs):
         self._set_sorting_dates()

--- a/pombola/core/templates/core/position_list_item.html
+++ b/pombola/core/templates/core/position_list_item.html
@@ -16,11 +16,8 @@
   <h4>{% maybehidden object.person user %}{{ object.person.name }}{% endmaybehidden %}</h4>
   {% if object.place %}
     <p>Member for {{ object.place.name }}</p>
-  {% else %}
-    {# Bring on the elif clause! #}
-    {% if object.is_nominated_politician %} 
-      <p>Nominated Member</p>
-    {% endif %}
+  {% elif object.is_nominated_politician %}
+    <p>Nominated Member</p>
   {% endif %}
   {% if not object.person.hidden %}
     <div class="read-more-wrap"><a href="{{ object.person.get_absolute_url }}" class="read-more">read more</a></div>

--- a/pombola/search/templates/search/items/position.html
+++ b/pombola/search/templates/search/items/position.html
@@ -18,11 +18,8 @@
     <h3>{% maybehidden object.person user %}{{ object.person.name }}{% endmaybehidden %}</h3>
     {% if object.place %}
       <p>Member for {{ object.place.name }}</p>
-    {% else %}
-      {# Bring on the elif clause! #}
-      {% if object.is_nominated_politician %}
-        <p>Nominated Member</p>
-      {% endif %}
+    {% elif object.is_nominated_politician %}
+      <p>Nominated Member</p>
     {% endif %}
   </section>
 


### PR DESCRIPTION
Change is_nominated_member method on Position to work on subtitle like the current data.

This method is only used in two templates, and it's not clear to me that those templates are used. Both templates are ancient enough not to have used the `elif` template tag, which came in in Django 1.4

Closes #1984 
