### PR TITLE
ZA: Show 'must read' posts in sidebar

### DIFF
--- a/pombola/core/templatetags/get_from_key.py
+++ b/pombola/core/templatetags/get_from_key.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def get_from_key(value, arg):
+    try:
+        return value[arg]
+    except KeyError:
+        return ''

--- a/pombola/core/tests/test_templatetags.py
+++ b/pombola/core/tests/test_templatetags.py
@@ -1,5 +1,6 @@
 # coding=UTF-8
 
+from django.template import Context, Template
 from django.test import TestCase
 
 from ..templatetags.breadcrumbs import breadcrumbs, path_element_overrides
@@ -71,3 +72,30 @@ class ActiveClassTest(TestCase):
             self.assertEqual(' active ', actual)
 
         self.assertEqual(active_class('/foo', 'home'), '')
+
+
+class GetFromKeyTest(TestCase):
+    def test_gets_existing_key_from_dictionary(self):
+        example_dict = {'foo': 'bar'}
+        template = Template("{% load get_from_key %}{{ d|get_from_key:'foo' }}")
+        self.assertEqual(
+            template.render(Context({'d': example_dict})), 'bar')
+
+    def test_fails_if_key_is_not_present(self):
+        example_dict = {'foo': 'bar'}
+        template = Template("{% load get_from_key %}{{ d|get_from_key:'qux' }}")
+        self.assertEqual(
+            template.render(Context({'d': example_dict})), '')
+
+    # This is to check that get_from_key works for classes that don't implement
+    # get, for example
+    def test_gets_dynamically_generated_value_from_key(self):
+        example_dict_like = LazyDictLike()
+        template = Template("{% load get_from_key %}{{ d|get_from_key:'foo' }}")
+        self.assertEqual(
+            template.render(Context({'d': example_dict_like})), 'foofoo')
+
+
+class LazyDictLike(object):
+    def __getitem__(self, key):
+        return key + key

--- a/pombola/south_africa/templates/info/_blog_sidebar.html
+++ b/pombola/south_africa/templates/info/_blog_sidebar.html
@@ -1,3 +1,5 @@
+{% load get_from_key %}
+
 <div class="sidebar">
 
     <ul class="social-links-list">
@@ -25,5 +27,17 @@
         {% endfor %}
       </ul>
     {% endif %}
+
+    {% with must_read_posts=posts_by_tag|get_from_key:'must-read' %}
+      {% if must_read_posts %}
+      <h3>Must Read</h3>
+
+      <ul>
+        {% for post in must_read_posts %}
+          <li><a href="{% url 'info_blog' slug=post.slug %}">{{ post.title }}</a></li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    {% endwith %}
 
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ django-ajax-selects==1.4.2
 django-autocomplete-light==2.3.3
 django-slug-helpers==0.0.3
 django-file-archive==0.0.2
-django-info-pages==0.0.4
+django-info-pages==0.0.5
 
 Markdown==2.5.1
 


### PR DESCRIPTION
The posts must be tagged with a tag whose slug is `must-read`
in order to appear there.

This change updates the django-info-pages package so that we
can use `posts_by_tag`.

We also added a new template tag to the core template tags
which allows us to return the value corresponding to a key when it
contains characters that are not allowed in template variable
names like `,`, `.`, `-`, etc. since it is very common to have dashes in
tag slugs.

Fixes #2213 