### PR TITLE
Disable Django template caching on Staging

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -23,6 +23,20 @@ else:
 # switch on all debug when staging
 DEBUG          = STAGING
 
+template_loaders = [
+    'django.template.loaders.app_directories.Loader',
+    'django.template.loaders.filesystem.Loader',
+    # 'django.template.loaders.eggs.Loader',
+]
+
+if not STAGING:
+    template_loaders = [
+        (
+            'django.template.loaders.cached.Loader',
+            template_loaders,
+        )
+    ]
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -46,13 +60,7 @@ TEMPLATES = [
             ],
             'debug': STAGING,
             # List of callables that know how to import templates from various sources.
-            'loaders': [
-                ('django.template.loaders.cached.Loader', [
-                    'django.template.loaders.app_directories.Loader',
-                    'django.template.loaders.filesystem.Loader',
-                    # 'django.template.loaders.eggs.Loader',
-                ]),
-            ],
+            'loaders': template_loaders,
         },
     }
 ]


### PR DESCRIPTION
Templates were previously cached, no matter where the site was running, which meant restarting the `./manage.py runserver` process whenever you made a change to the HTML templates on a staging / dev site.

This commit disables the caching if the Staging flag is set.