### PR TITLE
Improvements to core_find_stale_elasticsearch_documents

### DIFF
--- a/pombola/core/management/commands/core_find_stale_elasticsearch_documents.py
+++ b/pombola/core/management/commands/core_find_stale_elasticsearch_documents.py
@@ -64,6 +64,9 @@ class Command(BaseCommand):
     args = 'MODEL ...'
     help = 'Get all search results for the given models'
 
+    def add_arguments(self, parser):
+        parser.add_argument('--delete', action='store_true', default=False)
+
     def handle(self, *args, **options):
 
         available_models = get_all_indexed_models()
@@ -92,3 +95,6 @@ class Command(BaseCommand):
                 if search_result.pk not in pks_in_database:
                     msg = "stale search entry for primary key {0} (text: {1})"
                     print "     ", msg.format(search_result.pk, search_result.text)
+                    if options['delete']:
+                        model_details['index'].remove_object(search_result.id)
+                        print "      removed!"


### PR DESCRIPTION
The first two commits improve `core_find_stale_elasticsearch_documents` as a
tool for investigating the stale search index entries problem. The final commit
adds a option for fixing those issues as they're found. More background from
the commit message below:

There is an as yet unsolved problem where an object in the database
has been deleted, but there is still a stale Elasticsearch document
that refers to it; for some reason Haystack hasn't got the signal
to remove it.

We were fixing this synchronisation problem by running
`./manage.py rebuild_index`, but that takes a really long time to run
and means search will be missing results while it's running (since it
clears all the indices, and we haven't implemented
zero-search-downtime-reindexing of Elasticsearch yet).  This commit
adds a `--delete` option to `core_find_stale_elasticsearch_documents` so
that it can also remove any stale documents, which will mean we can
fix the symptoms of the problem without search downtime.

n.b. in looking through Haystack's source in the course of fixing
this issue, it looks from the source code as if
`./update_index --remove <MODEL>` would be a much quicker way of
fixing stale objects for a particular model - this commit essentially
duplicates that functionality.  However, this command is still useful
as a way of investigating the stale documents, and the tiny amount of
extra code here to let it fix that problem as well seems worth adding
to me.

Fixes #2084