### PR TITLE
ZA - remove place filter on MP profiles list page

### DIFF
--- a/pombola/south_africa/templates/core/position_position_section.html
+++ b/pombola/south_africa/templates/core/position_position_section.html
@@ -1,0 +1,9 @@
+{% load pagination_tags %}
+
+{% autopaginate positions %}
+
+{% include "core/_alphabetical_pagination.html" %}
+{% include "core/_search_pagination_text.html" %}
+{% include "core/_position_listing.html" %}
+
+{% paginate %}


### PR DESCRIPTION
This removes the dropdown for only showing MPs by area as it's largely been made redundant by the improved search.

Fixes #2233