### PR TITLE
Make sure JS files from addExtraJS are loaded after in-page <script>s

### DIFF
--- a/pombola/core/static/js/loader.js
+++ b/pombola/core/static/js/loader.js
@@ -24,14 +24,14 @@
                 '//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js',
             ].concat(pipeline_desktop_only),
             both: pipeline_desktop_and_mobile.concat(
-                ['//www.google.com/jsapi']).concat(extra_js),
+                ['//www.google.com/jsapi']),
             complete: function () {
-                for (i=0; i<pombola_run_when_document_ready_array.length; i++) {
-                    $( pombola_run_when_document_ready_array[i] );
-                }
-
-                // Now load all the optional bits that we didn't want slowing down the more important bits
-                Modernizr.load(pipeline_analytics);
+                $(function() {
+                    for (i=0; i<pombola_run_when_document_ready_array.length; i++) {
+                        $( pombola_run_when_document_ready_array[i] );
+                    }
+                    Modernizr.load(extra_js.concat(pipeline_analytics));
+                });
             }
         }
     );


### PR DESCRIPTION
In production we were getting an error that suggested that tabs.js was
being loaded before map.js.

These are loaded by different mechanisms (warning: this is all awful):

 - map.js is loaded via `{% javascript 'google-map' %}` in the `<body>`
   which is replaced by a `<script>` tag that loads it directly

 - tabs.js is loaded from the 'both' case of yepnope (although in a
   slightly convoluted way, because of the hack to make django-pipeline
   work with yepnope) - it starts with `addExtraJS`

I believe this is happening because the files that are loaded from
'both' don't wait for the document to be ready, so the `<script>` tag in
the body might not have been loaded yet.

This moves the loading of the extra JS into the `complete` callback of
yepnope, and wraps the body of that function in `$(function() { })` so
that it really is only run when the document's ready.

n.b. This is just a quick fix because the rep locator page is broken on
People's Assembly. I think the best way to fix this ultimately is to
remove this tangled web of hacked-together delayed loading entirely,
and replace it with something more coherent.

Fixes #2137
Fixes #2138
Fixes #2139