### PR TITLE
Add code coverage measurement and reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - bundle install --deployment --path ../gems --binstubs ../gem-bin
   # Now install the rest of the required Python packages:
   - CFLAGS="-O0" pip install -r requirements.txt
+  - pip install python-coveralls
   - pip check
   # Create a basic general.yml file:
   - sed -r
@@ -39,4 +40,7 @@ before_script:
   - ./manage.py collectstatic --noinput
 
 script:
-  - ./run-tests
+  - ./run-tests --coverage
+
+after_success:
+  - coveralls

--- a/run-tests
+++ b/run-tests
@@ -4,6 +4,14 @@ EXIT_CODE=0
 
 cd $(dirname "$BASH_SOURCE")
 
+if [ "$1" = "--coverage" ]
+then
+    shift
+    COVERAGE_PREFIX="coverage run -a --source=pombola,pombola_sayit,wordcloud"
+    coverage erase
+fi
+
+
 update_exit_code() {
     LAST_EXIT_CODE=$?
     if [ $LAST_EXIT_CODE != 0 ]
@@ -21,11 +29,16 @@ TEST_SETTINGS_MODULES=(
 
 for TEST_SETTINGS_MODULE in "${TEST_SETTINGS_MODULES[@]}"
 do
-    COMMAND="./manage.py test --settings=$TEST_SETTINGS_MODULE"
+    COMMAND="$COVERAGE_PREFIX ./manage.py test --settings=$TEST_SETTINGS_MODULE"
     echo Running: $COMMAND "$@"
     $COMMAND "$@"
     update_exit_code
 done
+
+if [ x"$COVERAGE_PREFIX" != x ]
+then
+    coverage html
+fi
 
 # If any test failed, make sure we output an error message in red at
 # the end of the test run, just in case the test failures from the


### PR DESCRIPTION
One of these commits adds a convenient `--coverage` option
to `./run-tests`, while the other uses that option on Travis and
reports the results to https://coveralls.io