### PR TITLE
Add filters for viewing positions from particular parliamentary sessions

### DIFF
--- a/pombola/core/management/commands/core_export_to_popolo_json.py
+++ b/pombola/core/management/commands/core_export_to_popolo_json.py
@@ -11,8 +11,6 @@ from pombola.core.popolo import get_popolo_data
 from django.core.management.base import BaseCommand, CommandError
 
 
-ideal_collection_order = ('organizations', 'persons', 'posts', 'memberships')
-
 class Command(BaseCommand):
     args = 'OUTPUT-DIRECTORY POMBOLA-URL'
     help = 'Export all people, organisations and memberships to Popolo JSON and mongoexport format'

--- a/pombola/core/management/commands/core_export_to_popolo_json.py
+++ b/pombola/core/management/commands/core_export_to_popolo_json.py
@@ -40,19 +40,25 @@ class Command(BaseCommand):
 
         primary_id_scheme = '.'.join(reversed(parsed_url.netloc.split('.')))
 
-        inline_memberships = options['pombola']
-
-        popolo_data = get_popolo_data(
-            primary_id_scheme,
-            pombola_url,
-            inline_memberships=inline_memberships
-        )
-
         if options['pombola']:
-            output_filename = join(output_directory, 'pombola.json')
-            with open(output_filename, 'w') as f:
-                json.dump(popolo_data, f, indent=4, sort_keys=True)
+            for inline_memberships, leafname in (
+                    (True, 'pombola.json'),
+                    (False, 'pombola-no-inline-memberships.json'),
+            ):
+                popolo_data = get_popolo_data(
+                    primary_id_scheme,
+                    pombola_url,
+                    inline_memberships=inline_memberships
+                )
+                output_filename = join(output_directory, leafname)
+                with open(output_filename, 'w') as f:
+                    json.dump(popolo_data, f, indent=4, sort_keys=True)
         else:
+            popolo_data = get_popolo_data(
+                primary_id_scheme,
+                pombola_url,
+                inline_memberships=False
+            )
             for collection, data in popolo_data.items():
                 for mongoexport_format in (True, False):
                     if mongoexport_format:

--- a/pombola/core/migrations/0004_parliamentarysession_position_title.py
+++ b/pombola/core/migrations/0004_parliamentarysession_position_title.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0003_new_emailfield_max_length'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='parliamentarysession',
+            name='position_title',
+            field=models.ForeignKey(blank=True, to='core.PositionTitle', null=True),
+        ),
+    ]

--- a/pombola/core/migrations/0005_parliamentarysession_make_house_optional.py
+++ b/pombola/core/migrations/0005_parliamentarysession_make_house_optional.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0004_parliamentarysession_position_title'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='parliamentarysession',
+            name='house',
+            field=models.ForeignKey(blank=True, to='core.Organisation', null=True),
+        ),
+    ]

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1371,6 +1371,23 @@ class Position(ModelBase, IdentifierMixin):
             else:
                 return "%s &rarr; %s" % (self.start_date, self.end_date)
 
+    def approximate_date_overlap(self, start_date, end_date):
+        """Return the approximate overlap between this position and a date range
+
+        This may be *very* approximate, but it's sometimes useful to
+        be able to have a rough idea of how much a position overlaps
+        with a date range, e.g. to see which parliamentary term a
+        position is most likely to refer to.
+
+        This returns a datetime.timedelta object.
+        """
+        approx_start = approximate_date_to_date(self.start_date, 'earliest')
+        approx_end = approximate_date_to_date(self.end_date, 'latest')
+        latest_start = max(approx_start, start_date)
+        earliest_end = max(approx_end, end_date)
+        if earliest_end <= latest_start:
+            return datetime.timedelta(days=0)
+        return earliest_end - latest_start
 
     def display_start_date(self):
         """Return text that represents the start date"""

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1392,7 +1392,8 @@ class Position(ModelBase, IdentifierMixin):
 class ParliamentarySession(ModelBase):
     start_date = DateField(blank=True, null=True)
     end_date = DateField(blank=True, null=True)
-    house = models.ForeignKey('Organisation')
+    house = models.ForeignKey('Organisation', blank=True, null=True)
+    position_title = models.ForeignKey('PositionTitle', blank=True, null=True)
     # It's not clear whether this field is a good idea or not - it
     # suggests that boundaries won't change within a
     # ParliamentarySession.  This assumption might well be untrue.

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1135,6 +1135,17 @@ class PositionQuerySet(models.query.GeoQuerySet):
 
         return self.filter(start_criteria)
 
+    def overlapping_dates(self, start_date, end_date):
+        start_criteria = \
+            Q(start_date='') | \
+            Q(start_date='past') | \
+            Q(sorting_start_date__lte=end_date)
+        end_criteria = \
+            Q(end_date='') | \
+            Q(end_date='future') | \
+            Q(sorting_end_date_high__gte=start_date)
+        return self.filter(start_criteria & end_criteria)
+
     def aspirant_positions(self):
         """
         Filter down to only positions which are aspirant ones. This uses the

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1446,6 +1446,21 @@ class ParliamentarySession(ModelBase):
             return "from %s to %s" % (self.format_date(self.start_date),
                                       self.format_date(self.end_date))
 
+    def positions_url(self):
+        if not self.position_title:
+            msg = ("There are currently no position views that don't require "
+                   " a position title")
+            raise NotImplementedError(msg)
+        if not self.house:
+            return reverse('position_pt', kwargs={
+                'pt_slug': self.position_title.slug
+            })
+        return reverse('position_pt_ok_o', kwargs={
+            'pt_slug': self.position_title.slug,
+            'ok_slug': self.house.kind.slug,
+            'o_slug': self.house.slug,
+        })
+
     class Meta:
         ordering = ['start_date']
 

--- a/pombola/core/popolo.py
+++ b/pombola/core/popolo.py
@@ -54,6 +54,7 @@ def get_area_information(place, base_url):
     if session:
         result['session'] = {
             'id': session.id,
+            'slug': session.slug,
             'name': session.name,
             'start_date': str(session.start_date),
             'end_date': str(session.end_date),

--- a/pombola/core/static/sass/_listing.scss
+++ b/pombola/core/static/sass/_listing.scss
@@ -85,6 +85,10 @@ ul.listing {
           width: auto;
           height: auto; } } } } }
 
+.parliamentary-session-links {
+  margin-bottom: 0.8em;
+  margin-top: 1.2em;
+}
 
 ul.position-listing {
 

--- a/pombola/core/templates/core/_position_session_links.html
+++ b/pombola/core/templates/core/_position_session_links.html
@@ -1,0 +1,17 @@
+{% if session %}
+  <h3>Position holders during {{ session.name }}</h3>
+  <h4>({{ session.readable_date_range }})</h4>
+{% else %}
+  <h3>Current Position Holders</h3>
+{% endif %}
+
+{% if session_details|length > 1 %}
+  <div class="parliamentary-session-links">Switch to:
+    {% for session in session_details %}
+      {% if session.should_link %}
+        <a href="{{ session.url }}">{{ session.name }}</a>
+        {% if not forloop.last %} &mdash; {% endif %}
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/pombola/core/templates/core/position_detail.html
+++ b/pombola/core/templates/core/position_detail.html
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="content_box">
-        <h3>Current Position Holders</h3>
+        {% include 'core/_position_session_links.html' %}
         {% include 'core/position_position_section.html' %}
     </div>
 

--- a/pombola/core/templates/core/position_detail_grid.html
+++ b/pombola/core/templates/core/position_detail_grid.html
@@ -22,7 +22,7 @@
 
 
     <div class="content_box">
-        <h3>Current Position Holders</h3>
+        {% include 'core/_position_session_links.html' %}
 
         {% for position in positions %}
             <div class="grid-listing-item">

--- a/pombola/core/templates/core/session_list.html
+++ b/pombola/core/templates/core/session_list.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+
+{% block title %}Parliamentary Sessions{% endblock %}
+
+{% block content %}
+
+  <h1 class="page-title">Parliamentary Sessions</h1>
+
+  <ul>
+    {% for object in object_list %}
+      <li>
+        <a href="{{ object.positions_url }}?session={{ object.slug }}">{{ object.name }}</a>
+        ({{ object.readable_date_range }})
+      </li>
+
+    {% endfor %}
+  </ul>
+
+{% endblock %}

--- a/pombola/core/urls.py
+++ b/pombola/core/urls.py
@@ -7,6 +7,7 @@ from pombola.core import models
 from pombola.core.views import (HomeView, PlaceDetailView,
     OrganisationList, OrganisationKindList, PlaceKindList, PersonDetail,
     PersonDetailSub, PlaceDetailSub, OrganisationDetailSub,
+    SessionListView,
     OrganisationDetailView, HelpApiView,
     featured_person,
     parties,
@@ -119,6 +120,8 @@ urlpatterns = [
     url(r'^position/(?P<pt_slug>[-\w]+)/$', position_pt, name='position_pt'),
     url(r'^position/(?P<pt_slug>[-\w]+)/(?P<ok_slug>[-\w]+)/$', position_pt_ok, name='position_pt_ok'),
     url(r'^position/(?P<pt_slug>[-\w]+)/(?P<ok_slug>[-\w]+)/(?P<o_slug>[-\w]+)/$', position_pt_ok_o, name='position_pt_ok_o'),
+
+    url(r'^sessions$', SessionListView.as_view(), name='sessions'),
 
     # specials
     url(r'^parties', parties, name='parties'),

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -571,3 +571,12 @@ class VersionView(View):
         return HttpResponse(
             json.dumps(result), content_type='application/json'
         )
+
+
+class SessionListView(ListView):
+
+    model = models.ParliamentarySession
+    template_name = 'core/session_list.html'
+
+    def get_ordering(self):
+        return ('-start_date', '-end_date', 'name')

--- a/pombola/country/__init__.py
+++ b/pombola/country/__init__.py
@@ -10,6 +10,8 @@ imports_and_defaults = (
      lambda person, dictionary, base_url: None),
     ('add_extra_popolo_data_for_organization',
      lambda organisation, dictionary, base_url: None),
+    ('override_current_session',
+     lambda session: None),
 )
 
 # Note that one could do this without the dynamic import and use of

--- a/pombola/kenya/lib.py
+++ b/pombola/kenya/lib.py
@@ -19,3 +19,13 @@ def significant_positions_filter(qs):
                            # 'governor',
                            # 'ward-representative',
                            'member-national-assembly')))
+
+
+def override_current_session(session):
+    from pombola.core.models import ParliamentarySession
+    if session and session.slug == 'na2007':
+        # Then find the most recent session with PositionTitle member
+        # of the national assembly:
+        return ParliamentarySession.objects.filter(
+            position_title__slug='member-national-assembly',
+        ).order_by('-start_date').first()

--- a/pombola/kenya/migrations/0002_adjust_parliamentary_sessions.py
+++ b/pombola/kenya/migrations/0002_adjust_parliamentary_sessions.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def add_position_title(apps, schema_editor):
+    ParliamentarySession = apps.get_model('core', 'ParliamentarySession')
+    PositionTitle = apps.get_model('core', 'PositionTitle')
+    for ps_slug, pt_slug in (
+            ('na2007', 'mp'),
+            ('na2013', 'member-national-assembly'),
+            ('s2013', 'senator'),
+    ):
+        try:
+            ps = ParliamentarySession.objects.get(slug=ps_slug)
+            ps.position_title = PositionTitle.objects.get(slug=pt_slug)
+            ps.save()
+        except ParliamentarySession.DoesNotExist:
+            pass
+
+
+def remove_position_title(apps, schema_editor):
+    ParliamentarySession = apps.get_model('core', 'ParliamentarySession')
+    for ps_slug in ('na2007', 'na2013', 's2013'):
+        try:
+            ps = ParliamentarySession.objects.get(slug=ps_slug)
+            ps.position_title = None
+            ps.save()
+        except ParliamentarySession.DoesNotExist:
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kenya', '0001_fix_mapit_area_types'),
+        ('core', '0005_parliamentarysession_make_house_optional'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            add_position_title,
+            remove_position_title,
+        )
+    ]

--- a/pombola/kenya/migrations/0003_remove_senate_organisation.py
+++ b/pombola/kenya/migrations/0003_remove_senate_organisation.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def remove_house_from_senate_session(apps, schema_editor):
+    ParliamentarySession = apps.get_model('core', 'ParliamentarySession')
+    try:
+        ps = ParliamentarySession.objects.get(slug='s2013')
+        ps.house = None
+        ps.save()
+    except ParliamentarySession.DoesNotExist:
+        pass
+
+
+def put_back_house_for_senate_session(apps, schema_editor):
+    ParliamentarySession = apps.get_model('core', 'ParliamentarySession')
+    Organisation = apps.get_model('core', 'Organisation')
+    try:
+        ps = ParliamentarySession.objects.get(slug='s2013')
+        ps.house = Organisation.objects.get(slug='senate')
+        ps.save()
+    except ParliamentarySession.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kenya', '0002_adjust_parliamentary_sessions'),
+        ('core', '0005_parliamentarysession_make_house_optional'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_house_from_senate_session,
+            put_back_house_for_senate_session,
+        )
+    ]


### PR DESCRIPTION
This will produce slightly confusing results at the moment because the 2007 -> 2013 parliamentary session object is associated with the National Assembly organisation, when really it should be associated with Parliament with the current way it's modelled. https://github.com/mysociety/pombola/issues/2092 is related. However, we can fix that after deploying this, I think.

![non-current](https://cloud.githubusercontent.com/assets/7907/15893777/d12d99ec-2d79-11e6-9641-69eeced8ef10.png)

![current](https://cloud.githubusercontent.com/assets/7907/15893782/d6f95262-2d79-11e6-80ae-da41e3dc9370.png)
