### PR TITLE
[ZA] Fix recent blog posts

### DIFF
--- a/pombola/south_africa/templates/info/_blog_sidebar.html
+++ b/pombola/south_africa/templates/info/_blog_sidebar.html
@@ -18,7 +18,7 @@
       <h3>Popular posts</h3>
 
       <ul>
-        {% for post in popular_posts|slice:":5" %}
+        {% for post in popular_recent_posts|slice:":5" %}
           <li><a href="{% url 'info_blog' slug=post.slug %}">{{ post.title }}</a></li>
         {% empty %}
           <li>No recent popular posts found.</li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ django-ajax-selects==1.4.2
 django-autocomplete-light==2.3.3
 django-slug-helpers==0.0.3
 django-file-archive==0.0.2
-django-info-pages==0.0.2
+django-info-pages==0.0.4
 
 Markdown==2.5.1
 


### PR DESCRIPTION
This PR shows recent posts only in the popular posts section of the sidebar.

PMG requested to show only posts that were published during the
last month in the popular posts section of the sidebar shown in blog pages.

Fixes #2212