### PR TITLE
Add option to display original names of speakers

### DIFF
--- a/pombola/hansard/templates/hansard/sitting_detail.html
+++ b/pombola/hansard/templates/hansard/sitting_detail.html
@@ -28,6 +28,9 @@
 
                     {% if entry.speaker %}
                         <strong><a href="{{ entry.speaker.get_absolute_url }}">{{ entry.speaker.name }}</a></strong>
+                        {% if show_original_name %}
+                        <i>[Original name: {{ entry.speaker_name }}]</i>
+                        {% endif %}
                     {% else %}
                         <strong>{{ entry.speaker_name }}</strong>
                     {% endif %}
@@ -52,5 +55,14 @@
     </ul>
 
     {% endwith %}
+
+    {% if display_original_name_option %}
+    <div class="search-filters">
+      <form>
+        <input type="checkbox" id="show_original_name" name="show_original_name" value="1"{% if show_original_name %} checked{% endif %}><label for="show_original_name">Show original speaker names from Hansard</label>
+        <input type="submit" value="Reload">
+      </form>
+    </div>
+    {% endif %}
 
 {% endblock %}

--- a/pombola/hansard/tests/test_sitting_view.py
+++ b/pombola/hansard/tests/test_sitting_view.py
@@ -1,0 +1,56 @@
+from django.contrib.auth.models import User
+from django_webtest import WebTest
+
+from pombola.core import models
+from ..models import Entry, Sitting
+
+class TestSittingView(WebTest):
+
+    fixtures = ['hansard_test_data']
+
+    def setUp(self):
+        self.staffuser = User.objects.create(
+            username='editor',
+            is_staff=True)
+        self.person = models.Person.objects.create(
+            legal_name="Alfred Smith",
+            slug='alfred-smith')
+        self.sitting = Sitting.objects.get(
+            venue__slug='national_assembly',
+            start_date='2010-04-11',
+            start_time='09:30:00')
+        Entry.objects.create(
+            sitting=self.sitting,
+            type='speech',
+            page_number=1,
+            text_counter=1,
+            speaker_name='John Smith',
+            speaker=self.person,
+            content='Good morning, everyone')
+
+    def test_normal_view(self):
+        response = self.app.get('/hansard/sitting/national_assembly/2010-04-11-09-30-00')
+        self.assertIn('Good morning, everyone', response.content)
+        self.assertIn(
+            '<strong><a href="/person/alfred-smith/">Alfred Smith</a></strong>',
+            response.content)
+        self.assertNotIn('John Smith', response.content)
+
+    def test_with_speaker_names_anonymous_user(self):
+        response = self.app.get(
+            '/hansard/sitting/national_assembly/2010-04-11-09-30-00?show_original_name=1')
+        self.assertIn('Good morning, everyone', response.content)
+        self.assertIn(
+            '<strong><a href="/person/alfred-smith/">Alfred Smith</a></strong>',
+            response.content)
+        self.assertNotIn('John Smith', response.content)
+
+    def test_with_speaker_names_user_is_staff(self):
+        response = self.app.get(
+            '/hansard/sitting/national_assembly/2010-04-11-09-30-00?show_original_name=1',
+            user=self.staffuser)
+        self.assertIn('Good morning, everyone', response.content)
+        self.assertIn(
+            '<strong><a href="/person/alfred-smith/">Alfred Smith</a></strong>',
+            response.content)
+        self.assertIn('John Smith', response.content)

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -105,6 +105,13 @@ class SittingView(DetailView):
 
         return sittings[0]
 
+    def get_context_data(self, **kwargs):
+        context = super(SittingView, self).get_context_data(**kwargs)
+        if self.request.user.is_staff:
+            context['show_original_name'] = self.request.GET.get('show_original_name', False)
+        context['display_original_name_option'] = self.request.user.is_staff
+        return context
+
 
 # class BaseView ( View ):
 #     pass


### PR DESCRIPTION
Allow admin users to select an option that will display the original
name of the speaker from Hansard next to the name we have matched
against. This should help to make debugging problems with aliasing and
speaker matching a bit easier.