### PR TITLE
Fix errors when deploying to production

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -106,7 +106,10 @@ else:
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
-STATIC_ROOT = os.path.normpath( os.path.join( base_dir, "staticfiles") )
+if 'ON_HEROKU' in os.environ:
+    STATIC_ROOT = os.path.normpath( os.path.join( base_dir, "staticfiles") )
+else:
+    STATIC_ROOT = os.path.normpath( os.path.join( root_dir, "collected_static/") )
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"

--- a/pombola/wsgi.py
+++ b/pombola/wsgi.py
@@ -16,8 +16,6 @@ framework.
 import os
 import sys
 
-from pombola.config import config, config_path
-
 # Add the path to the project root manually here. Ideally it could be added via
 # python-path in the httpd.conf WSGI config, but I'm not changing that due to
 # the large number of sites running under that config (although it shouldn't
@@ -29,6 +27,7 @@ sys.path.insert(
     os.path.normpath(file_dir + "/..")
 )
 
+from pombola.config import config, config_path
 
 if int(config.get('STAGING')) and sys.argv[1:2] != ['runserver']:
     import pombola.wsgi_monitor


### PR DESCRIPTION
Merging the `heroku` branch introduced a couple of errors that
only became apparent in production:

* Loading the config in `wsgi.py` was failing
* The `STATIC_ROOT` directory was accidentally and unnecessarily changed

These commits fix those issues.