### PR TITLE
Use a relative link to Disqus comments from social tools

### DIFF
--- a/pombola/core/templates/core/social_tools.html
+++ b/pombola/core/templates/core/social_tools.html
@@ -22,7 +22,7 @@
 
   {% if settings.DISQUS_SHORTNAME %}
     <li>
-      <a  href="{% url "person" slug=object.slug %}#disqus_thread"
+      <a  href="#disqus_thread"
           class="big-btn-text-green"
       >Post Comment</a>
     </li>


### PR DESCRIPTION
The Disqus link previously always went to a person, but the comments box can appear on orgs and places as well. This changes the link to a relative link using a url fragment.

Fixes #1460 