### PR TITLE
Cache pip dependencies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
     skip_join: true
 
 language: python
+cache: pip
 
 services:
   - elasticsearch


### PR DESCRIPTION
This should speed up builds significantly.

Fixes #2088 