### PR TITLE
A/B test "Hot Topics" position to increase clicks on "MP Profiles" button on mobile

### DIFF
--- a/pombola/core/static/js/analytics.js
+++ b/pombola/core/static/js/analytics.js
@@ -3,7 +3,7 @@
 
 
 (function() {
-  // based on code from http://stackoverflow.com/a/11060206/5349  
+  // based on code from http://stackoverflow.com/a/11060206/5349
 
   // track the print request - with debounce for chrome.
   var haveTracked = false;
@@ -26,5 +26,55 @@
     });
   }
   window.onbeforeprint = beforePrint;
+
+  window.analytics = {
+    trackEvents: function(listOfEvents){
+      // Takes a list of arguments suitable for trackEvent.
+      // Returns a jQuery Deferred object.
+      // The deferred object is resolved when
+      // all of the trackEvent calls are resolved.
+      var dfd = $.Deferred();
+      var deferreds = [];
+      var _this = this;
+      $.each(listOfEvents, function(i, params){
+          deferreds.push(_this.trackEvent(params));
+      });
+      $.when.apply($, deferreds).done(function(){
+          dfd.resolve();
+      });
+      return dfd.promise();
+    },
+
+    trackEvent: function(params){
+      // Takes an object of event parameters, eg:
+      // { eventCategory: 'foo', eventAction: 'bar' }
+      // Returns a jQuery Deferred object.
+      // The deferred object is resolved when the GA call
+      // completes or fails to respond within 2 seconds.
+      var dfd = $.Deferred();
+
+      if(typeof ga === 'undefined' || !ga.loaded){
+        // GA has not loaded (blocked by adblock?)
+        return dfd.resolve();
+      }
+
+      var defaults = {
+        hitType: 'event',
+        eventLabel: document.title,
+        hitCallback: function(){
+          dfd.resolve();
+        }
+      }
+
+      ga('send', $.extend(defaults, params));
+
+      // Wait a maximum of 2 seconds for GA response.
+      setTimeout(function(){
+        dfd.resolve();
+      }, 2000);
+
+      return dfd.promise();
+    }
+  };
 
 }());

--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -5,9 +5,35 @@
 
 {% block title %}Home{% endblock %}
 
+{% block ga_experiment %}
+<script src="//www.google-analytics.com/cx/api.js?experiment=VBriYVTaRiuLeNK8NimPCw"></script>
+{% endblock %}
+
 {% block js_end_of_body %}
   {{ block.super }}
   {% javascript 'feeds' %}
+  <script>
+      $(function(){
+          if( $('#mobile-top-tools').is(':visible') ){
+              window.cxVariation = cxApi.chooseVariation();
+              if(window.cxVariation === 1){
+                  $('.home__topics').insertBefore('.home__news');
+              }
+          }
+
+          $('.js-track-mp-profiles').on('click', function(e){
+              var that = this;
+              e.preventDefault();
+              window.analytics.trackEvent({
+                  eventCategory: 'homepage-mp-profiles-link',
+                  eventAction: 'click'
+              }).done(function(){
+                  var link = $(that).attr('href');
+                  if (link) window.location.href = link;
+              });
+          })
+      });
+  </script>
 {% endblock %}
 
 {% block body_attributes %} class="home" {% endblock %}
@@ -102,7 +128,7 @@
             Hot topics
         </h3>
         <div class="home__topics__list">
-            <a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name&amp;a=1" class="home__topics__topic">MP profiles</a>
+            <a href="{% url 'position_pt_ok' pt_slug='member' ok_slug='parliament' %}?order=name&amp;a=1" class="home__topics__topic js-track-mp-profiles">MP profiles</a>
             <a href="{% url 'info_blog_category' slug='mp-corner' %}" class="home__topics__topic">MP corner</a>
             <a href="{% url 'mp-attendance' %}" class="home__topics__topic">MP attendance</a>
             <a href="{% url 'sa-interests-index' %}" class="home__topics__topic">MP assets</a>


### PR DESCRIPTION
Part of #2250. (Only _part_ because this is an experiment, so we should leave #2250 open until the experiment has finished.)

Template changes to hook up Google Analytics Experiment `VBriYVTaRiuLeNK8NimPCw` on the Peoples Assembly homepage. 50% of mobile visitors will be shown the following variation, with the "Hot topics" links at the _top_ of the homepage:

![screen shot 2017-04-12 at 11 15 53](https://cloud.githubusercontent.com/assets/739624/24953039/c529647e-1f71-11e7-8389-40a4a8d84c76.png)

The success metric for the experiment is an increase in clicks on the "MP Profiles" button, so we also add some event tracking for that, using mySociety’s standard `trackEvent` wrapper.

The analytics "experiment" is already running, so data will start being collected as soon as this is merged and deployed.

![screen shot 2017-04-12 at 11 20 38](https://cloud.githubusercontent.com/assets/739624/24953127/18fbb282-1f72-11e7-9b1d-6b46a2cc2fc2.png)
