### PR TITLE
South Africa: Add alphabet navigation to MP profile pages

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1261,6 +1261,10 @@ class PositionQuerySet(models.query.GeoQuerySet):
                       key=lambda p: p.name)
         return result
 
+    def person_sort_name_prefix(self, prefix):
+        """Filter by a prefix of the person's sort_name"""
+        return self.filter(person__sort_name__istartswith=prefix)
+
 
 class Position(ModelBase, IdentifierMixin):
     category_choices = (

--- a/pombola/core/templates/core/_alphabetical_pagination.html
+++ b/pombola/core/templates/core/_alphabetical_pagination.html
@@ -14,7 +14,7 @@
       {% elif count %}
         <a class="alphabet-links__link" href='{{ letter }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>{{ letter }}</a>
       {% else %}
-        <span class="alphabet-links__link alphabet-links__link--disabled">{{ letter }}</a>
+        <span class="alphabet-links__link alphabet-links__link--disabled">{{ letter }}</span>
       {% endif %}
     </li>
   {% endfor %}

--- a/pombola/core/templates/core/_alphabetical_pagination.html
+++ b/pombola/core/templates/core/_alphabetical_pagination.html
@@ -1,21 +1,29 @@
-<ol class="alphabet-links">
-    <li>
-      {% if current_name_prefix %}
-        <a class="alphabet-links__link" href='.{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>All</a>
-      {% else %}
-        <span class="alphabet-links__link alphabet-links__link--current">All</span>
-      {% endif %}
-    </li>
+{% load add_query_parameter %}
 
-  {% for letter, count in count_by_prefix %}
-    <li>
-      {% if letter == current_name_prefix %}
-        <span class="alphabet-links__link alphabet-links__link--current">{{ letter }}</span>
-      {% elif count %}
-        <a class="alphabet-links__link" href='{{ letter }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>{{ letter }}</a>
-      {% else %}
-        <span class="alphabet-links__link alphabet-links__link--disabled">{{ letter }}</span>
-      {% endif %}
-    </li>
-  {% endfor %}
-</ol>
+{% if count_by_prefix %}
+  <ol class="alphabet-links">
+      <li>
+        {% if current_name_prefix %}
+          <a class="alphabet-links__link" href='.{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>All</a>
+        {% else %}
+          <span class="alphabet-links__link alphabet-links__link--current">All</span>
+        {% endif %}
+      </li>
+
+    {% for letter, count in count_by_prefix %}
+      <li>
+        {% if letter == current_name_prefix %}
+          <span class="alphabet-links__link alphabet-links__link--current">{{ letter }}</span>
+        {% elif count %}
+          {% if alphabetical_link_from_query_parameter %}
+            <a class="alphabet-links__link" href="?{% add_query_parameter request 'letter' letter %}">{{ letter }}</a>
+          {% else %}
+            <a class="alphabet-links__link" href='{{ letter }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>{{ letter }}</a>
+          {% endif %}
+        {% else %}
+          <span class="alphabet-links__link alphabet-links__link--disabled">{{ letter }}</span>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ol>
+{% endif %}

--- a/pombola/core/templates/core/_alphabetical_pagination.html
+++ b/pombola/core/templates/core/_alphabetical_pagination.html
@@ -1,0 +1,21 @@
+<ol class="alphabet-links">
+    <li>
+      {% if current_name_prefix %}
+        <a class="alphabet-links__link" href='.{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>All</a>
+      {% else %}
+        <span class="alphabet-links__link alphabet-links__link--current">All</span>
+      {% endif %}
+    </li>
+
+  {% for letter, count in count_by_prefix %}
+    <li>
+      {% if letter == current_name_prefix %}
+        <span class="alphabet-links__link alphabet-links__link--current">{{ letter }}</span>
+      {% elif count %}
+        <a class="alphabet-links__link" href='{{ letter }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>{{ letter }}</a>
+      {% else %}
+        <span class="alphabet-links__link alphabet-links__link--disabled">{{ letter }}</a>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ol>

--- a/pombola/core/templates/core/position_position_section.html
+++ b/pombola/core/templates/core/position_position_section.html
@@ -3,6 +3,7 @@
 {% autopaginate positions %}
 
 {% include "core/_place_search_filters.html" %}
+{% include "core/_alphabetical_pagination.html" %}
 {% include "core/_search_pagination_text.html" %}
 {% include "core/_position_listing.html" %}
 

--- a/pombola/core/templatetags/add_query_parameter.py
+++ b/pombola/core/templatetags/add_query_parameter.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def add_query_parameter(request, key, value):
+    query_parameters = request.GET.copy()
+    query_parameters[key] = value
+    return query_parameters.urlencode()

--- a/pombola/core/tests/test_templatetags.py
+++ b/pombola/core/tests/test_templatetags.py
@@ -1,5 +1,6 @@
 # coding=UTF-8
 
+from django.http import QueryDict
 from django.template import Context, Template
 from django.test import TestCase
 
@@ -99,3 +100,29 @@ class GetFromKeyTest(TestCase):
 class LazyDictLike(object):
     def __getitem__(self, key):
         return key + key
+
+
+class AddQueryParameterTest(TestCase):
+    def test_adds_query_parameters_when_there_are_none(self):
+        request  = RequestFake('')
+        template = Template("{% load add_query_parameter %}{% add_query_parameter request 'parameter' 'value' %}")
+        self.assertEqual(
+            template.render(Context({'request': request})), 'parameter=value')
+
+    def test_adds_query_parameters_to_the_existing_ones(self):
+        request  = RequestFake('parameter=value')
+        template = Template("{% load add_query_parameter %}{% add_query_parameter request 'foo' 'bar' %}")
+        self.assertEqual(
+            template.render(Context({'request': request})),
+            'foo=bar&parameter=value')
+
+    def test_overwrites_query_parameters_if_they_exist(self):
+        request  = RequestFake('parameter=value')
+        template = Template("{% load add_query_parameter %}{% add_query_parameter request 'parameter' 'bar' %}")
+        self.assertEqual(
+            template.render(Context({'request': request})), 'parameter=bar')
+
+
+class RequestFake:
+    def __init__(self, query_parameters):
+        self.GET = QueryDict(query_parameters)

--- a/pombola/core/tests/test_views.py
+++ b/pombola/core/tests/test_views.py
@@ -269,6 +269,30 @@ class PositionViewTest(WebTest):
             ['John Much Earlier'],
         )
 
+    def test_shows_alphabetical_pagination_if_query_param_present(self):
+        response = self.app.get('/position/test-title/foo/?a=1')
+        self.assertEqual(
+            len(response.html.findAll('ol', {'class': 'alphabet-links'})), 1)
+
+    def test_shows_alphabetical_pagination_if_query_param_present_with_others(self):
+        response = self.app.get(
+            '/position/test-title/foo/?order=name&a=1')
+        self.assertEqual(
+            len(response.html.findAll('ol', {'class': 'alphabet-links'})), 1)
+
+    def test_does_not_show_alphabetical_pagination_if_no_query_param(self):
+        response = self.app.get('/position/test-title/foo/')
+        self.assertEqual(
+            len(response.html.findAll('ol', {'class': 'alphabet-links'})), 0)
+        self.assertNotIn('alphabetical_link_from_query_parameter', response.context)
+
+    def test_letters_link_to_the_right_url_if_query_param_present(self):
+        response = self.app.get('/position/test-title/foo/?order=name&a=1')
+        ol = response.html.find('ol', {'class': 'alphabet-links'})
+        link = ol.find('a', text='P')['href']
+        self.assertEqual(link, '?a=1&order=name&letter=P')
+        self.assertTrue(response.context['alphabetical_link_from_query_parameter'])
+
 
 class TestPersonView(WebTest):
 

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -480,18 +480,26 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
         places.extend(parent_places)
         places.extend(child_places)
 
+    context = {
+        'object':     title,
+        'page_title': page_title,
+        'order':      request.GET.get('order'),
+        'places':     places,
+        'place_slug': place_slug,
+        'session': session,
+        'session_details': session_details,
+    }
+
+    if request.GET.get('a') == '1':
+        positions, extra_context = filter_by_alphabet(
+            request.GET.get('letter'), positions)
+        context.update(extra_context)
+        context['alphabetical_link_from_query_parameter'] = True
+    context['positions'] = positions
+
     return render_to_response(
         template,
-        {
-            'object':     title,
-            'page_title': page_title,
-            'positions':  positions,
-            'order':      request.GET.get('order'),
-            'places':     places,
-            'place_slug': place_slug,
-            'session': session,
-            'session_details': session_details,
-        },
+        context,
         context_instance=RequestContext(request)
     )
 

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -11,6 +11,7 @@ import datetime
 import os
 import random
 import json
+import string
 import sys
 import subprocess
 from urlparse import urlsplit, urlunsplit
@@ -271,6 +272,45 @@ class PlaceKindList(ListView):
             all_kinds = models.PlaceKind.objects.all(),
         )
         return context
+
+
+def positions_count_for_letter(positions):
+    """Count positions by inital letter of the holders' names
+
+    Given a queryset of positions, this will return a list of tuples
+    where each is (letter, position_count); this groups together and
+    counts the positions held by people whose sort_name has the same
+    initial letter.
+    """
+    return [
+        (letter, positions.person_sort_name_prefix(letter).count())
+        for letter in string.ascii_uppercase
+    ]
+
+
+def filter_by_alphabet(prefix_letter, position_qs):
+    """A helper for producing an alpabetic grouping of positions
+
+    We sometimes wish to list the people holding particular positions
+    grouped by the first letter of their sort_name - this makes it
+    easier to navigate to the person you're looking for. This function
+    helps to generate context values for rending such a menu and the
+    right positions / people.
+
+    'prefix_letter' should either be a letter of the alphabet (if you
+    only want people starting with that letter returned) or None if
+    all positions should be returned (no filtering).  This returns
+    both that filtered position queryset and a dictionary of helpful
+    values for the context for rendering the alphabetic menu.
+    """
+    extra_context = {}
+    extra_context['count_by_prefix'] = \
+        positions_count_for_letter(position_qs)
+    extra_context['current_name_prefix'] = prefix_letter
+    if prefix_letter:
+        position_qs = position_qs.filter(
+            person__sort_name__istartswith=prefix_letter)
+    return position_qs, extra_context
 
 def position_pt(request, pt_slug):
     """Show current positions with a given PositionTitle"""

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -1610,6 +1610,7 @@ ul.pager {
   @include unstyled-list;
   @include clearfix;
   font-size: 0.9em;
+  margin-top: 1em;
 }
 
 .alphabet-links__link {

--- a/pombola/south_africa/templates/core/organisation_people.html
+++ b/pombola/south_africa/templates/core/organisation_people.html
@@ -31,10 +31,9 @@
       </div>
     </div>
 
-    {% regroup sorted_positions by person as regroup_on_person_list %}
-
     <div class="column major-column">
       {% include 'core/_alphabetical_pagination.html' %}
+      {% regroup sorted_positions by person as regroup_on_person_list %}
       <div class="list-of-things list-of-people">
           {% autopaginate regroup_on_person_list %}
 

--- a/pombola/south_africa/templates/core/organisation_people.html
+++ b/pombola/south_africa/templates/core/organisation_people.html
@@ -34,29 +34,7 @@
     {% regroup sorted_positions by person as regroup_on_person_list %}
 
     <div class="column major-column">
-
-      <ol class="alphabet-links">
-          <li>
-            {% if current_name_prefix %}
-              <a class="alphabet-links__link" href='.{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>All</a>
-            {% else %}
-              <span class="alphabet-links__link alphabet-links__link--current">All</span>
-            {% endif %}
-          </li>
-
-        {% for letter, count in count_by_prefix %}
-          <li>
-            {% if letter == current_name_prefix %}
-              <span class="alphabet-links__link alphabet-links__link--current">{{ letter }}</span>
-            {% elif count %}
-              <a class="alphabet-links__link" href='{{ letter }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'>{{ letter }}</a>
-            {% else %}
-              <span class="alphabet-links__link alphabet-links__link--disabled">{{ letter }}</a>
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ol>
-
+      {% include 'core/_alphabetical_pagination.html' %}
       <div class="list-of-things list-of-people">
           {% autopaginate regroup_on_person_list %}
 

--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -102,7 +102,7 @@
             Hot topics
         </h3>
         <div class="home__topics__list">
-            <a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name" class="home__topics__topic">MP profiles</a>
+            <a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name&amp;a=1" class="home__topics__topic">MP profiles</a>
             <a href="{% url 'info_blog_category' slug='mp-corner' %}" class="home__topics__topic">MP corner</a>
             <a href="{% url 'mp-attendance' %}" class="home__topics__topic">MP attendance</a>
             <a href="{% url 'sa-interests-index' %}" class="home__topics__topic">MP assets</a>

--- a/pombola/south_africa/templates/menu_entries.html
+++ b/pombola/south_africa/templates/menu_entries.html
@@ -85,7 +85,7 @@
   {% if include_sub_menu_entries %}
     <ul id="extras-overview" class="js-hover-dropdown" role="menu">
       <li><a href="{% url 'mp-attendance' %}" role="menuitem">MP attendance</a></li>
-      <li><a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name" role="menuitem">MP profiles</a></li>
+      <li><a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name&amp;a=1" role="menuitem">MP profiles</a></li>
       <li><a href="{% url 'sa-interests-index' %}" role="menuitem">MP assets</a></li>
       <li><a href="{% url 'info_blog_category' slug='mp-corner' %}" role="menuitem">MP Corner</a></li>
       <li><a href="{% url 'info_page' slug="infographics" %}" role="menuitem">Infographics</a></li>


### PR DESCRIPTION
This PR:

* Adds a new template tag to add a query parameter to a URL in a template
* Moves the logic for showing an alphabet navigation from the South African views.py to the core so that it can be used elsewhere
* Adds a new query parameter to use in pages where we want to show the alphabet navigation `?a=1`. 

In the screenshot, you can see the url with the new query parameter and the MPs sorted by the letter C

![alpha](https://cloud.githubusercontent.com/assets/2157089/20718071/7c8703f6-b64f-11e6-89e7-b1571dbe9741.png)

Fixes  #2215