### PR TITLE
ZA: MP Profiles tiny header fix

### DIFF
--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -384,6 +384,8 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
         possible_sessions = models.ParliamentarySession.objects.order_by('name')
 
     page_title = title.name
+
+    organisation_kind = None
     if o_slug:
         organisation = get_object_or_404(models.Organisation,
                                          slug=o_slug)
@@ -489,6 +491,9 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
         'session': session,
         'session_details': session_details,
     }
+
+    if organisation_kind is not None:
+        context['organisation_kind'] = organisation_kind
 
     if request.GET.get('a') == '1':
         positions, extra_context = filter_by_alphabet(

--- a/pombola/south_africa/templates/core/position_detail.html
+++ b/pombola/south_africa/templates/core/position_detail.html
@@ -10,7 +10,11 @@
         <a href="{% url "position_pt" pt_slug=object.slug %}?view=grid{% if order %}&order={{order|urlencode}}{% endif %}">View as grid</a>
     </div>
 
+    {% if object.slug == 'member' and organisation_kind.slug == 'parliament' %}
+    <h1 class="page-title">Members of Parliament</h1>
+    {% else %}
     <h1 class="page-title">{{ page_title }}</h1>
+    {% endif %}
 
     <form action="{% url "core_search" %}">
         <div class="inline-search-box people-list-inline-search">

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -2025,3 +2025,39 @@ class SAUrlRoutingTest(TestCase):
     def test_za_home(self):
         match = resolve('/')
         self.assertEqual(match.func.func_name, 'SAHomeView')
+
+
+@attr(country='south_africa')
+class SAMPProfilesMainHeader(WebTest):
+    def setUp(self):
+        self.title1 = models.PositionTitle.objects.create(
+            name='Member',
+            slug='member',
+        )
+        self.organisation_kind1 = models.OrganisationKind.objects.create(
+            name='Parliament',
+            slug='parliament',
+        )
+        self.title2 = models.PositionTitle.objects.create(
+            name='Foo',
+            slug='foo',
+        )
+        self.organisation_kind2 = models.OrganisationKind.objects.create(
+            name='Bar',
+            slug='bar',
+        )
+
+    def test_mp_profiles_page_has_no_any_in_the_header(self):
+        response = self.app.get('/position/member/parliament/')
+        self.assertEqual(
+            response.html.find(class_='page-title').string, 'Members of Parliament')
+
+    def test_pages_with_other_ok_slug_have_any_in_the_header(self):
+        response = self.app.get('/position/member/bar/')
+        self.assertEqual(
+            response.html.find(class_='page-title').string, 'Member of any Bar')
+
+    def test_pages_with_other_position_title_have_any_in_the_header(self):
+        response = self.app.get('/position/foo/parliament/')
+        self.assertEqual(
+            response.html.find(class_='page-title').string, 'Foo of any Parliament')


### PR DESCRIPTION
This PR addresses the first part of #2221, in particular, deleting "any" from the header of the MP Profiles page.

Since this change affects only a particular page in a particular country, a conditional was added to the template that renders the MP Profiles page in the South African site to discriminate this particular page from other position pages.

For this conditional to work properly, a new item was added to the positions context in the core views so that it also sends the organization kind slug (`ok_slug`) to the template.

The tests cover the three branches of the condition.