### PR TITLE
Always output fb:app_id meta tag

### DIFF
--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -23,15 +23,14 @@
         {% block extra_head_meta %}
         {% endblock%}
 
-        {% block open_graph %}
-        <meta property="og:title" content="{{ site.name }}" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="{{ request.build_absolute_uri }}" />
-
         {% if settings.FACEBOOK_APP_ID %}
         <meta property="fb:app_id" content="{{ settings.FACEBOOK_APP_ID }}" />
         {% endif %}
 
+        {% block open_graph %}
+        <meta property="og:title" content="{{ site.name }}" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="{{ request.build_absolute_uri }}" />
         {% endblock %}
 
         {% block css_headers %}


### PR DESCRIPTION
Some templates, such as [blog posts](https://github.com/mysociety/pombola/blob/4d05dc88f3be6acfddc49b18cf4ccff907720557/pombola/south_africa/templates/info/blog_post.html#L17) and [person pages](https://github.com/mysociety/pombola/blob/4d05dc88f3be6acfddc49b18cf4ccff907720557/pombola/core/templates/core/person_base.html#L17), override the `open_graph` template block, which means the `fb:app_id` meta tag isn't in the HTML for those pages.

To avoid that problem this moves the `fb:app_id` meta tag outside any template blocks so that it always appears in the HTML output.

This is the fix I proposed in https://github.com/mysociety/pombola/issues/2281#issuecomment-311941902.

Part of https://github.com/mysociety/pombola/issues/2281