### PR TITLE
Greatly reduce queries needed for Place pages in the admin

### DIFF
--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -211,6 +211,19 @@ class PlaceAdmin(StricterSlugFieldMixin, admin.ModelAdmin):
         IdentifierInlineAdmin,
         )
 
+    def get_field_queryset(self, db, db_field, request):
+        if db_field.name == 'parent_place':
+            fields = ('kind', 'organisation', 'parliamentary_session')
+            return db_field.rel.to.objects.select_related(*fields)
+        elif db_field.name == 'organisation':
+            return db_field.rel.to.objects.select_related('kind')
+        return None
+
+    def get_queryset(self, request):
+        return super(PlaceAdmin, self).get_queryset(request) \
+            .select_related(
+                'kind', 'organisation', 'organisation__kind', 'parliamentary_session')
+
     def show_organisation(self, obj):
         if obj.organisation:
             return create_admin_link_for(

--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -173,6 +173,9 @@ class PositionInlineAdmin(admin.TabularInline):
     )
     ordering = ('-category', 'organisation__name', '-start_date')
 
+    def get_queryset(self, request):
+        queryset = super(PositionInlineAdmin, self).get_queryset(request)
+        return queryset.select_related('person', 'organisation', 'title')
 
 class ScorecardInlineAdmin(GenericTabularInline):
     model = scorecard_models.Entry


### PR DESCRIPTION
Place pages (both the list and the detail) in the admin were incredibly
slow because they were making thousands of queries. This is because the
__unicode__ methods of Place and Organisation use related objects.

There are two changes here:

 * get_queryset - This is used for the list page.

 * get_field_queryset - This is used to create the querysets for
   populating the select elements for foreign keys on the detail
   page.

So the former speeds up the place page, while the latter speeds up the
detail page.

Fixes #2085