### PR TITLE
Consistent styling for `.people-list-inline-search`

### DIFF
--- a/pombola/core/static/sass/_search.scss
+++ b/pombola/core/static/sass/_search.scss
@@ -118,7 +118,15 @@
       width: 25%;
     }
   }
+}
 
+.people-list-inline-search {
+  margin: 2em 0 2.5em 0; // search input needs to stand out on crowded person list page
+
+  label {
+    display: block;
+    margin-bottom: 0.5em;
+  }
 }
 
 .advanced-search-options {

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -1736,10 +1736,6 @@ li, div {
     }
 }
 
-.people-list-inline-search {
-    padding-bottom: 0.5em;
-}
-
 
 // Display more useful map on narrow screens
 // eg: for Constituency Office pages

--- a/pombola/south_africa/templates/core/organisation_people.html
+++ b/pombola/south_africa/templates/core/organisation_people.html
@@ -10,14 +10,14 @@
 
   <h2>People at {{ object.name }}</h2>
 
-  <div class="people-list-inline-search">
-    <span class="">Find a person by name:</span>
-    <form class="inline-search" action="{% url "core_search" %}">
-      <input class="search-autocomplete-name" id="core_search" data-source="/search/autocomplete/?model=person" type="text" name="q" value="" placeholder="e.g. Baleka Mbete"></input>
-      <input type="hidden" name="section" value="persons">
-      <input type="submit">
-    </form>
-  </div>
+  <form action="{% url "core_search" %}">
+      <div class="inline-search-box people-list-inline-search">
+          <label for="id_q" class="inline-search-box__label">Find a person by name</label>
+          <input id="id_q" name="q" class="search-autocomplete-name" type="text" value="{{ query }}" placeholder="e.g. Baleka Mbete" data-source="/search/autocomplete/?model=person">
+          <input type="hidden" name="section" value="persons">
+          <input type="submit" value="Search" class="button">
+      </div>
+  </form>
 
   <div class="layout layout-major-minor">
 

--- a/pombola/south_africa/templates/core/position_detail.html
+++ b/pombola/south_africa/templates/core/position_detail.html
@@ -12,15 +12,15 @@
 
     <h1 class="page-title">{{ page_title }}</h1>
 
-    <div class="people-list-inline-search">
-        <span class="">Find a person by name:</span>
-        <form class="inline-search" action="{% url "core_search" %}">
-            <input class="search-autocomplete-name" id="core_search" data-source="/search/autocomplete/?model=person" type="text" name="q" value="" placeholder="e.g. Baleka Mbete"></input>
+    <form action="{% url "core_search" %}">
+        <div class="inline-search-box people-list-inline-search">
+            <label for="id_q" class="inline-search-box__label">Find a person by name</label>
+            <input id="id_q" name="q" class="search-autocomplete-name" type="text" value="{{ query }}" placeholder="e.g. Baleka Mbete" data-source="/search/autocomplete/?model=person">
             <input type="hidden" name="section" value="persons">
-            <input type="submit">
-        </form>
-    </div>
-    
+            <input type="submit" value="Search" class="button">
+        </div>
+    </form>
+
     {% if object.summary %}
         <div class="summary markdown">
             {{ object.summary }}


### PR DESCRIPTION
Fixes #2216.

The search box at the top of the "MP Profiles" page now matches the main search page:

![screen shot 2016-11-22 at 16 43 08](https://cloud.githubusercontent.com/assets/739624/20532734/eb765492-b0d2-11e6-871f-c75874b080f2.png)
