### PR TITLE
Remove 'ford-k' slug from parties list.

### DIFF
--- a/pombola/kenya/management/commands/kenya_assign_aspirants_to_coalitions.py
+++ b/pombola/kenya/management/commands/kenya_assign_aspirants_to_coalitions.py
@@ -30,7 +30,6 @@ class Command(BaseCommand):
         'wdm-k':      'cord', # Wiper democratic Movement Kenya
         'ford-kenya': 'cord', # Ford Kenya
         'ford':       'cord', # Forum For The Restoration Of Democracy
-        'ford-k':     'cord', # Forum For The Restoration Of Democracy - Kenya
         'ksc':        'cord', # Kenya Social Congress
         'tip':        'cord', # The Independent Party
         'kadu-asili': 'cord', # Kenya African Democratic Union - Asili


### PR DESCRIPTION
Since we merged the 'ford-k' party with 'ford-kenya', we don't need this slug in this script any more.

Fixes #2111 