### PR TITLE
Don't delete items while iterating over list

### DIFF
--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -71,13 +71,15 @@ class SAMpAttendanceView(TemplateView):
         active_minister_slugs = set(am.person.slug for am in active_minister_positions)
 
         minister_attendance = []
+
         for attendance in attendance_summary:
             if attendance['member']['pa_url']:
                 slug = attendance['member']['pa_url'].split('/')[-2]
                 if slug in active_minister_slugs:
                     minister_attendance.append(attendance)
-                    attendance_summary.remove(attendance)
                     active_minister_slugs.remove(slug)
+
+        attendance_summary = [a for a in attendance_summary if a not in minister_attendance]
 
         if position == 'ministers':
             # Some Ministers don't have attendance records,


### PR DESCRIPTION
Filter `attendance_summary` by excluding attendance records which are in `minister_attendance`.

This was previously done by removing items as we were iterating over a list. Which doesn't quite work as expected. And obviously so.
