### PR TITLE
MPs and Ministers are mutually exclusive

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2863,6 +2863,12 @@ p.attendance__disclaimer {
             label {
                 width: 100%;
             }
+
+            .note {
+                font-size: 12px;
+                margin: 15px;
+                display: block;
+            }
         }
 
         input {

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -49,12 +49,13 @@
       <div class="filter radio">
         <label>
           <input type="radio" name="position" value="ministers"{% if position == "ministers" %} checked{% endif %}/>
-          Show ministers and deputy ministers
+          Show ministers and deputy ministers *
         </label>
         <label>
-          <input type="radio" name="position" value="all" {% if position == "all" %}checked{% endif %}/>
-          Show all MPs
+          <input type="radio" name="position" value="mps" {% if position == "mps" %}checked{% endif %}/>
+          Show MPs
         </label>
+        <span class="note">* Ministerial attendance is not compulsory but is encouraged</span>
       </div>
     </div>
     <div class="clear"></div>
@@ -66,11 +67,13 @@
 
   {% if party %}
    <div class="col-50">
-    {% if aggregate_attendance >= 0 %}
-      <h2 class="average-attendance">{{ aggregate_attendance }}%</h2>
-      <p>Average attendance for {{ party }}</p>
-    {% else %}
-      <p>Not enough data to calculate average attendance.</p>
+    {% if position = 'mps' %}
+      {% if aggregate_attendance >= 0 %}
+        <h2 class="average-attendance">{{ aggregate_attendance }}%</h2>
+        <p>Average attendance for {{ party }}</p>
+      {% else %}
+        <p>Not enough data to calculate average attendance.</p>
+      {% endif %}
     {% endif %}
    </div>
   {% endif %}


### PR DESCRIPTION
This change excludes Ministers from the list when viewing the attendance of MPs.

If we cannot determine the `Position` of a `Person` (when the Members returned from the PMG API  has `pa_url=None`), we assume them to be an MP.

The average attendance for parties should only be displayed when viewing MP attendance, and not when viewing the attendance for Ministers, as their attendance is only encouraged and not  compulsory.