### PR TITLE
[ZA] Reusable .cta-box component for static pages

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -3345,3 +3345,25 @@ p.attendance__disclaimer {
   padding: 1em;
   margin-bottom: 1em;
 }
+
+.cta-box {
+    padding: 1em;
+    background-color: $colour_cream;
+    border-radius: $border_radius;
+
+    @media (min-width: 640px) {
+        padding: 1.5em;
+    }
+
+    & > * {
+        margin: 0 0 0.5em 0;
+    }
+
+    & > :last-child {
+        margin-bottom: 0;
+    }
+
+    .button {
+        padding: 0.75em 1em;
+    }
+}


### PR DESCRIPTION
Fixes #2268.

Example:

```html
<div class="cta-box">
    <p>Things are important</p>
    <h2>You should do this thing</h2>
    <p>
        <a href="#" class="button">Do the thing</a>
    </p>
</div>
```

Looks like:

![screen shot 2017-08-18 at 11 10 02](https://user-images.githubusercontent.com/739624/29454652-d2135516-8405-11e7-8a0c-5db911e7b3ec.png)

A few generic styles mean you can combine paragraphs, headings, and other block elements in whatever order you like and it should still look fairly good.