### PR TITLE
Send update_hansard cron emails to mzalendo-managers

### DIFF
--- a/conf/crontab.ugly
+++ b/conf/crontab.ugly
@@ -40,6 +40,7 @@ PYTHONIOENCODING=utf-8
 !!(* if ($vhost eq 'mzalendo.mysociety.org') { *)!!
 MAILTO=cron-mzalendo@mysociety.org
 0 7 * * *  !!(*= $user *)!! run_management_command feedback_report_pending
+MAILTO=mzalendo-managers@mysociety.org
 6 7 * * *  !!(*= $user *)!! update_hansard.bash
 MAILTO=cron-!!(*= $site *)!!@mysociety.org
 3 10 * * * !!(*= $user *)!! output-on-error run_management_command kenya_assign_aspirants_to_coalitions


### PR DESCRIPTION
This alias is logged in Google Groups and goes to Jess and the rest of
the Mzalendo team.

Fixes #1582 