### PR TITLE
ZA: Add a search box to the Hansard page

### DIFF
--- a/pombola/south_africa/templates/south_africa/hansard_index.html
+++ b/pombola/south_africa/templates/south_africa/hansard_index.html
@@ -14,6 +14,17 @@
   <p>Note: There is a delay in the release of Hansard transcripts of about six months</p>
 {% endif %}
 
+<form method="get" action="{% url 'core_search' %}" class="global-search-form">
+    <input type="hidden" name="section" value="hansard">
+    <div class="search-section-box">
+        <div class="inline-search-box">
+            <label for="id_q">Search</label>
+            <input id="id_q" name="q" type="text" value="{{ query }}">
+            <input type="submit" value="Search" class="button">
+        </div>
+    </div>
+</form>
+
 <div class="clearfix">
   <p style="float: right;">
     <a class="js-reveal-all-link" href="#">Expand all subsections</a>


### PR DESCRIPTION
Adds a search box to the Hansard page. This acts like the regular search, but restricted to Hansard results.

![screen shot 2016-03-09 at 16 09 50](https://cloud.githubusercontent.com/assets/22996/13641707/68bedc22-e611-11e5-897b-99c6ca0a6250.png)

Fixes https://github.com/mysociety/pombola/issues/1846