### PR TITLE
ZA: add a 3 second timeout to HTTP requests to external services

### DIFF
--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -281,7 +281,7 @@ class SASearchViewTest(WebTest):
         mocked_geocoder.assert_called_once_with(q='Trafford Road', country='za')
 
 
-def connection_error(x):
+def connection_error(x, *args, **kwargs):
     print 'Raising connection error'
     raise requests.exceptions.ConnectionError
 


### PR DESCRIPTION
The site has gone down a few times recently, and we suspect this was
because of workers being tied up waiting for external services that are
timing out.  To hopefully reduce the effect of such outages, this commit
times-out any such requests after three seconds.

Fixes #2174