### PR TITLE
To help the EP scraper, add the person ID in a <meta> tag

### DIFF
--- a/pombola/core/templates/core/person_base.html
+++ b/pombola/core/templates/core/person_base.html
@@ -11,6 +11,7 @@
       <link href="http://{{ settings.DISQUS_SHORTNAME }}.disqus.com/" rel="prefetch" />
     <![endif]-->
   {% endif %}
+  <meta name="pombola-person-id" content="{{ object.id }}">
 {% endblock%}
 
 {% block open_graph %}{% include 'core/_person_open_graph.html' %}{% endblock %}

--- a/pombola/kenya/templates/core/person_base.html
+++ b/pombola/kenya/templates/core/person_base.html
@@ -6,6 +6,11 @@
 
 {% block open_graph %}{% include 'core/_person_open_graph.html' %}{% endblock %}
 
+{% block extra_head_meta %}
+  {{ block.super }}
+  <meta name="pombola-person-id" content="{{ object.id }}">
+{% endblock%}
+
 {% block object_menu_links %}{% endblock %}
 
 {% block object_tagline %}


### PR DESCRIPTION
We'd like the EveryPolitician scraper to be able to extract the Pombola
person ID in a predictable way - this commit adds that value in a
`<meta name="pombola-person-id">` in the `<head>`.

Fixes #2130