### PR TITLE
KE: fix MapIt area type codes (they should be uppercase)

### DIFF
--- a/pombola/core/management/commands/core_import_kenyan_boundaries_2013.py
+++ b/pombola/core/management/commands/core_import_kenyan_boundaries_2013.py
@@ -49,8 +49,8 @@ class Command(NoArgsCommand):
             if not options[required]:
                 raise CommandError("You must specify --" + required)
 
-        all_data = (('dis', 'COUNTY_NAM', map_county_name, options['counties_shpfile']),
-                    ('con', 'CONSTITUEN', map_constituency_name, options['constituencies_shpfile']))
+        all_data = (('DIS', 'COUNTY_NAM', map_county_name, options['counties_shpfile']),
+                    ('CON', 'CONSTITUEN', map_constituency_name, options['constituencies_shpfile']))
 
         for area_type_code, name_field, map_name_function, filename in all_data:
 

--- a/pombola/core/management/commands/core_match_places_to_mapit_areas.py
+++ b/pombola/core/management/commands/core_match_places_to_mapit_areas.py
@@ -9,10 +9,10 @@ class Command(NoArgsCommand):
     help = 'Link places to areas in mapit'
 
     def handle_noargs(self, **options):
-        self.match_for_types(type_code='con', place_kind_slug='constituency'          )
-        self.match_for_types(type_code='pro', place_kind_slug='province', suffix=True )
-        self.match_for_types(type_code='dis', place_kind_slug='county',   suffix=True )
-        self.match_for_types(type_code='ctr', place_kind_slug='country',  suffix=True )
+        self.match_for_types(type_code='CON', place_kind_slug='constituency'          )
+        self.match_for_types(type_code='PRO', place_kind_slug='province', suffix=True )
+        self.match_for_types(type_code='DIS', place_kind_slug='county',   suffix=True )
+        self.match_for_types(type_code='CTR', place_kind_slug='country',  suffix=True )
 
 
     def match_for_types(self, type_code, place_kind_slug, suffix=False ):

--- a/pombola/core/management/commands/core_match_places_to_mapit_areas_2013.py
+++ b/pombola/core/management/commands/core_match_places_to_mapit_areas_2013.py
@@ -17,12 +17,12 @@ class Command(NoArgsCommand):
     )
 
     def handle_noargs(self, **options):
-        self.match_for_types(type_code='con',
+        self.match_for_types(type_code='CON',
                              mapit_generation=3,
                              place_kind_slug='constituency',
                              session_slug='na2013',
                              commit=options['commit'])
-        self.match_for_types(type_code='dis',
+        self.match_for_types(type_code='DIS',
                              mapit_generation=3,
                              place_kind_slug='county',
                              session_slug='s2013',

--- a/pombola/kenya/migrations/0001_fix_mapit_area_types.py
+++ b/pombola/kenya/migrations/0001_fix_mapit_area_types.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+def uppercase_type_names(apps, schema_editor):
+    Type = apps.get_model('mapit', 'Type')
+    for mapit_type in Type.objects.all():
+        new_code = mapit_type.code.upper()
+        mapit_type.code = new_code
+        mapit_type.save()
+
+def lowercase_type_names(apps, schema_editor):
+    Type = apps.get_model('mapit', 'Type')
+    for mapit_type in Type.objects.all():
+        new_code = mapit_type.code.lower()
+        mapit_type.code = new_code
+        mapit_type.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mapit', '0002_auto_20141218_1615'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            uppercase_type_names,
+            lowercase_type_names,
+        )
+    ]

--- a/pombola/map/templates/map/home.html
+++ b/pombola/map/templates/map/home.html
@@ -10,7 +10,7 @@
   <script>
     var mapDrilldownSettings = {
       {% if settings.COUNTRY_APP == 'kenya' %}
-        mapitAreaType: 'con'
+        mapitAreaType: 'CON'
       {% endif %}
     };
   </script>

--- a/pombola/south_africa/templates/map/home.html
+++ b/pombola/south_africa/templates/map/home.html
@@ -9,7 +9,7 @@
   <script>
     var mapDrilldownSettings = {
       {% if settings.COUNTRY_APP == 'kenya' %}
-      mapitAreaType: 'con',
+      mapitAreaType: 'CON',
       {% endif %}
 
       i18n: {


### PR DESCRIPTION
MapIt does allow type codes that have lower-case letters, but they can't
then be looked up with, for example:

   /mapit/areas/ctr.html

This commit migrates the MapIt area types to have upper case codes, so
that these helpful API endpoints are usable again.  It should change all
references to these types in the code as well.  (I checked for uses of
ctr|pro|div|loc|sub|con|dis to update.)

We've never advertised the Mzalendo MapIt, so there shouldn't be any
external users of the API who would be affected.

Fixes #495