### PR TITLE
Remove the survey banner from pa.org.za.

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -550,12 +550,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/hide-reveal.js',
     },
-    'survey': {
-        'source_filenames': (
-            'js/survey.js',
-        ),
-        'output_filename': 'js/survey.js',
-    },
+    # 'survey': {
+    #     'source_filenames': (
+    #         'js/survey.js',
+    #     ),
+    #     'output_filename': 'js/survey.js',
+    # },
 }
 
 # Only for debugging compression (the default is: 'not DEBUG' which is

--- a/pombola/south_africa/templates/header.html
+++ b/pombola/south_africa/templates/header.html
@@ -2,8 +2,4 @@
 
 {% include 'site_header.html' %}
 
-<div id="ms_srv_wrapper" style="display:none" data-display-percentage="0.4">
-    <a href="https://www.surveygizmo.com/s3/2458850/People-s-Assembly-Indigo-Trust-Impact-Survey" id="ms_srv_link" target="_blank">We&rsquo;re running a short survey to help us understand how well People's Assembly works and how we can make it better. If you&rsquo;d like to take it, click here.</a>
-</div>
-
 {% include 'main_menu.html' %}


### PR DESCRIPTION
Comments out the survey JS, as no other Pombola sites are running a survey right now. Leaves CSS, since surveys may come back and it’s tiny.