### PR TITLE
Add a template tag for "cleaning" HTML using lxml.html.clean

### DIFF
--- a/pombola/core/templatetags/clean_html.py
+++ b/pombola/core/templatetags/clean_html.py
@@ -1,0 +1,10 @@
+from lxml.html.clean import Cleaner
+
+from django.template import Library
+
+register = Library()
+
+@register.filter
+def as_clean_html(value):
+    cleaner = Cleaner(style=True, scripts=True)
+    return cleaner.clean_html(value)

--- a/pombola/core/tests/test_clean_html_templatetags.py
+++ b/pombola/core/tests/test_clean_html_templatetags.py
@@ -1,0 +1,24 @@
+from django.template import Context, Template
+from django.test import TestCase
+
+
+class CleanHTMLTest(TestCase):
+
+    def test_plain_text_works(self):
+        template = Template(
+            '{% load clean_html %}{{ answer_text|as_clean_html|safe }}')
+        self.assertEqual(
+            template.render(
+                Context({'answer_text': 'Mary had a little lamb'})),
+            '<p>Mary had a little lamb</p>')
+
+    def test_script_removed(self):
+        template = Template(
+            '{% load clean_html %}{{ answer_text|as_clean_html|safe }}')
+        self.assertEqual(
+            template.render(
+                Context({
+                    'answer_text':
+                    'Hello and <script>alert("Bad!");</script> goodbye'
+                })),
+            '<p>Hello and  goodbye</p>')


### PR DESCRIPTION
This should remove HTML that might be dangerous (e.g. script tags)