### PR TITLE
ZA: MP Profiles tiny subheader fix 

### DIFF
--- a/pombola/core/templates/core/_position_session_links.html
+++ b/pombola/core/templates/core/_position_session_links.html
@@ -1,7 +1,7 @@
 {% if session %}
   <h3>Position holders during {{ session.name }}</h3>
   <h4>({{ session.readable_date_range }})</h4>
-{% else %}
+{% elif object.slug != 'member' or organisation_kind.slug != 'parliament' %}
   <h3>Current Position Holders</h3>
 {% endif %}
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -2061,3 +2061,41 @@ class SAMPProfilesMainHeader(WebTest):
         response = self.app.get('/position/foo/parliament/')
         self.assertEqual(
             response.html.find(class_='page-title').string, 'Foo of any Parliament')
+
+
+@attr(country='south_africa')
+class SAMPProfilesSubHeader(WebTest):
+    def setUp(self):
+        self.title1 = models.PositionTitle.objects.create(
+            name='Member',
+            slug='member',
+        )
+        self.organisation_kind1 = models.OrganisationKind.objects.create(
+            name='Parliament',
+            slug='parliament',
+        )
+        self.title2 = models.PositionTitle.objects.create(
+            name='Foo',
+            slug='foo',
+        )
+        self.organisation_kind2 = models.OrganisationKind.objects.create(
+            name='Bar',
+            slug='bar',
+        )
+
+    def test_mp_profiles_page_has_no_subheader(self):
+        response = self.app.get('/position/member/parliament/')
+        self.assertTrue(
+            response.html.find(class_='content_box').find('h3') is None)
+
+    def test_pages_with_other_ok_slug_have_the_subheader(self):
+        response = self.app.get('/position/member/bar/')
+        self.assertEqual(
+            response.html.find(class_='content_box').find('h3').string,
+            'Current Position Holders')
+
+    def test_pages_with_other_position_title_have_the_subheader(self):
+        response = self.app.get('/position/foo/parliament/')
+        self.assertEqual(
+            response.html.find(class_='content_box').find('h3').string,
+            'Current Position Holders')


### PR DESCRIPTION
This PR addresses the second part of #2221, in particular, deleting the subheader that reads "Current Position Holders" in the MP Profiles page.

Since this change affects only a particular page in a particular country, a conditional was added to the template that renders the MP Profiles page in the South African site to discriminate this particular page from other position pages.

The tests cover the three branches of the condition.

## Notes to merger

 #2228 should be merged first. However, I have cherry-picked a commit from that PR that was needed for this PR (3075173). Hopefully once the other branch is merged, and this branch is rebased with master, that duplicated commit will dissapear.

Fixes #2221