### PR TITLE
2247 minister attendance

### DIFF
--- a/pombola/south_africa/static/js/attendance-table.js
+++ b/pombola/south_africa/static/js/attendance-table.js
@@ -1,8 +1,13 @@
 jQuery (function($) {
   $(document).ready(function(){
+      var order_by;
+      if (POSITION == 'ministers') {
+        order_by = [2, "desc"]
+      }
       $('#mp-attendance').DataTable({
         "paging": false,
-        "info": false
+        "info": false,
+        "order": order_by
       });
   });
 });

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2120,7 +2120,7 @@ p.attendance__percentage {
 p.attendance__disclaimer {
   color: $colour_middling_grey;
   font-size: 0.8em;
-  margin: 2em 0;
+  margin: 0.8em 0;
 }
 
 /* Hansard index page */
@@ -2811,6 +2811,7 @@ p.attendance__disclaimer {
 }
 
 .mp-attendance {
+
     #warning-notice {
         background-color: #e23d28;
         color: #fff;
@@ -2823,9 +2824,17 @@ p.attendance__disclaimer {
         padding: 12px 0;
     }
 
+    .dataTables_wrapper .dataTables_filter {
+        float: left;
+    }
+
     .mp-attendance-filter {
         form.filter-attendance {
             margin-bottom: 15px;
+
+            .button {
+                float: right;
+            }
         }
 
         .col-50 {
@@ -2866,8 +2875,10 @@ p.attendance__disclaimer {
 
             .note {
                 font-size: 12px;
-                margin: 15px;
+                margin-top: 15px;
                 display: block;
+                line-height: 14px;
+                color: $colour_middling_grey;
             }
         }
 
@@ -2892,6 +2903,7 @@ p.attendance__disclaimer {
             margin-top: 0;
             background-color: $colour_middling_grey;
             font-size: 0.75em;
+            float: right;
 
             &:hover,
             &:focus {

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -67,7 +67,7 @@
 
   {% if party %}
    <div class="col-50">
-    {% if position = 'mps' %}
+    {% if position == 'mps' %}
       {% if aggregate_attendance >= 0 %}
         <h2 class="average-attendance">{{ aggregate_attendance }}%</h2>
         <p>Average attendance for {{ party }}</p>
@@ -91,9 +91,11 @@
       <th>Name</th>
       <th>Party</th>
       <th>Meetings</th>
+      {% if position == 'mps' %}
       <th>Present</th>
       <th>Arrived late</th>
       <th>Departed Early</th>
+      {% endif %}
     </tr>
   </thead>
   <tbody>
@@ -101,6 +103,9 @@
     <tr>
       <td><a href="{{ member.pa_url }}">{{ member.name }}</td>
       <td>{{ member.party_name }}</td>
+      {% if position == 'ministers' %}
+      <td>{{ member.present }}</td>
+      {% else %}
       <td>{{ member.total }}</td>
       <td width="15%">
         <div class="attendance">
@@ -127,6 +132,7 @@
           </div>
         </div>
       </td>
+      {% endif %}
     </tr>
    {% endfor %}
   </tbody>

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -5,6 +5,9 @@
 
 {% block js_end_of_body %}
   {{ block.super }}
+  <script type="text/javascript">
+    var POSITION = '{{ position|escapejs }}';
+  </script>
   {% javascript 'attendance-table' %}
 {% endblock %}
 

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -19,16 +19,30 @@
 {% block body_attributes %} class="mp-attendance" {% endblock %}
 
 {% block content %}
-<h1 class="page-title">MP Attendance</h1>
+<h1 class="page-title">MP and Minister Attendance</h1>
 <div class="major-column">
-  <p>Explore the committee meeting attendance records for the members of parliament.</p>
-</div>
-<div id="warning-notice">
-    Please note: People's Assembly has suspended access to attendance of the MPs of small parties.
+  <p>Explore the committee meeting attendance records for the members and ministers of parliament.</p>
 </div>
 
 <div class='mp-attendance-filter'>
   <form class='filter-attendance' action="{% url 'mp-attendance' %}" method="get">
+    <div class="col-50">
+      <div class="filter radio">
+        <label>
+          <input type="radio" name="position" value="ministers"{% if position == "ministers" %} checked{% endif %}/>
+          Show ministers and deputy ministers *
+        </label>
+        <label>
+          <input type="radio" name="position" value="mps" {% if position == "mps" %}checked{% endif %}/>
+          Show MPs
+        </label>
+        <span class="note">
+        * Ministerial attendance is not compulsory but is encouraged <br/>
+        &nbsp; Ministerial attendance captured only since mid 2016
+        </span>
+      </div>
+
+    </div>
     <div class="col-50">
       <div class="filter select">
         <label>Select a year:</label>
@@ -47,25 +61,11 @@
          {% endfor %}
         </select>
       </div>
-    </div>
-    <div class="col-50">
-      <div class="filter radio">
-        <label>
-          <input type="radio" name="position" value="ministers"{% if position == "ministers" %} checked{% endif %}/>
-          Show ministers and deputy ministers *
-        </label>
-        <label>
-          <input type="radio" name="position" value="mps" {% if position == "mps" %}checked{% endif %}/>
-          Show MPs
-        </label>
-        <span class="note">* Ministerial attendance is not compulsory but is encouraged</span>
-      </div>
-    </div>
-    <div class="clear"></div>
-    <div class="col-50">
+
       <input class="button" type="submit" value="Show attendance">
     </div>
     <div class="clear"></div>
+
   </form>
 
   {% if party %}
@@ -84,7 +84,16 @@
   <div class="clear"></div>
 
   <hr>
-  <a class="button download" href="{{ download_url }}">Download raw data</a>
+  <div class="col-50">
+    <p class="attendance__disclaimer">Methodology: MPs are recorded as absent whether they have, or have not submitted apologies.</p>
+    <p class="attendance__disclaimer">Please note: People's Assembly has suspended access to attendance of the MPs of small parties.</p>
+  </div>
+  <div class="col-50">
+    <p class="attendance__disclaimer">DISCLAIMER: This is not the official attendance record of Parliament. This information has been obtained via the Parliamentary Monitoring Group. PMG makes every effort to compile reliable and comprehensive information, but does not claim that the data is 100% accurate and complete.</p>
+    <a class="button download" href="{{ download_url }}">Download raw data</a>
+  </div>
+
+  <div class="clear"></div>
 
 </div>
 
@@ -93,8 +102,10 @@
     <tr>
       <th>Name</th>
       <th>Party</th>
+      {% if position == 'ministers' %}
+      <th>Present</th>
+      {% else %}
       <th>Meetings</th>
-      {% if position == 'mps' %}
       <th>Present</th>
       <th>Arrived late</th>
       <th>Departed Early</th>
@@ -140,8 +151,5 @@
    {% endfor %}
   </tbody>
 </table>
-
-<p class="attendance__disclaimer">DISCLAIMER: This is not the official attendance record of Parliament. This information has been obtained via the Parliamentary Monitoring Group. PMG makes every effort to compile reliable and comprehensive information, but does not claim that the data is 100% accurate and complete.</p>
-<p class="attendance__disclaimer">Methodology: MPs are recorded as absent whether they have, or have not submitted apologies.</p>
 
 {% endblock %}

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -87,21 +87,27 @@ class SAMpAttendanceView(TemplateView):
             # and we need to show that they haven't attendended any meetings
             for position in active_minister_positions:
                 minister = position.person
-                if minister.slug in active_minister_slugs:
+                # `active_ministers` contain ministers from all parties.
+                # If the user selected to filter by party, only append ministers from that party
+                # to `minister_attendance`.
+                if party and minister.parties()[0].slug.upper() != party:
+                    continue
+                else:
+                    if minister.slug in active_minister_slugs:
 
-                    # Build name consistent with PMG data
-                    initials = "".join(name[0].upper() for name in minister.given_name.split())
-                    minister_name = "{}, {} {}".format(
-                        minister.family_name, minister.title, initials)
+                        # Build name consistent with PMG data
+                        initials = "".join(name[0].upper() for name in minister.given_name.split())
+                        minister_name = "{}, {} {}".format(
+                            minister.family_name, minister.title, initials)
 
-                    minister_attendance.append({
-                        'member': {
-                            'name': minister_name,
-                            'pa_url': minister.get_absolute_url(),
-                            'party_name': minister.parties()[0].slug.upper()},
-                        'attendance': {
-                            'P': 0}
-                    })
+                        minister_attendance.append({
+                            'member': {
+                                'name': minister_name,
+                                'pa_url': minister.get_absolute_url(),
+                                'party_name': minister.parties()[0].slug.upper()},
+                            'attendance': {
+                                'P': 0}
+                        })
             attendance = minister_attendance
 
         else:


### PR DESCRIPTION
This enables us to show an attendance of 0 for ministers without attendance records, and to only display a subset of columns for the ministers.

We get all the active Minister Positions from the DB as at the date of the query, or the year end. Whichever is earlier.

For the People associated with active ministerial Positions, for whom we didn't receive data from the PMG API, we add attendance records of 0. If we cannot determine a member in the API results to be a Minister, we assume them to be an MP.

We only show meetings attended for ministers, as attendance is not compulsory, and we don't want to give this impression by showing a ratio.

The filters and disclaimers have also been re-arranged on the page.