### PR TITLE
Disambiguate the model names automatically imported by shell_plus

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -612,3 +612,20 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
     'PAGE_SIZE': 10,
 }
+
+# The feature of the ./manage.py shell_plus command in
+# django-extensions that automatically imports the models from your
+# django applications is very useful, but there are some name
+# conflicts.  e.g. Person unhelpfully is the django-popolo Person
+# model, not the Pombola core person model. This setting allows you to
+# specify a prefix for all the models imported from a particular
+# app. For example, this means that the django-popolo Person model is
+# now available under the 'popolo_Person' alias, and 'Person' refers
+# to the Pombola core person.
+
+SHELL_PLUS_APP_PREFIXES = {
+    'popolo': 'popolo',
+    'speeches': 'speeches',
+    'scorecards': 'scorecards',
+    'interests_register': 'interests',
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,7 @@ python-dateutil==2.4.2
 # Packages that are helpful for development:
 coverage==3.7.1
 django-debug-toolbar==1.4
-django-extensions==1.6.1
+django-extensions==1.7.4
 
 ## votematch
 django-model-utils==2.3.1
@@ -134,7 +134,7 @@ parslepy==0.2.0
 python-magic==0.4.6
 pytz==2014.10
 simplejson==3.6.5
-six==1.8
+six==1.10.0
 slumber==0.6.2
 sqlparse==0.1.14
 virtualenv==1.11.6


### PR DESCRIPTION
./manage.py shell_plus, from django-extensions, is very useful and a
great time-saver, but there are plenty of model name collisions among
all the Django applications used by Pombola - this commit uses the
SHELL_PLUS_APP_PREFIXES setting to disambiguate those, adding a prefix
to the generally less commonly used application.