### PR TITLE
WIP: mirror external HTTP-based API data

### DIFF
--- a/conf/crontab.ugly
+++ b/conf/crontab.ugly
@@ -62,10 +62,18 @@ MAILTO=cron-!!(*= $site *)!!@mysociety.org
 # NOTE - this should probably be removed once the live site is launched
 13 0 * * * !!(*= $user *)!! output-on-error update_za_hansard.bash
 
+23 1 * * * !!(*= $user *)!! run_management_command south_africa_populate_api_caches
+
+35 3 * * 0 !!(*= $user *)!! run_management_command south_africa_mirror_mapit_wards
+
 !!(* } elsif ($vhost eq 'www.pa.org.za') { *)!!
 
 # NOTE - until the live site is launched, crons are turned off in vhosts.pl
 13 1 * * * !!(*= $user *)!! output-on-error update_za_hansard.bash
+
+23 2 * * * !!(*= $user *)!! run_management_command south_africa_populate_api_caches
+
+7 5 * * 0 !!(*= $user *)!! run_management_command south_africa_mirror_mapit_wards
 
 # Generate the Popolo JSON files
 13 2 * * * !!(*= $user *)!! run_management_command core_export_to_popolo_json /data/vhost/!!(*= $vhost *)!!/media_root/popolo_json/ http://www.pa.org.za

--- a/pombola/south_africa/management/commands/south_africa_mirror_mapit_wards.py
+++ b/pombola/south_africa/management/commands/south_africa_mirror_mapit_wards.py
@@ -1,0 +1,64 @@
+from contextlib import closing
+import os
+from tempfile import NamedTemporaryFile
+import time
+from urlparse import urljoin
+
+import requests
+
+from django.contrib.gis.gdal import DataSource
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from mapit.models import Area, Country, Geometry, Generation, Type
+from mapit.management.command_utils import save_polygons
+
+SLEEP_BETWEEN_REQUESTS = 1
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        remote_mapit_url = 'http://mapit.code4sa.org/'
+        all_wards_url = urljoin(remote_mapit_url, '/areas/WD')
+        r = requests.get(all_wards_url)
+        time.sleep(SLEEP_BETWEEN_REQUESTS)
+        with transaction.atomic():
+            # Remove existing wards from MapIt:
+            Geometry.objects.filter(area__type__code='WD').delete()
+            Area.objects.filter(type__code='WD').delete()
+            # Get the Country object for South Africa:
+            country, _ = Country.objects.get_or_create(
+                name='South Africa',
+                defaults={'code': 'ZA'})
+            # Get the current Generation:
+            generation = Generation.objects.current()
+            # Make sure the ward type exists:
+            ward_type, _ = Type.objects.get_or_create(
+                code='WD', defaults={'description': 'Ward'})
+            for wd_id, wd_data in r.json().items():
+                # FIXME: we don't actually need the extra names (from
+                # 'all_names'), the codes (from 'codes') or the
+                # parent_area, but use the other attributes. We might
+                # want to add them later.
+                area = Area.objects.create(
+                    country=country,
+                    generation_low=generation,
+                    generation_high=generation,
+                    name=wd_data['name'],
+                    type=ward_type,
+                )
+                geojson_url = urljoin(
+                    remote_mapit_url,
+                    '/area/{0}.geojson'.format(wd_id))
+                ntf = NamedTemporaryFile(delete=False)
+                print "Downloading {0} to {1}".format(geojson_url, ntf.name)
+                with open(ntf.name, 'wb') as f:
+                    with closing(requests.get(geojson_url)) as r:
+                        f.write(r.text.encode('utf-8'))
+                ds = DataSource(ntf.name)
+                layer = ds[0]
+                for feat in layer:
+                    g = feat.geom
+                    save_polygons({area.id: (area, [g])})
+                os.remove(ntf.name)
+                time.sleep(SLEEP_BETWEEN_REQUESTS)

--- a/pombola/south_africa/management/commands/south_africa_populate_api_caches.py
+++ b/pombola/south_africa/management/commands/south_africa_populate_api_caches.py
@@ -1,0 +1,48 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+import requests
+
+from pombola.core.models import Identifier, Person
+from pombola.south_africa.pmg_api import (
+    get_person_from_pa_url,
+    update_or_create_pmg_api_identifier,
+    update_attendance_data_in_cache,
+    update_committee_attendance_data_in_cache,
+)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        # First get the ID mapping for PMG API <-> PA, and make sure
+        # that's cached.
+        pmg_member_ids = set()
+        page = 0
+        while True:
+            url = 'https://api.pmg.org.za/member/?page={0}'.format(page)
+            r = requests.get(url)
+            data = r.json()
+            for member_data in data['results']:
+                # Skip people with no PA URL:
+                if not member_data.get('pa_link'):
+                    continue
+                person = get_person_from_pa_url(member_data['pa_link'])
+                update_or_create_pmg_api_identifier(person, member_data['id'])
+            if not data['next']:
+                break
+            page += 1
+        # Now remove that Identifier from any people that it's disappeared from:
+        Identifier.objects.filter(
+            content_type=ContentType.objects.get_for_model(Person),
+            scheme='za.org.pmg.api/member',
+        ).exclude(object_id__in=pmg_member_ids).delete()
+
+        # Now each person should have an identifier giving their PMG API.
+
+        # Next, populate the attendance data cache:
+        for pmg_member_id in pmg_member_ids:
+            update_attendance_data_in_cache(pmg_member_id)
+
+        # Populate committee attendance data in the cache:
+        update_committee_attendance_data_in_cache()

--- a/pombola/south_africa/pmg_api.py
+++ b/pombola/south_africa/pmg_api.py
@@ -45,6 +45,11 @@ def get_committee_attendance_data_url():
     return 'https://api.pmg.org.za/committee-meeting-attendance/summary/'
 
 
+def get_ward_councillors_data_url(ward_name):
+    return 'http://nearby.code4sa.org/councillor/ward-{0}.json'.format(
+        ward_name)
+
+
 def get_paginated_api_results(initial_url):
     next_url = initial_url
 
@@ -75,3 +80,10 @@ def update_committee_attendance_data_in_cache():
     cache = caches['pmg_api']
     data = get_paginated_api_results(attendance_url)
     cache.set(attendance_url, data, CACHE_TTL_SECONDS)
+
+
+def update_ward_councillor_data_in_cache(ward_name):
+    nearby_url = get_ward_councillors_data_url(ward_name)
+    r = requests.get(nearby_url)
+    cache = caches['pmg_api']
+    cache.set(nearby_url, r.json(), CACHE_TTL_SECONDS)

--- a/pombola/south_africa/pmg_api.py
+++ b/pombola/south_africa/pmg_api.py
@@ -1,0 +1,77 @@
+import json
+import re
+from urlparse import urlparse
+
+from django.core.cache import caches
+
+import requests
+
+from pombola.core.models import Person
+
+# Cache API results for 5 days, since it sometimes goes down for days
+# at a time; we try to update the data on a nightly basis:
+CACHE_TTL_SECONDS = 60 * 60 * 24 * 5
+
+# For requests to external APIs, timeout after 3 seconds:
+API_REQUESTS_TIMEOUT = 3.05
+
+
+class AttendanceAPIDown(Exception):
+    pass
+
+
+def get_person_from_pa_url(url):
+    parsed = urlparse(url)
+    m = re.search(r'^/person/(?P<slug>[-\w]+)/', parsed.path)
+    if not m:
+        raise ValueError("Malformed URL '{0}'".format(url))
+    slug = m.group('slug')
+    return Person.objects.get(slug=slug)
+
+
+def update_or_create_pmg_api_identifier(person, pmg_api_member_id):
+    scheme = 'za.org.pmg.api/member'
+    person.identifiers.update_or_create(
+        scheme=scheme,
+        defaults={'identifier': pmg_api_member_id}
+    )
+
+
+def get_attendance_data_url(member_id):
+    return "http://api.pmg.org.za/member/{0}/attendance/".format(member_id)
+
+
+def get_committee_attendance_data_url():
+    return 'https://api.pmg.org.za/committee-meeting-attendance/summary/'
+
+
+def get_paginated_api_results(initial_url):
+    next_url = initial_url
+
+    results = []
+    while next_url:
+        try:
+            resp = requests.get(next_url, timeout=API_REQUESTS_TIMEOUT)
+        except requests.exceptions.RequestException:
+            raise AttendanceAPIDown
+
+        data = json.loads(resp.text)
+        results.extend(data.get('results'))
+
+        next_url = data.get('next')
+
+    return results
+
+
+def update_attendance_data_in_cache(member_id):
+    attendance_url = get_attendance_data_url(member_id)
+    cache = caches['pmg_api']
+    data = get_paginated_api_results(attendance_url)
+    cache.set(attendance_url, data, CACHE_TTL_SECONDS)
+
+
+def update_committee_attendance_data_in_cache():
+    attendance_url = get_committee_attendance_data_url()
+    cache = caches['pmg_api']
+    data = get_paginated_api_results(attendance_url)
+    cache.set(attendance_url, data, CACHE_TTL_SECONDS)

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -528,23 +528,6 @@ class SAPersonDetailViewTest(PersonSpeakerMappingsMixin, TestCase):
               'title': u'One District-One Agri-Park implementation in context of Rural Economic Transformation Model'}],
             )
 
-    @patch('requests.get', side_effect=connection_error)
-    def test_attendance_data_requests_errors(self, m):
-        # Check context if identifier exists, cache lookup misses
-        # and the PMG API is unavailable.
-        pmg_api_cache = caches['pmg_api']
-        pmg_api_cache.clear()
-
-        context = self.client.get(reverse('person', args=('moomin-finn',))).context
-        assert context['attendance'] == 'UNAVAILABLE'
-
-        # Get rid of identifiers so that we do the mocked url fetch
-        # to find the identifier.
-        models.Identifier.objects.all().delete()
-
-        context = self.client.get(reverse('person', args=('moomin-finn',))).context
-        assert context['attendance'] == 'UNAVAILABLE'
-
     def _setup_example_positions(self, past, current):
         parliament = models.OrganisationKind.objects.create(
             name='Parliament',

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -39,6 +39,8 @@ from pombola.core.views import PersonSpeakerMappingsMixin
 from instances.models import Instance
 from pombola.interests_register.models import Category, Release, Entry, EntryLineItem
 
+from .pmg_api import get_person_from_pa_url
+
 from nose.plugins.attrib import attr
 
 def fake_geocoder(country, q, decimal_places=3):
@@ -2025,3 +2027,17 @@ class SAUrlRoutingTest(TestCase):
     def test_za_home(self):
         match = resolve('/')
         self.assertEqual(match.func.func_name, 'SAHomeView')
+
+
+@attr(country='south_africa')
+class SAPMGAPITests(TestCase):
+
+    def setUp(self):
+        self.person = models.Person.objects.create(
+            legal_name='Moomin Finn',
+            slug='moomin-finn')
+
+    def test_pa_url_parsing(self):
+        url = "http://www.pa.org.za/person/moomin-finn/"
+        found_person = get_person_from_pa_url(url)
+        self.assertEqual(found_person.id, self.person.id)


### PR DESCRIPTION
This is only still work-in-progress because `nearby.code4sa.org` is down at the moment (e.g. http://nearby.code4sa.org/councillor/ward-52401006.json is 404) - this is usually due to the data source upstream of Code4SA's API (the IEC API) being down. The remaining things to be done are:
- [ ] Test the mirroring scripts and updated views on staging
- [ ] Deploy to production in two stages:
  - [ ] Deploy everything but the view changes
  - [ ] Run both `south_africa_populate_api_caches` and `south_africa_mirror_mapit_wards`
  - [ ] Deploy the changes to the views as well.

For #2183 
