### PR TITLE
Only show no of meetings attended for ministers on Person profile

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -1265,6 +1265,18 @@ class PositionQuerySet(models.query.GeoQuerySet):
         """Filter by a prefix of the person's sort_name"""
         return self.filter(person__sort_name__istartswith=prefix)
 
+    def active_at_end_of_year(self, year):
+        """Return the active positions at the of year, or today if it's before."""
+        year_end_date = datetime.date(year, 12, 31)
+        today = datetime.date.today()
+
+        return self.currently_active(
+            today if year_end_date > today else year_end_date)
+
+    def title_slug_prefixes(self, titles):
+        """Fileter positions by prefixes in the title's slug"""
+        qs = [Q(title__slug__startswith=title) for title in titles]
+        return self.filter(reduce(lambda acc, item: acc | item, qs))
 
 class Position(ModelBase, IdentifierMixin):
     category_choices = (

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2098,6 +2098,12 @@ p.attendance__percentage {
     margin-bottom: 0.3em;
 }
 
+p.attendance__number {
+    font-size: 1.2em;
+    color: $colour_green;
+    font-family: $font_family_lato;
+}
+
 .attendance__context {
     color: $colour_grey;
 }

--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -228,14 +228,17 @@
                     <h3 class="attendance__heading">{{ data.year }} attendance</h3>
                     {% if data.year == 2014 %}<p>(From the start of the Fifth Parliament)</p>{% endif %}
                   </header>
-
-                  <p class="attendance__percentage">{{ data.percentage|floatformat:"0" }}% attendance rate</p>
-                  <p class="attendance__context">Attended {{ data.attended }} meeting{{ data.attended|pluralize }} out of {{ data.total }}</p>
+                  {% if data.position == 'minister' %}
+                    <p class="attendance__number">Attended {{ data.attended }} meeting{{ data.attended|pluralize }}</p>
+                  {% else %}
+                    <p class="attendance__percentage">{{ data.percentage|floatformat:"0" }}% attendance rate</p>
+                    <p class="attendance__context">Attended {{ data.attended }} meeting{{ data.attended|pluralize }} out of {{ data.total }}</p>
+                  {% endif %}
                 {% endfor %}
 
-                <p>MP attendance is compulsory unless an apology
-                is given. Minister/Deputy Minister attendance is
-                not compulsory.</p>
+                <p>Minister/Deputy Minister attendance is
+                not compulsory. MP attendance is compulsory unless an apology
+                is given.</p>
 
               </div>
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -503,8 +503,8 @@ class SAPersonDetailViewTest(PersonSpeakerMappingsMixin, TestCase):
 
         self.assertEqual(
             context['attendance'],
-            [{'total': 28, 'percentage': 89.28571428571429, 'attended': 25, 'year': 2015    },
-             {'total': 15, 'percentage': 93.33333333333333, 'attended': 14, 'year': 2014}],
+            [{'total': 28, 'percentage': 89.28571428571429, 'attended': 25, 'year': 2015, 'position':'mp'},
+             {'total': 15, 'percentage': 93.33333333333333, 'attended': 14, 'year': 2014, 'position':'mp'}],
             )
 
         self.assertEqual(
@@ -657,6 +657,13 @@ class SAPersonDetailViewTest(PersonSpeakerMappingsMixin, TestCase):
 
 @attr(country='south_africa')
 class SAAttendanceDataTest(TestCase):
+    def setUp(self):
+        org_kind_party = models.OrganisationKind.objects.create(name='Party', slug='party')
+        party1 = models.Organisation.objects.create(name='Party1', slug='party1', kind=org_kind_party)
+        positiontitle1 = models.PositionTitle.objects.create(name='Member', slug='member')
+        person1 = models.Person.objects.create(legal_name='Person1', slug='person1')
+        models.Position.objects.create(person=person1, organisation=party1, title=positiontitle1)
+
     def test_get_attendance_stats(self):
         raw_data = {
             2000: {'A': 1, 'AP': 2, 'DE': 4, 'L': 8, 'LDE': 16, 'P': 32},
@@ -667,10 +674,17 @@ class SAAttendanceDataTest(TestCase):
             'attended': 60,
             'total': 63,
             'percentage': 100 * 60 / 63,
+            'position': 'mp',
              }
             ]
 
-        stats = SAPersonDetail().get_attendance_stats(raw_data)
+        person = models.Person.objects.get(slug='person1')
+        person_detail = SAPersonDetail()
+        person_detail.object = person
+
+        stats = person_detail.get_attendance_stats(raw_data)
+
+        # stats = person.get_attendance_stats(raw_data)
         self.assertEqual(stats, expected)
 
         raw_data = {
@@ -683,15 +697,17 @@ class SAAttendanceDataTest(TestCase):
              'attended': 8,
              'total': 12,
              'percentage': 100 * 8 / 12,
+             'position': 'mp',
              },
             {'year': 2000,
              'attended': 2,
              'total': 3,
              'percentage': 100 * 2 / 3,
+             'position': 'mp',
              }
         ]
 
-        stats = SAPersonDetail().get_attendance_stats(raw_data)
+        stats = person_detail.get_attendance_stats(raw_data)
         self.assertEqual(stats, expected)
 
     def test_get_attendance_stats_raw(self):

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -61,15 +61,12 @@ class SAMpAttendanceView(TemplateView):
             attendance_summary = [ma for ma in attendance_summary if
                 ma['member']['party_name'] == party]
 
-        year_end_date = datetime.datetime.strptime(
-            annual_attendance['end_date'], "%Y-%m-%d").date()
-        today = datetime.date.today()
+        year = datetime.datetime.strptime(annual_attendance['end_date'], "%Y-%m-%d").year
 
-        active_minister_positions = Position.objects.filter(
-                Q(title__slug__startswith='minister') |
-                Q(title__slug__startswith='deputy-minister')
-            ).currently_active(
-                today if year_end_date > today else year_end_date).select_related('person')
+        active_minister_positions = Position.objects \
+            .title_slug_prefixes(['minister', 'deputy-minister']) \
+            .active_at_end_of_year(year) \
+            .select_related('person')
 
         active_minister_slugs = set(am.person.slug for am in active_minister_positions)
 

--- a/pombola/south_africa/views/person.py
+++ b/pombola/south_africa/views/person.py
@@ -248,20 +248,15 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
         # Check if the Person held an active ministerial position the last day
         # of the year. Return 'minister' if so, 'mp' if not.
 
-        year_end_date = datetime.date(year, 12, 31)
-        today = datetime.date.today()
-
-        active_minister = self.object.position_set.filter(
-                Q(title__slug__startswith='minister') |
-                Q(title__slug__startswith='deputy-minister')
-            ).currently_active(
-                today if year_end_date > today else year_end_date)
+        active_minister = self.object.position_set \
+            .title_slug_prefixes(['minister', 'deputy-minister']) \
+            .active_at_end_of_year(year) \
+            .select_related('person')
 
         if active_minister:
             return 'minister'
         else:
             return 'mp'
-
 
     def get_attendance_stats(self, attendance_by_year):
         present_values = set(('P', 'DE', 'L', 'LDE'))


### PR DESCRIPTION
This makes the attendance records on Person profiles consistent with the attendance listing page.

For an active ministerial position in a given year, we only display the number of meetings attended, and not a percentage