### PR TITLE
ZA: add parliamentary session data for the 25th and 26th parliaments

### DIFF
--- a/pombola/core/static/sass/_listing.scss
+++ b/pombola/core/static/sass/_listing.scss
@@ -85,6 +85,10 @@ ul.listing {
           width: auto;
           height: auto; } } } } }
 
+.session-date-range {
+  margin-bottom: 0.8em;
+}
+
 .parliamentary-session-links {
   margin-bottom: 0.8em;
   margin-top: 1.2em;

--- a/pombola/core/templates/core/_position_session_links.html
+++ b/pombola/core/templates/core/_position_session_links.html
@@ -1,8 +1,8 @@
 {% if session %}
-  <h3>Position holders during {{ session.name }}</h3>
-  <h4>({{ session.readable_date_range }})</h4>
+  <h3 class="session-heading">Position holders during {{ session.name }}</h3>
+  <h4 class="session-date-range">({{ session.readable_date_range }})</h4>
 {% elif object.slug != 'member' or organisation_kind.slug != 'parliament' %}
-  <h3>Current Position Holders</h3>
+  <h3 class="session-heading">Current Position Holders</h3>
 {% endif %}
 
 {% if session_details|length > 1 %}

--- a/pombola/south_africa/migrations/0002_add_parliamentary_sessions.py
+++ b/pombola/south_africa/migrations/0002_add_parliamentary_sessions.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def add_parliamentary_sessions(apps, schema_editor):
+    ParliamentarySession = apps.get_model('core', 'ParliamentarySession')
+    Organisation = apps.get_model('core', 'Organisation')
+    PositionTitle = apps.get_model('core', 'PositionTitle')
+    # National Assembly:
+    if Organisation.objects.filter(slug='national-assembly').exists():
+        #   Current:
+        ParliamentarySession.objects.create(
+            start_date='2014-05-21',
+            end_date='2019-05-21',
+            house=Organisation.objects.get(slug='national-assembly'),
+            position_title=PositionTitle.objects.get(slug='member'),
+            mapit_generation=1,
+            name='26th Parliament (National Assembly)',
+            slug='na26',
+        )
+        #   Previous:
+        ParliamentarySession.objects.create(
+            start_date='2009-05-06',
+            end_date='2014-05-06',
+            house=Organisation.objects.get(slug='national-assembly'),
+            position_title=PositionTitle.objects.get(slug='member'),
+            mapit_generation=1,
+            name='25th Parliament (National Assembly)',
+            slug='na25',
+        )
+    if Organisation.objects.filter(slug='ncop').exists():
+        # NCOP:
+        #   Current:
+        ParliamentarySession.objects.create(
+            start_date='2014-05-21',
+            end_date='2019-05-21',
+            house=Organisation.objects.get(slug='ncop'),
+            position_title=PositionTitle.objects.get(slug='delegate'),
+            mapit_generation=1,
+            name='26th Parliament (National Council of Provinces)',
+            slug='ncop26',
+        )
+        #   Previous:
+        ParliamentarySession.objects.create(
+            start_date='2009-05-06',
+            end_date='2014-05-06',
+            house=Organisation.objects.get(slug='ncop'),
+            position_title=PositionTitle.objects.get(slug='delegate'),
+            mapit_generation=1,
+            name='25th Parliament (National Council of Provinces)',
+            slug='ncop25',
+        )
+
+
+def remove_parliamentary_sessions(apps, schema_editor):
+    ParliamentarySession = apps.get_model('core', 'ParliamentarySession')
+    ParliamentarySession.objects.filter(
+        slug__in=('na25', 'na26', 'ncop25', 'ncop26')
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+        ('south_africa', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            add_parliamentary_sessions,
+            remove_parliamentary_sessions,
+        ),
+    ]


### PR DESCRIPTION
For Kenya, we've created instances of a `ParliamentarySession` model to represent a term of a particular house of parliament. (The name is a bit misleading - [it should probably be `Term` instead](https://github.com/mysociety/pombola/issues/2179).) This was introduced primarily so that we could distinguish places from different terms with different boundaries. Later we added links to views of positions of a particular parliament, like:

![kenya-session-switches](https://user-images.githubusercontent.com/7907/27740138-d1993d22-5da8-11e7-9d87-a1531f855da0.png)

The position view, when provided with a `session` query parameter, only includes positions whose start and end date overlap with the start and end date of the corresponding `ParliamentarySession`.

In Pombola, this mechanism provides the only easy way to see all the people who were ever a representative in a particular house for a given session, which means that since there are no such `ParliamentarySession`s for South Africa, the EveryPolitician scraper can only ever find the current representatives.

Essentially the only `/position/` URL that's used on People's Assembly is the "MP Profiles" page which has been overridden and doesn't include the session switch link, so adding these ParliamentarySession objects will only affect pages that aren't linked to by default, but the following links will still be helpful to the EP scrapers (https://github.com/mysociety/pombola/pull/2172#issuecomment-274468313):

* /position/delegate/parliament/ncop/?session=ncop25
* /position/delegate/parliament/ncop/?session=ncop26
* /position/member/parliament/national-assembly/?session=na25
* /position/member/parliament/national-assembly/?session=na26

On these pages, the session switch links look like:

![sessions-on-pa](https://user-images.githubusercontent.com/7907/27741281-8019e060-5dac-11e7-99ee-a13cea3887d8.png)

... although since they're not linked from the site, the appearance doesn't matter much.

Note that because these views just look for overlapping dates with a session, just creating the `ParliamentarySession` objects is enough - they don't need to be linked with positions by foreign keys. (This is probably a misfeature.)

PMG have been careful about setting precise start and end dates, so this should accurately identify who was really a represenative during each session.