### PR TITLE
The Google Feed API is deprecated and no longer works; replace its use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ notifications:
 language: python
 cache: pip
 
-services:
-  - elasticsearch
-
 addons:
   postgresql: "9.6"
   apt:
@@ -17,6 +14,9 @@ addons:
     - postgresql-9.6-postgis-2.3
 
 install:
+  - wget ${ES_DOWNLOAD_URL}
+  - tar xzf elasticsearch-${ES_VERSION}.tar.gz
+  - elasticsearch-${ES_VERSION}/bin/elasticsearch &
   - pip install -U pip
   - bundle update json
   - bundle install --deployment --path ../gems --binstubs ../gem-bin
@@ -39,8 +39,12 @@ before_script:
   - ./manage.py collectstatic --noinput
 
 script:
+  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
   - ./run-tests --coverage
 
 after_success:
   - coveralls
   - ocular --data-file ".coverage"
+
+env:
+  - ES_VERSION=0.90.13 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
 
 install:
   - pip install -U pip
+  - bundle update json
   - bundle install --deployment --path ../gems --binstubs ../gem-bin
   # Now install the rest of the required Python packages:
   - CFLAGS="-O0" pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ services:
   - elasticsearch
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
     - yui-compressor
+    - postgresql-9.6-postgis-2.3
 
 install:
   - pip install -U pip

--- a/pombola/core/static/js/feeds.js
+++ b/pombola/core/static/js/feeds.js
@@ -13,47 +13,40 @@
           '</span> <span class="year">' + year + '</span>';
     }
 
-    // Get the blog feeds - if needed
-    var $blog_container = $("#home-news-list");
-    if ( $blog_container ) {
+    // This Javascript will populate a <ul> with list items from an
+    // RSS feed. The remote site that serves the RSS should include
+    // CORS headers to allow this Javascript to fetch the RSS feed.
 
-        function fetch_blog_feeds () {
-
-            var feed_url = $blog_container.attr("data-blog-rss-feed");
-            var feed = new google.feeds.Feed( feed_url );
-
-            feed.load(function(result) {
-                if (!result.error) {
-
-                    $blog_container.html('');
-
-                    for (var i = 0; i < result.feed.entries.length; i++) {
-                        var entry = result.feed.entries[i];
-
-                        var pub_date = new Date(entry.publishedDate);
-
-                        var $item = $('<li />');
-                        $item
-                            .append(
-                                $('<h3 >')
-                                    .append(
-                                        $('<a/>')
-                                            .text( entry.title )
-                                            .attr( { href: entry.link } )
-                                    )
-                            )
-                            .append( '<p class="meta">' + dateFormat(pub_date) + '</p>')
-                            .append( $('<p/>').text(entry.contentSnippet) );
-
-
-                        $blog_container.append( $item );
-                    }
-                }
-            });
-        }
-
-        // load the feeds API from google
-        google.load('feeds', '1', { callback: fetch_blog_feeds });
+    var blogContainer = $("#home-news-list");
+    var maximumListItems = 2;
+    if ( blogContainer ) {
+        var feedURL = blogContainer.attr("data-blog-rss-feed");
+        $.ajax(feedURL, dataType='xml').done(
+            function (xml) {
+                blogContainer.html('');
+                $(xml).find('item').each(function (index) {
+                    var item = $(this),
+                        listItem = $('<li>'),
+                        title = item.find('title').text(),
+                        url = item.find('link').text(),
+                        description = item.find('description').text(),
+                        published = new Date(item.find('pubDate').text());
+                    if (index >= maximumListItems) {
+                        return false;
+                    };
+                    listItem.append(
+                        $('<h3>').append(
+                            $('<a>').text(title).attr({href: url})
+                        ).append(
+                            '<p class="meta">' + dateFormat(published) + '</p>'
+                        ).append(
+                            $('<p>').html(description)
+                        )
+                    );
+                    blogContainer.append(listItem);
+                })
+            }
+        );
     }
 
 })();


### PR DESCRIPTION
The Google Feed API, which we used to fetch an RSS feed in Javascript
and display it on the homepage, was deprecated and stopped working at
the end of 2016.

There are similar generic services we could use, but it's not clear how
stable or trustworthy those would be, and it's almost as simple to
write our own Javascript for fetching the feed, parsing it and
rendering it as a list, as this commit does.

For this to work there need to be appropriate CORS headers returned by
the server returning the RSS feed. For example, in the case of
Mzalendo, this means that we've added:

  Access-Control-Allow-Origin: http://info.mzalendo.com

... to reponses from http://www.mzalendo.com/blog/

Fixes #2292 

![rss-feed-back](https://user-images.githubusercontent.com/7907/30125992-58ab30cc-9332-11e7-9d66-e9ac5d82cf3d.png)
