### PR TITLE
Order by person__id when it's going to be used in distinct.

### DIFF
--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -1308,15 +1308,52 @@ class SAElectionStatisticsView(SAElectionOverviewMixin):
 
         context['current_mps'] = {'all': {}, 'byparty': []}
 
-        context['current_mps']['all']['current'] = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().order_by('person__id').distinct('person__id').count()
-        context['current_mps']['all']['rerunning'] = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(Q(person__position__organisation__slug__contains='national-election-list-2014') | (Q(person__position__organisation__slug__contains='election-list-2014') & Q(person__position__organisation__slug__contains='regional'))).order_by('person__id').distinct('person__id').count()
+        election_2014_query = (
+            Q(person__position__organisation__slug__contains='national-election-list-2014') |
+            (Q(person__position__organisation__slug__contains='election-list-2014') &
+             Q(person__position__organisation__slug__contains='regional'))
+            )
+
+        current_na_positions = (
+            models.Organisation.objects
+            .get(slug='national-assembly')
+            .position_set.all()
+            .currently_active()
+            )
+
+        context['current_mps']['all']['current'] = (
+            current_na_positions
+            .order_by('person__id')
+            .distinct('person__id')
+            .count()
+            )
+        context['current_mps']['all']['rerunning'] = (
+            current_na_positions
+            .filter(election_2014_query)
+            .order_by('person__id')
+            .distinct('person__id')
+            .count()
+            )
         context['current_mps']['all']['percent_rerunning'] = 100 * context['current_mps']['all']['rerunning'] / context['current_mps']['all']['current']
 
         #find the number of current MPs running for office per party
         for p in context['party_list']:
             party = models.Organisation.objects.get(slug=p.slug)
-            current = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(person__position__organisation__slug=p.slug).order_by('person__id').distinct('person__id').count()
-            rerunning = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(person__position__organisation__slug=p.slug).filter(Q(person__position__organisation__slug__contains='national-election-list-2014') | (Q(person__position__organisation__slug__contains='election-list-2014') & Q(person__position__organisation__slug__contains='regional'))).order_by('person__id').distinct('person__id').count()
+            current = (
+                current_na_positions
+                .filter(person__position__organisation__slug=p.slug)
+                .order_by('person__id')
+                .distinct('person__id')
+                .count()
+                )
+            rerunning = (
+                current_na_positions
+                .filter(person__position__organisation__slug=p.slug)
+                .filter(election_2014_query)
+                .order_by('person__id')
+                .distinct('person__id')
+                .count()
+                )
             if current:
                 percent = 100 * rerunning / current
                 context['current_mps']['byparty'].append({'party': party, 'current': current, 'rerunning': rerunning, 'percent_rerunning': percent})

--- a/pombola/south_africa/views.py
+++ b/pombola/south_africa/views.py
@@ -1308,15 +1308,15 @@ class SAElectionStatisticsView(SAElectionOverviewMixin):
 
         context['current_mps'] = {'all': {}, 'byparty': []}
 
-        context['current_mps']['all']['current'] = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().distinct('person__id').count()
-        context['current_mps']['all']['rerunning'] = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(Q(person__position__organisation__slug__contains='national-election-list-2014') | (Q(person__position__organisation__slug__contains='election-list-2014') & Q(person__position__organisation__slug__contains='regional'))).distinct('person__id').count()
+        context['current_mps']['all']['current'] = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().order_by('person__id').distinct('person__id').count()
+        context['current_mps']['all']['rerunning'] = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(Q(person__position__organisation__slug__contains='national-election-list-2014') | (Q(person__position__organisation__slug__contains='election-list-2014') & Q(person__position__organisation__slug__contains='regional'))).order_by('person__id').distinct('person__id').count()
         context['current_mps']['all']['percent_rerunning'] = 100 * context['current_mps']['all']['rerunning'] / context['current_mps']['all']['current']
 
         #find the number of current MPs running for office per party
         for p in context['party_list']:
             party = models.Organisation.objects.get(slug=p.slug)
-            current = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(person__position__organisation__slug=p.slug).distinct('person__id').count()
-            rerunning = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(person__position__organisation__slug=p.slug).filter(Q(person__position__organisation__slug__contains='national-election-list-2014') | (Q(person__position__organisation__slug__contains='election-list-2014') & Q(person__position__organisation__slug__contains='regional'))).distinct('person__id').count()
+            current = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(person__position__organisation__slug=p.slug).order_by('person__id').distinct('person__id').count()
+            rerunning = models.Organisation.objects.get(slug='national-assembly').position_set.all().currently_active().filter(person__position__organisation__slug=p.slug).filter(Q(person__position__organisation__slug__contains='national-election-list-2014') | (Q(person__position__organisation__slug__contains='election-list-2014') & Q(person__position__organisation__slug__contains='regional'))).order_by('person__id').distinct('person__id').count()
             if current:
                 percent = 100 * rerunning / current
                 context['current_mps']['byparty'].append({'party': party, 'current': current, 'rerunning': rerunning, 'percent_rerunning': percent})


### PR DESCRIPTION
A bad query is somehow getting through the Django ORM to postgres.
The first occurrence of this is on 2016-03-05, which is a couple
of days after we upgraded to Django 1.8, so I imagine it's
something that's changed in the ORM.

Postgres is complaining that a field which is has a distinct on it
needs to be the first in the order by, so I've added an order by
for this field.

Fixes #2109.