### PR TITLE
2271 new attendance api

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -225,7 +225,7 @@
               <div class="column">
                 {% for data in attendance %}
                   <header>
-                    <h3 class="attendance__heading">{{ data.year }} attendance</h3>
+                    <h3 class="attendance__heading">{{ data.year }} attendance as {{ data.position }}</h3>
                     {% if data.year == 2014 %}<p>(From the start of the Fifth Parliament)</p>{% endif %}
                   </header>
                   {% if data.position == 'minister' %}
@@ -236,9 +236,8 @@
                   {% endif %}
                 {% endfor %}
 
-                <p>Minister/Deputy Minister attendance is
-                not compulsory. MP attendance is compulsory unless an apology
-                is given.</p>
+                <p>Minister/Deputy Minister attendance is not compulsory.<br>
+                MP attendance is compulsory unless an apology is given.</p>
 
               </div>
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -693,6 +693,7 @@ class SAAttendanceDataTest(TestCase):
         person = models.Person.objects.get(slug='person1')
         person_detail = SAPersonDetail()
         person_detail.object = person
+        person_detail.present_values = set(('P', 'DE', 'L', 'LDE'))
 
         stats = person_detail.get_attendance_stats(raw_data)
         self.assertEqual(stats, expected)

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -5,6 +5,7 @@ import os
 from datetime import date, time
 from StringIO import StringIO
 from urlparse import urlparse
+from collections import OrderedDict
 
 import requests
 
@@ -664,32 +665,41 @@ class SAAttendanceDataTest(TestCase):
         person1 = models.Person.objects.create(legal_name='Person1', slug='person1')
         models.Position.objects.create(person=person1, organisation=party1, title=positiontitle1)
 
+        person2 = models.Person.objects.create(legal_name='Person2', slug='person2')
+        positiontitle2 = models.PositionTitle.objects.create(name='Minister', slug='minister')
+        models.Position.objects.create(person=person2, organisation=party1, title=positiontitle2, start_date='2015-08-01', end_date='future')
+
     def test_get_attendance_stats(self):
         raw_data = {
-            2000: {'A': 1, 'AP': 2, 'DE': 4, 'L': 8, 'LDE': 16, 'P': 32},
-            }
+            2000: {
+                'mp': {'A': 1, 'AP': 2, 'DE': 4, 'L': 8, 'LDE': 16, 'P': 32},
+                'minister': {'A': 7, 'P': 48, 'L': 2, 'AP': 5}}
+        }
 
+        # Minister data expected first
         expected = [
+            {'year': 2000,
+            'attended': 50,
+            'total': 62,
+            'percentage': 100 * 50 / 62,
+            'position': 'minister'},
             {'year': 2000,
             'attended': 60,
             'total': 63,
             'percentage': 100 * 60 / 63,
-            'position': 'mp',
-             }
-            ]
+            'position': 'mp'},
+        ]
 
         person = models.Person.objects.get(slug='person1')
         person_detail = SAPersonDetail()
         person_detail.object = person
 
         stats = person_detail.get_attendance_stats(raw_data)
-
-        # stats = person.get_attendance_stats(raw_data)
         self.assertEqual(stats, expected)
 
         raw_data = {
-            2000: {'A': 1, 'P': 2},
-            2001: {'A': 4, 'P': 8},
+            2000: {'mp': {'A': 1, 'P': 2}},
+            2001: {'mp': {'A': 4, 'P': 8}},
             }
 
         expected = [
@@ -718,11 +728,86 @@ class SAAttendanceDataTest(TestCase):
         with open(test_data_path) as f:
             raw_data = json.load(f)
 
-        raw_stats = SAPersonDetail().get_attendance_stats_raw(raw_data['results'])
+        person = models.Person.objects.get(slug='person1')
+        person_detail = SAPersonDetail()
+        person_detail.object = person
 
-        expected = {2014: {u'A': 1, u'P': 14}, 2015: {u'A': 1, u'P': 25, u'AP': 2}}
-
+        expected = {2014: {'mp': {u'A': 1, u'P': 14}}, 2015: {'mp': {u'A': 1, u'P': 25, u'AP': 2}}}
+        raw_stats = person_detail.get_attendance_stats_raw(raw_data['results'])
         self.assertEqual(raw_stats, expected)
+
+        # MP who has become a Minister
+        person = models.Person.objects.get(slug='person2')
+        person_detail = SAPersonDetail()
+        person_detail.object = person
+
+        expected = {2014: {'mp': {u'A': 1, u'P': 14}}, 2015: {'minister': {u'P': 4}, 'mp': {u'A': 1, u'P': 21, u'AP': 2}}}
+        raw_stats = person_detail.get_attendance_stats_raw(raw_data['results'])
+        self.assertEqual(raw_stats, expected)
+
+
+@attr(country='south_africa')
+class SAMpAttendancePageTest(TestCase):
+    def setUp(self):
+        org_kind_party = models.OrganisationKind.objects.create(name='Party', slug='party')
+        party1 = models.Organisation.objects.create(name='Party1', slug='party1', kind=org_kind_party)
+        positiontitle1 = models.PositionTitle.objects.create(name='Member', slug='member')
+        person1 = models.Person.objects.create(legal_name='Person1', slug='person1')
+        models.Position.objects.create(person=person1, organisation=party1, title=positiontitle1)
+
+        person2 = models.Person.objects.create(legal_name='Person2', slug='person2')
+        positiontitle2 = models.PositionTitle.objects.create(name='Minister', slug='minister')
+        models.Position.objects.create(person=person2, organisation=party1, title=positiontitle2, start_date='2000-03-30', end_date='future')
+
+    def test_mp_attendance_context(self):
+        raw_data = [{
+            u'end_date': u'2000-12-31',
+            u'meetings_by_member': [
+                {u'member': {
+                    u'party_id': 1, u'pa_url': u'http://www.pa.org.za/person/person1/',
+                    u'party_name': u'Party1', u'name': u'Person 1', u'id': 1},
+                u'meetings': [
+                    {u'date': u'2000-03-01', u'attendance': u'A'},
+                    {u'date': u'2000-03-02', u'attendance': u'P'},
+                    {u'date': u'2000-03-03', u'attendance': u'P'},
+                    {u'date': u'2000-03-04', u'attendance': u'L'}]},
+                {u'member': {
+                    u'party_id': 1, u'pa_url': u'http://www.pa.org.za/person/person2/',
+                    u'party_name': u'Party1', u'name': u'Person 2', u'id': 2},
+                u'meetings': [
+                    {u'date': u'2000-03-01', u'attendance': u'A'},
+                    {u'date': u'2000-03-01', u'attendance': u'P'},
+                    {u'date': u'2000-04-01', u'attendance': u'P'},
+                    {u'date': u'2000-04-01', u'attendance': u'P'},
+                    {u'date': u'2000-04-01', u'attendance': u'A'}]}],
+            u'start_date': u'2000-01-01'}]
+
+        pmg_api_cache = caches['pmg_api']
+        pmg_api_cache.set(
+            "https://api.pmg.org.za/committee-meeting-attendance/meetings-by-member/",
+            raw_data,
+        )
+
+        # Default, Minister attendance
+        url = "%s?year=2000" % reverse('mp-attendance')
+        context = self.client.get(url).context
+
+        expected = [{'name': u'Person 2', 'pa_url': u'http://www.pa.org.za/person/person2/', 'party_name': u'Party1', 'present': 2}]
+        self.assertEqual(context['attendance_data'], expected)
+
+        # MP attendance selected
+        url = "%s?position=mps&year=2000" % reverse('mp-attendance')
+        context = self.client.get(url).context
+
+        # total: number of meetings
+        # absent, arrived_late, depart_early, present: percentages
+        expected = [
+            {'name': u'Person 1', 'party_name': u'Party1', 'pa_url': u'http://www.pa.org.za/person/person1/',
+            'absent': 25, 'arrive_late': 25, 'depart_early': 0, 'total': 4, 'present': 75},
+            {'name': u'Person 2', 'party_name': u'Party1', 'pa_url': u'http://www.pa.org.za/person/person2/',
+            'absent': 50, 'arrive_late': 0, 'depart_early': 0, 'total': 2, 'present': 50}
+        ]
+        self.assertEqual(context['attendance_data'], expected)
 
 
 @attr(country='south_africa')

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -794,7 +794,7 @@ class SAMpAttendancePageTest(TestCase):
         url = "%s?year=2000" % reverse('mp-attendance')
         context = self.client.get(url).context
 
-        expected = [{'name': u'Person 2', 'pa_url': u'http://www.pa.org.za/person/person2/', 'party_name': u'Party1', 'present': 2}]
+        expected = [{'name': u'Person 2', 'pa_url': u'/person/person2/', 'party_name': u'Party1', 'present': 2}]
         self.assertEqual(context['attendance_data'], expected)
 
         # MP attendance selected
@@ -804,9 +804,9 @@ class SAMpAttendancePageTest(TestCase):
         # total: number of meetings
         # absent, arrived_late, depart_early, present: percentages
         expected = [
-            {'name': u'Person 1', 'party_name': u'Party1', 'pa_url': u'http://www.pa.org.za/person/person1/',
+            {'name': u'Person 1', 'party_name': u'Party1', 'pa_url': u'/person/person1/',
             'absent': 25, 'arrive_late': 25, 'depart_early': 0, 'total': 4, 'present': 75},
-            {'name': u'Person 2', 'party_name': u'Party1', 'pa_url': u'http://www.pa.org.za/person/person2/',
+            {'name': u'Person 2', 'party_name': u'Party1', 'pa_url': u'/person/person2/',
             'absent': 50, 'arrive_late': 0, 'depart_early': 0, 'total': 2, 'present': 50}
         ]
         self.assertEqual(context['attendance_data'], expected)
@@ -843,7 +843,7 @@ class SAMpAttendancePageTest(TestCase):
         # total: number of meetings
         # absent, arrived_late, depart_early, present: percentages
         expected = [
-            {'name': u'Person 2', 'party_name': u'Party1', 'pa_url': u'http://www.pa.org.za/person/person2/',
+            {'name': u'Person 2', 'party_name': u'Party1', 'pa_url': u'/person/person2/',
             'absent': 50, 'arrive_late': 0, 'depart_early': 0, 'total': 2, 'present': 50}
         ]
         self.assertEqual(context['attendance_data'], expected)

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -230,14 +230,12 @@ class SAMpAttendanceView(TemplateView):
 
                         aggregate_total += total
                         aggregate_present += present
-
                         present_perc = self.calculate_abs_percenatge(present, total)
                         arrive_late_perc = self.calculate_abs_percenatge(arrive_late, total)
                         depart_early_perc = self.calculate_abs_percenatge(depart_early, total)
-
                         context['attendance_data'].append({
                             "name": summary['member']['name'],
-                            "pa_url": summary['member']['pa_url'],
+                            "pa_url": urlsplit(summary['member']['pa_url']).path,
                             "party_name": summary['member']['party_name'],
                             "present": present_perc,
                             "absent": 100 - present_perc,
@@ -262,7 +260,7 @@ class SAMpAttendanceView(TemplateView):
                             if k in present_codes)
                         context['attendance_data'].append({
                                 "name": summary['member']['name'],
-                                "pa_url": summary['member']['pa_url'],
+                                "pa_url": urlsplit(summary['member']['pa_url']).path,
                                 "party_name": summary['member']['party_name'],
                                 "present": present,
                         })

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -123,9 +123,13 @@ class SAMpAttendanceView(TemplateView):
                     # Member can be a Minister and an MP during the year
                     if attendance_as_minister:
                         minister_attendance.append({'member': record['member'], 'meetings': attendance_as_minister})
+                        # Only remove if slug if minister attendance was added.
+                        # If not, retain, as zero attendance zero attendance entry needs to be added.
+                        minister_slugs.remove(slug)
+
                     if attendance_as_mp:
                         mp_attendance.append({'member': record['member'], 'meetings': attendance_as_mp})
-                    minister_slugs.remove(slug)
+
                 else:
                     # Member wasn't a minister during the year. All attendance as MP.
                     mp_attendance.append(record)

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -5,6 +5,7 @@ import json
 import requests
 import datetime
 from urlparse import urlsplit
+from collections import defaultdict
 
 from .constants import API_REQUESTS_TIMEOUT
 
@@ -25,7 +26,7 @@ class SAMpAttendanceView(TemplateView):
         return int("{:.0f}".format(num / total * 100))
 
     def download_attendance_data(self):
-        attendance_url = next_url = 'https://api.pmg.org.za/committee-meeting-attendance/summary/'
+        attendance_url = next_url = 'https://api.pmg.org.za/committee-meeting-attendance/meetings-by-member/'
 
         cache = caches['pmg_api']
         results = cache.get(attendance_url)
@@ -50,74 +51,116 @@ class SAMpAttendanceView(TemplateView):
             ma, member=dict(
                 ma['member'], pa_url=urlsplit(ma['member']['pa_url']).path))
 
-    def filter_attendance(self, annual_attendance, party, position):
+    def build_minister_zero_attendance(self, minister):
+        """
+        Return a record in the same format as the PMG API data for ministers with
+        no attendance records. These records should be populated with zero.
+        """
+        initials = "".join(name[0].upper() for name in minister.given_name.split())
+        minister_name = "{}, {} {}".format(
+            minister.family_name, minister.title, initials)
+
+        return {'member': {
+                    'name': minister_name,
+                    'pa_url': minister.get_absolute_url(),
+                    'party_name': minister.parties()[0].slug.upper()},
+                'meetings': None}
+
+    def filter_attendance(self, annual_attendance, ctx_party, ctx_pos):
         """
         Filter meeting attendance to only include items which match
-        the party and position selections by the user.
+        the party and position selected by the user.
+
+        `ctx_party`, `ctx_pos` are the party and position parameters sent by the client.
+        These values are directly from the GET parameters, and should be deemed unsafe.
         """
 
-        attendance_summary = annual_attendance['attendance_summary']
-        if party:
-            attendance_summary = [ma for ma in attendance_summary if
-                ma['member']['party_name'] == party]
+        attendance_records = annual_attendance['meetings_by_member']
+        if ctx_party:
+            attendance_records = [ma for ma in attendance_records if
+                ma['member']['party_name'] == ctx_party]
 
         year = datetime.datetime.strptime(annual_attendance['end_date'], "%Y-%m-%d").year
 
         active_minister_positions = Position.objects \
             .title_slug_prefixes(['minister', 'deputy-minister']) \
-            .active_at_end_of_year(year) \
+            .active_during_year(year) \
             .select_related('person')
 
-        active_minister_slugs = set(am.person.slug for am in active_minister_positions)
+        ministers = defaultdict(list)
+        for position in active_minister_positions:
+            ministers[position.person.slug].append(position)
+
+        minister_slugs = ministers.keys()
 
         minister_attendance = []
+        mp_attendance = []
 
-        for attendance in attendance_summary:
-            if attendance['member']['pa_url']:
-                slug = attendance['member']['pa_url'].split('/')[-2]
-                if slug in active_minister_slugs:
-                    minister_attendance.append(attendance)
-                    active_minister_slugs.remove(slug)
+        for record in attendance_records:
+            # Split records between MP and Minister attendance
+            attendance_as_minister = []
+            attendance_as_mp = []
 
-        attendance_summary = [a for a in attendance_summary if a not in minister_attendance]
+            if record['member']['pa_url']:
+                # We cannot determine a position if no `pa_url` was returned. Ignore these records.
+                slug = record['member']['pa_url'].split('/')[-2]
+                if slug in minister_slugs:
+                    # This member was a minister during the year
+                    positions = ministers[slug]
+                    for meeting in record['meetings']:
+                        # Check the member position at each meeting date.
+                        minister_at_date = False
+                        for position in positions:
+                        # A member can have more than one active ministerial position in a year
+                            if position.is_active_at_date(meeting['date']):
+                                minister_at_date = True
 
-        if position == 'ministers':
-            # Some Ministers don't have attendance records,
-            # and we need to show that they haven't attendended any meetings
-            for position in active_minister_positions:
-                minister = position.person
-                # `active_ministers` contain ministers from all parties.
-                # If the user selected to filter by party, only append ministers from that party
-                # to `minister_attendance`.
-                if party and minister.parties()[0].slug.upper() != party:
+                        if minister_at_date:
+                            attendance_as_minister.append(meeting)
+                        else:
+                            attendance_as_mp.append(meeting)
+
+                    # Member can be a Minister and an MP during the year
+                    if attendance_as_minister:
+                        minister_attendance.append({'member': record['member'], 'meetings': attendance_as_minister})
+                    if attendance_as_mp:
+                        mp_attendance.append({'member': record['member'], 'meetings': attendance_as_mp})
+                    minister_slugs.remove(slug)
+                else:
+                    # Member wasn't a minister during the year. All attendance as MP.
+                    mp_attendance.append(record)
+
+        if ctx_pos == 'ministers':
+            # Ministers remaining in `minister_slugs` had no attendance records returned
+            # Create a record for each.
+            for slug in minister_slugs:
+                minister = ministers[slug][0].person
+                if ctx_party and minister.parties()[0].slug.upper() != ctx_party:
+                    # Only include ministers belonging to the party selected.
                     continue
                 else:
-                    if minister.slug in active_minister_slugs:
+                    minister_attendance.append(self.build_minister_zero_attendance(minister))
 
-                        # Build name consistent with PMG data
-                        initials = "".join(name[0].upper() for name in minister.given_name.split())
-                        minister_name = "{}, {} {}".format(
-                            minister.family_name, minister.title, initials)
+            return minister_attendance
 
-                        minister_attendance.append({
-                            'member': {
-                                'name': minister_name,
-                                'pa_url': minister.get_absolute_url(),
-                                'party_name': minister.parties()[0].slug.upper()},
-                            'attendance': {
-                                'P': 0}
-                        })
-            attendance = minister_attendance
+        return mp_attendance
 
-        else:
-            # Show Members returned who we aren't considered Ministers
-            # Exclude records without a pa_url,
-            # as we don't know whether it's an MP or Minister
-            attendance = [
-                self.just_path_of_pa_url(ma)
-                for ma in attendance_summary if ma['member']['pa_url']]
+    def get_attendance_summary(self, attendance):
+        """Return the tallied attendance records"""
+        attendance_summary = []
+        for record in attendance:
+            attendance_count = {}
+            if not record['meetings']:
+                # Ministers with no attendance records. Show zero attendance.
+                attendance_summary.append({'member': record['member'], 'attendance': {'P': 0}})
+            else:
+                for meeting in record['meetings']:
+                    attendance_count.setdefault(meeting['attendance'], 0)
+                    attendance_count[meeting['attendance']] += 1
 
-        return attendance
+                attendance_summary.append({'member': record['member'], 'attendance': attendance_count})
+
+        return attendance_summary
 
     def get_context_data(self, **kwargs):
         data = self.download_attendance_data()
@@ -133,6 +176,7 @@ class SAMpAttendanceView(TemplateView):
         arrive_late_codes = ['L', 'LDE']
         depart_early_codes = ['DE', 'LDE']
 
+        # Page defaults
         context = {}
         context['year'] = str(
             dateutil.parser.parse(data[0]['end_date']).year)
@@ -153,13 +197,14 @@ class SAMpAttendanceView(TemplateView):
 
             if year == context['year']:
                 parties = set(ma['member']['party_name'] for
-                    ma in annual_attendance['attendance_summary'])
+                    ma in annual_attendance['meetings_by_member'])
                 parties.discard(None)
                 context['parties'] = sorted(parties)
 
-
-                attendance_summary = self.filter_attendance(
+                attendance = self.filter_attendance(
                     annual_attendance, context['party'], context['position'])
+
+                attendance_summary = self.get_attendance_summary(attendance)
 
                 if context['position'] == 'mps':
                     aggregate_total = aggregate_present = 0
@@ -205,6 +250,8 @@ class SAMpAttendanceView(TemplateView):
                     context['aggregate_attendance'] = aggregate_attendance
 
                 else:
+                    # Only show meetings attended for Ministers
+                    # No aggregates are calculated
                     for summary in attendance_summary:
                         present = sum(
                             v for k, v in summary['attendance'].iteritems()

--- a/pombola/south_africa/views/person.py
+++ b/pombola/south_africa/views/person.py
@@ -239,6 +239,15 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
             position_dict.setdefault(attendance, 0)
             position_dict[attendance] += 1
 
+        # Add zero minister attendance if person was active minister during a year,
+        # but no reocrds was returned for that year.
+        for year, positions in minister_positions_by_year.iteritems():
+            if positions:
+                # There were active minister positions
+                if 'minister' not in attendance_by_year[year].keys():
+                    # No minister attendance recorded
+                    attendance_by_year[year]['minister'] = {'P': 0}
+
         return attendance_by_year
 
     def get_latest_meeting_urls(self, data):
@@ -298,7 +307,11 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
             for position in sorted(year_dict.keys()):
                 attendance = sum((year_dict[position][x] for x in year_dict[position] if x in present_values))
                 meeting_count = sum((year_dict[position][x] for x in year_dict[position]))
-                percentage = 100 * attendance / meeting_count
+                if meeting_count == 0:
+                    # To avoid a division by zero for zero minister attendance
+                    percentage = 0
+                else:
+                    percentage = 100 * attendance / meeting_count
 
                 return_data.append(
                     {


### PR DESCRIPTION
As person's position can change at any time during a year, and attendance for ministers and MPs are reported differently, ministerial status should be checked at the date of each meeting.

A new API endpoint is used for data on the MP attendance page.