### PR TITLE
[SA] hide obvious or irrelevant positions and places in people lists

### DIFF
--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -384,7 +384,7 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
         possible_sessions = models.ParliamentarySession.objects.order_by('name')
 
     page_title = title.name
-
+    organisation = None
     organisation_kind = None
     if o_slug:
         organisation = get_object_or_404(models.Organisation,
@@ -486,14 +486,13 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
         'object':     title,
         'page_title': page_title,
         'order':      request.GET.get('order'),
+        'organisation_kind':   organisation_kind,
+        'org':        organisation,
         'places':     places,
         'place_slug': place_slug,
         'session': session,
         'session_details': session_details,
     }
-
-    if organisation_kind is not None:
-        context['organisation_kind'] = organisation_kind
 
     if request.GET.get('a') == '1':
         positions, extra_context = filter_by_alphabet(

--- a/pombola/south_africa/templates/core/_person_position.html
+++ b/pombola/south_africa/templates/core/_person_position.html
@@ -1,0 +1,13 @@
+{% load za_people_display %}
+
+{% should_display_position position.organisation position.title as display_position %}
+{% if display_position %}
+  {{ position.title }}
+{% endif %}
+{% should_display_place position.organisation as display_place %}
+{% if display_place and position.place %}
+    (<a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>)
+{% endif %}
+{% if display_position or display_place and position.place %}
+  <br/>
+{% endif %}

--- a/pombola/south_africa/templates/core/organisation_party.html
+++ b/pombola/south_africa/templates/core/organisation_party.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load thumbnail %}
 {% load hidden %}
+{% load za_people_display %}
 
 
 {% block title %}{{ object.name }} {{ party.slug.upper }} members{% endblock %}
@@ -60,11 +61,17 @@
                   {% endmaybehidden %}
 
                   {% for position in positions %}
-                      {{ position.title }}
-                      {% if position.place %}
+                      {% should_display_position position.organisation position.title as display_position %}
+                      {% if display_position %}
+                        {{ position.title }}
+                      {% endif %}
+                      {% should_display_place position.organisation as display_place %}
+                      {% if display_place and position.place %}
                           (<a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>)
                       {% endif %}
-                      <br/>
+                      {% if display_position or display_place and position.place %}
+                        <br/>
+                      {% endif %}
                   {% endfor %}
 
                 </li>

--- a/pombola/south_africa/templates/core/organisation_party.html
+++ b/pombola/south_africa/templates/core/organisation_party.html
@@ -3,7 +3,6 @@
 {% load staticfiles %}
 {% load thumbnail %}
 {% load hidden %}
-{% load za_people_display %}
 
 
 {% block title %}{{ object.name }} {{ party.slug.upper }} members{% endblock %}
@@ -61,17 +60,7 @@
                   {% endmaybehidden %}
 
                   {% for position in positions %}
-                      {% should_display_position position.organisation position.title as display_position %}
-                      {% if display_position %}
-                        {{ position.title }}
-                      {% endif %}
-                      {% should_display_place position.organisation as display_place %}
-                      {% if display_place and position.place %}
-                          (<a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>)
-                      {% endif %}
-                      {% if display_position or display_place and position.place %}
-                        <br/>
-                      {% endif %}
+                    {% include "core/_person_position.html" %}
                   {% endfor %}
 
                 </li>

--- a/pombola/south_africa/templates/core/organisation_people.html
+++ b/pombola/south_africa/templates/core/organisation_people.html
@@ -2,6 +2,7 @@
 {% load pagination_tags %}
 {% load staticfiles %}
 {% load thumbnail %}
+{% load za_people_display %}
 
 
 {% block title %}{{ object.name }} People{% endblock %}
@@ -54,11 +55,17 @@
                   </a>
 
                   {% for position in positions %}
-                      {{ position.title }}
-                      {% if position.place %}
+                      {% should_display_position position.organisation position.title as display_position %}
+                      {% if display_position %}
+                        {{ position.title }}
+                      {% endif %}
+                      {% should_display_place position.organisation as display_place %}
+                      {% if display_place and position.place %}
                           (<a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>)
                       {% endif %}
-                      <br/>
+                      {% if display_position or display_place and position.place %}
+                        <br/>
+                      {% endif %}
                   {% endfor %}
 
                 </li>

--- a/pombola/south_africa/templates/core/organisation_people.html
+++ b/pombola/south_africa/templates/core/organisation_people.html
@@ -2,7 +2,6 @@
 {% load pagination_tags %}
 {% load staticfiles %}
 {% load thumbnail %}
-{% load za_people_display %}
 
 
 {% block title %}{{ object.name }} People{% endblock %}
@@ -55,17 +54,7 @@
                   </a>
 
                   {% for position in positions %}
-                      {% should_display_position position.organisation position.title as display_position %}
-                      {% if display_position %}
-                        {{ position.title }}
-                      {% endif %}
-                      {% should_display_place position.organisation as display_place %}
-                      {% if display_place and position.place %}
-                          (<a href="{{ position.place.get_absolute_url }}">{{ position.place.name }}</a>)
-                      {% endif %}
-                      {% if display_position or display_place and position.place %}
-                        <br/>
-                      {% endif %}
+                    {% include "core/_person_position.html" %}
                   {% endfor %}
 
                 </li>

--- a/pombola/south_africa/templates/core/person_list_item.html
+++ b/pombola/south_africa/templates/core/person_list_item.html
@@ -1,5 +1,6 @@
 {% load staticfiles %}
 {% load thumbnail %}
+{% load za_people_display %}
 
 <a href="{{ object.get_absolute_url }}">
     {% thumbnail object.primary_image "58x78" crop="center" as im %}
@@ -12,16 +13,19 @@
 </a>
 
 {% if not skip_positions %}
-  {% for place in object.position_set.all.current_unique_places %}
-      <div class="position-place">
-        <a href="{{ place.get_absolute_url }}">{{ place.name }}</a>
+  {% should_display_place organisation_kind as display_place %}
+  {% if display_place %}
+    {% for place in object.position_set.all.current_unique_places %}
+        <div class="position-place">
+          <a href="{{ place.get_absolute_url }}">{{ place.name }}</a>
 
-        {% if place.parent_place %}
-          <a href="{{ place.parent_place.get_absolute_url }}">{{ place.parent_place.name }}</a>
-          {{ place.parent_place.kind.name }}
-        {% endif %}
-      </div>
-  {% endfor %}
+          {% if place.parent_place %}
+            <a href="{{ place.parent_place.get_absolute_url }}">{{ place.parent_place.name }}</a>
+            {{ place.parent_place.kind.name }}
+          {% endif %}
+        </div>
+    {% endfor %}
+  {% endif %}
 {% endif %}
 
 {% if object.parties %}

--- a/pombola/south_africa/templatetags/za_people_display.py
+++ b/pombola/south_africa/templatetags/za_people_display.py
@@ -1,0 +1,24 @@
+from django import template
+
+register = template.Library()
+
+NO_PLACE_ORGS = ('parliament', 'national-assembly', )
+MEMBER_ORGS = ('parliament', 'national-assembly', )
+
+
+@register.assignment_tag()
+def should_display_place(organisation):
+    return organisation.slug not in NO_PLACE_ORGS
+
+
+@register.assignment_tag()
+def should_display_position(organisation, position_title):
+    should_display = True
+
+    if organisation.slug in MEMBER_ORGS and unicode(position_title) in (u'Member',):
+        should_display = False
+
+    if 'ncop' == organisation.slug and unicode(position_title) in (u'Delegate',):
+        should_display = False
+
+    return should_display

--- a/pombola/south_africa/views/organisations.py
+++ b/pombola/south_africa/views/organisations.py
@@ -45,6 +45,8 @@ class SAOrganisationDetailView(CommentArchiveMixin, OrganisationDetailView):
         if self.object.kind.slug == 'parliament':
             self.add_parliament_counts_to_context_data(context)
 
+        context['organisation_kind'] = self.object.kind
+
         # Sort the list of positions in an organisation by an approximation
         # of their holder's last name.
         context['positions'] = sorted(


### PR DESCRIPTION
This hides place names and positions in people lists where they are either obvious (e.g. all Members of Parliament will have the position Member) or irrelevant (the province of an MP is not very useful).

It does this using template tags to check if the position or place is relevant for the organisation that is currently being displayed.

Fixes #2222