### PR TITLE
Add test coverage to Scrutinizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   # Now install the rest of the required Python packages:
   - CFLAGS="-O0" pip install -r requirements.txt
   - pip install python-coveralls
+  - pip install scrutinizer-ocular
   - pip check
   # Create a basic general.yml file:
   - sed -r
@@ -39,3 +40,4 @@ script:
 
 after_success:
   - coveralls
+  - ocular --data-file ".coverage"


### PR DESCRIPTION
This modifies Pombola's Travis config to include [sending coverage data to Scrutinizer](https://scrutinizer-ci.com/docs/tools/external-code-coverage/) as well as Coveralls.

Scrutinizer will now also [fail a build](https://scrutinizer-ci.com/docs/configuration/build_status) if coverage drops by more than 1%. See [Scrutinizer Config](https://scrutinizer-ci.com/g/mysociety/pombola/settings/build-config) to fine-tune this.

<img width="520" alt="screen shot 2017-08-14 at 18 04 52" src="https://user-images.githubusercontent.com/619082/29282547-1e3fa356-811b-11e7-9594-f77f937da21a.png">