### PR TITLE
Output fb:app_id meta tag on all pages

### DIFF
--- a/pombola/core/templates/core/object_base.html
+++ b/pombola/core/templates/core/object_base.html
@@ -1,12 +1,6 @@
 {% extends 'base.html' %}
 {% load thumbnail %}
 
-{% block extra_head_meta %}
-{% if settings.FACEBOOK_APP_ID %}
-  <meta property="fb:app_id" content="{{ settings.FACEBOOK_APP_ID }}" />
-{% endif %}
-{% endblock %}
-
 {% block title %}{{ object.name }}{% endblock %}
 
 {% block content %}

--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -27,6 +27,11 @@
         <meta property="og:title" content="{{ site.name }}" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+
+        {% if settings.FACEBOOK_APP_ID %}
+        <meta property="fb:app_id" content="{{ settings.FACEBOOK_APP_ID }}" />
+        {% endif %}
+
         {% endblock %}
 
         {% block css_headers %}


### PR DESCRIPTION
In order for the [Facebook comments moderation tool](https://developers.facebook.com/tools/comments/1619725741628189/pending/descending/) to work correctly this meta tag needs to be on all pages that contain the comment widget, more details [in the documentation](https://developers.facebook.com/docs/plugins/comments#moderation-setup-instructions). To future proof this I'm putting it into the base template, so that it gets included on all pages on the site.

I haven't got a good way of testing whether this actually makes the moderation tool work other than putting it live and checking, but suggestions welcome!

Part of https://github.com/mysociety/pombola/issues/2281