### PR TITLE
Links generated to a sitting should actually show that sitting

### DIFF
--- a/pombola/hansard/fixtures/hansard_test_data.json
+++ b/pombola/hansard/fixtures/hansard_test_data.json
@@ -51,5 +51,41 @@
       },
       "model" : "hansard.sitting",
       "pk" : 1
+   },
+   {
+      "fields" : {
+         "end_date" : null,
+         "end_time" : null,
+         "source" : 1,
+         "start_date" : "2010-04-11",
+         "start_time" : null,
+         "venue" : 1
+      },
+      "model" : "hansard.sitting",
+      "pk" : 2
+   },
+   {
+      "fields" : {
+         "end_date" : null,
+         "end_time" : null,
+         "source" : 1,
+         "start_date" : "2010-04-11",
+         "start_time" : "09:30:00",
+         "venue" : 1
+      },
+      "model" : "hansard.sitting",
+      "pk" : 3
+   },
+   {
+      "fields" : {
+         "end_date" : null,
+         "end_time" : null,
+         "source" : 1,
+         "start_date" : "2010-04-11",
+         "start_time" : "14:30:00",
+         "venue" : 1
+      },
+      "model" : "hansard.sitting",
+      "pk" : 4
    }
 ]

--- a/pombola/hansard/tests/test_sitting.py
+++ b/pombola/hansard/tests/test_sitting.py
@@ -2,6 +2,7 @@ from datetime import date, time
 
 from django.test import TestCase
 from pombola.hansard.models import Source, Sitting, Venue
+from pombola.hansard.views import get_sittings_from_slugs
 
 
 class HansardSittingTest(TestCase):
@@ -12,6 +13,19 @@ class HansardSittingTest(TestCase):
         # grab a source from the test_data
         self.source = Source.objects.all()[0]
         self.venue  = Venue.objects.all()[0]
+
+        self.sitting_none = Sitting.objects.get(
+            venue__slug='national_assembly',
+            start_date='2010-04-11',
+            start_time=None)
+        self.sitting_morning = Sitting.objects.get(
+            venue__slug='national_assembly',
+            start_date='2010-04-11',
+            start_time='09:30:00')
+        self.sitting_afternoon = Sitting.objects.get(
+            venue__slug='national_assembly',
+            start_date='2010-04-11',
+            start_time='14:30:00')
 
 
     def test_sitting_naming(self):
@@ -39,6 +53,31 @@ class HansardSittingTest(TestCase):
 
         sitting.end_time = time( 18, 0 )
         self.assertEqual( str(sitting), 'National Assembly 2011-11-15: 13:00 to 18:00' )
-        
+
         sitting.end_date = date( 2011, 11, 16 )
         self.assertEqual( str(sitting), 'National Assembly 2011-11-15 13:00 to 2011-11-16 18:00' )
+
+
+    def test_sitting_link_url(self):
+        self.assertEqual(
+            '/hansard/sitting/national_assembly/2010-04-11',
+            self.sitting_none.get_absolute_url())
+        self.assertEqual(
+            '/hansard/sitting/national_assembly/2010-04-11-09-30-00',
+            self.sitting_morning.get_absolute_url())
+        self.assertEqual(
+            '/hansard/sitting/national_assembly/2010-04-11-14-30-00',
+            self.sitting_afternoon.get_absolute_url())
+
+    def test_sitting_url_decoding(self):
+        s = get_sittings_from_slugs('national_assembly', '2010-04-11')
+        self.assertEqual(1, len(s))
+        self.assertEqual(s[0].id, self.sitting_none.id)
+
+        s = get_sittings_from_slugs('national_assembly', '2010-04-11-09-30-00')
+        self.assertEqual(1, len(s))
+        self.assertEqual(s[0].id, self.sitting_morning.id)
+
+        s = get_sittings_from_slugs('national_assembly', '2010-04-11-14-30-00')
+        self.assertEqual(1, len(s))
+        self.assertEqual(s[0].id, self.sitting_afternoon.id)

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -85,7 +85,8 @@ def get_sittings_from_slugs(venue_slug, start_date_and_time_from_url):
     sittings = Sitting.objects.filter( **query_args ).order_by('start_time')
 
     if not len(sittings):
-        raise Http404
+        raise Http404("Sitting of venue {0} at {1} not found".format(
+            venue_slug, start_date_and_time_from_url))
 
     return sittings
 

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -60,25 +60,27 @@ class IndexView(TemplateView):
         return context
 
 
+START_TIME_RE = re.compile(
+    r'^(?P<start_date>\d{4}-\d{2}-\d{2})(?:-(?P<start_time>.*))?$'
+)
+
+
 def get_sittings_from_slugs(venue_slug, start_date_and_time_from_url):
     query_args = {
         'venue__slug': venue_slug,
     }
 
-    # add blank HH-MM-SS if needed
-    start_time_parts = re.split('-', start_date_and_time_from_url)
-    if len(start_time_parts) == 3:
-        start_time_parts.extend( [ '00','00','00' ] )
+    m = START_TIME_RE.search(start_date_and_time_from_url)
+    if not m:
+        msg = "Malformed sitting date and start time '{0}'"
+        raise Http404(msg.format(start_date_and_time_from_url))
 
-    # split the date and time up into the relevant fields
-    (year,month,day,hour,minute,second) = [ int(x) for x in start_time_parts ]
+    start_date, start_time = m.groups()
+    if start_time:
+        start_time = start_time.replace('-', ':')
 
-    # add start_date to the query
-    query_args['start_date'] = datetime.date(year=year,month=month,day=day)
-
-    # if there is a time use it
-    if hour or minute or second:
-        query_args['start_time__gte'] = datetime.time(hour=hour, minute=minute, second=second)
+    query_args['start_date'] = start_date
+    query_args['start_time'] = start_time
 
     # get all matching sittings
     sittings = Sitting.objects.filter( **query_args ).order_by('start_time')

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -61,9 +61,8 @@ class IndexView(TemplateView):
 
 
 def get_sittings_from_slugs(venue_slug, start_date_and_time_from_url):
-
     query_args = {
-        'venue__slug':     venue_slug,
+        'venue__slug': venue_slug,
     }
 
     # add blank HH-MM-SS if needed

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -60,14 +60,14 @@ class IndexView(TemplateView):
         return context
 
 
-def get_sittings_from_slugs(venue_slug, start_date_and_time):
+def get_sittings_from_slugs(venue_slug, start_date_and_time_from_url):
 
     query_args = {
         'venue__slug':     venue_slug,
     }
 
     # add blank HH-MM-SS if needed
-    start_time_parts = re.split('-', start_date_and_time)
+    start_time_parts = re.split('-', start_date_and_time_from_url)
     if len(start_time_parts) == 3:
         start_time_parts.extend( [ '00','00','00' ] )
 


### PR DESCRIPTION
Sitting.get_absolute_url would omit the start_time suffix if
start_time was None, but the SittingView would interpret that
URL as referring arbitrarily to the first sitting in that venue
on that date.  This meant that appearances might link to the
wrong sitting, confusingly.

This commit changes that logic so that if the start_time is
missing, it looks for a sitting with start_time None.

Fixes #2195