### PR TITLE
2239 za filter attendance by minister

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2814,7 +2814,7 @@ p.attendance__disclaimer {
     #warning-notice {
         background-color: #e23d28;
         color: #fff;
-        font-size: 14px;
+        font-size: 12px;
         padding: 10px;
         margin-bottom: 10px;
     }

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2824,6 +2824,10 @@ p.attendance__disclaimer {
     }
 
     .mp-attendance-filter {
+        form.filter-attendance {
+            margin-bottom: 15px;
+        }
+
         .col-50 {
             @media only all and (min-width: 640px) {
                 float: left;
@@ -2842,13 +2846,23 @@ p.attendance__disclaimer {
         background-color: #f6f6f6;
         vertical-align: top;
 
-        label {
-            width: 25%;
-            display: inline-block;
+        .filter {
+            margin-bottom: 10px;
+            label {
+                display: inline-block;
+            }
         }
 
-        .filter-option {
-            height: 30px;
+        .select {
+            label {
+                width: 25%;
+            }
+        }
+
+        .radio {
+            label {
+                width: 100%;
+            }
         }
 
         input {
@@ -2880,6 +2894,10 @@ p.attendance__disclaimer {
                 text-decoration: none;
             }
         }
+    }
+
+    h2.average-attendance {
+        margin-bottom: 0;
     }
 
     th.sorting {

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -21,7 +21,7 @@
   <p>Explore the committee meeting attendance records for the members of parliament.</p>
 </div>
 <div id="warning-notice">
-    Please note: People's Assembly has suspended access to attendance of the MPs of small parties until it gets to grips with the framework under which small parties operate. It is also re-evaluating how to process the attendance of alternate members of committees.
+    Please note: People's Assembly has suspended access to attendance of the MPs of small parties.
 </div>
 
 <div class='mp-attendance-filter'>

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -48,12 +48,12 @@
     <div class="col-50">
       <div class="filter radio">
         <label>
-          <input type="radio" name="position" value="all" {% if position == "all" %}checked{% endif %}/>
-          Show all MPs
-        </label>
-        <label>
           <input type="radio" name="position" value="ministers"{% if position == "ministers" %} checked{% endif %}/>
           Show ministers and deputy ministers
+        </label>
+        <label>
+          <input type="radio" name="position" value="all" {% if position == "all" %}checked{% endif %}/>
+          Show all MPs
         </label>
       </div>
     </div>

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -25,9 +25,9 @@
 </div>
 
 <div class='mp-attendance-filter'>
-  <div class="col-50">
-    <form class='select-year' action="{% url 'mp-attendance' %}" method="get">
-      <div class="filter-option">
+  <form class='filter-attendance' action="{% url 'mp-attendance' %}" method="get">
+    <div class="col-50">
+      <div class="filter select">
         <label>Select a year:</label>
         <select name="year">
          {% for yr in years %}
@@ -35,7 +35,7 @@
          {% endfor %}
         </select>
       </div>
-      <div class="filter-option">
+      <div class="filter select">
         <label>Choose a party:</label>
         <select name="party">
           <option value="" selected>All</option>
@@ -44,14 +44,30 @@
          {% endfor %}
         </select>
       </div>
+    </div>
+    <div class="col-50">
+      <div class="filter radio">
+        <label>
+          <input type="radio" name="position" value="all" {% if position == "all" %}checked{% endif %}/>
+          Show all MPs
+        </label>
+        <label>
+          <input type="radio" name="position" value="ministers"{% if position == "ministers" %} checked{% endif %}/>
+          Show ministers and deputy ministers
+        </label>
+      </div>
+    </div>
+    <div class="clear"></div>
+    <div class="col-50">
       <input class="button" type="submit" value="Show attendance">
-    </form>
-  </div>
+    </div>
+    <div class="clear"></div>
+  </form>
 
   {% if party %}
    <div class="col-50">
     {% if aggregate_attendance >= 0 %}
-      <h2>{{ aggregate_attendance }}%</h2>
+      <h2 class="average-attendance">{{ aggregate_attendance }}%</h2>
       <p>Average attendance for {{ party }}</p>
     {% else %}
       <p>Not enough data to calculate average attendance.</p>

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -87,7 +87,7 @@ class SAMpAttendanceView(TemplateView):
         context['year'] = str(
             dateutil.parser.parse(data[0]['end_date']).year)
         context['party'] = ''
-        context['position'] = 'all'
+        context['position'] = 'ministers'
 
         for key in ('year', 'party', 'position'):
             if key in self.request.GET:


### PR DESCRIPTION
These changes allow a user to filter the attendance by all MPs or only Ministers,
with the page defaulting to show the attendance of Ministers only.

Data received from the PMG API is matched with Persons by comparing part of the PA URL received with the slug field.

The Position's slug is also used to get Ministers and Deputy Ministers. `overlapping_dates` is used to include all active Ministers for the year being viewed.

A small edit to the text in the notification box has also been made.
