### PR TITLE
Person attendance: Change wording & clarify methodology

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2220,9 +2220,20 @@ p.attendance__number {
 }
 
 p.attendance__disclaimer {
-  color: $colour_middling_grey;
-  font-size: 0.8em;
-  margin: 0.8em 0;
+    color: $colour_middling_grey;
+    font-size: 0.8em;
+    margin: 0.8em 0;
+}
+
+ul.attendance__notes {
+    color: $colour_middling_grey;
+    margin: 0.8em 0;
+    padding-left: 0;
+
+    li {
+        font-size: 0.9em;
+    }
+
 }
 
 /* List pages for recent appearances, questions and attendances*/

--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -123,20 +123,25 @@
               <div class="column">
                 {% for data in attendance %}
                   <header>
-                    <h3 class="attendance__heading">{{ data.year }} attendance as {{ data.position }}</h3>
+                    <h3 class="attendance__heading">{{ data.year }} committee attendance as {{ data.position }}</h3>
                     {% if data.year == 2014 %}<p>(From the start of the Fifth Parliament)</p>{% endif %}
                   </header>
-                  {% if data.position == 'minister' %}
+                  {% if data.position == 'minister/deputy' %}
                     <p class="attendance__number">Attended {{ data.attended }} meeting{{ data.attended|pluralize }}</p>
                   {% else %}
                     <p class="attendance__percentage">{{ data.percentage|floatformat:"0" }}% attendance rate</p>
                     <p class="attendance__context">Attended {{ data.attended }} meeting{{ data.attended|pluralize }} out of {{ data.total }}</p>
                   {% endif %}
                 {% endfor %}
-                <p class="attendance__disclaimer">
-                  Minister/Deputy Minister attendance is not compulsory.<br>
-                  MP attendance is compulsory unless an apology is given.
-                </p>
+
+                <ul class="attendance__notes">
+                  <li>Attendance records reflect Committee not Plenary Attendance</li>
+                  <li>Minister/Deputy Minister attendance is not compulsory.</li>
+                  <li>MP attendance is compulsory unless an apology is given</li>
+                  <li>MPs are recorded as absent whether they have, or have not submitted apologies.</li>
+                  <li>This is not the official committee attendance record of Parliament.</li>
+                  <li>Plenary Attendance is not made public by Parliament although it has been requested.</li>
+                </ul>
               </div>
 
               {% if latest_meetings_attended %}
@@ -154,7 +159,8 @@
             {% endif %}
 
           </div>
-          <p class="attendance__disclaimer">DISCLAIMER: This is not the official attendance record of Parliament. This information has been obtained via the Parliamentary Monitoring Group. PMG makes every effort to compile reliable and comprehensive information, but does not claim that the data is 100% accurate and complete.</p>
+          <p class="attendance__disclaimer">DISCLAIMER: This information has been obtained via the Parliamentary Monitoring Group. PMG makes every effort to compile reliable and comprehensive information, but does not claim that the data is 100% accurate and complete.
+          </p>
         </div> <!-- .attendance -->
       {% endif %}
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -688,7 +688,7 @@ class SAAttendanceDataTest(TestCase):
             'attended': 50,
             'total': 62,
             'percentage': 100 * 50 / 62,
-            'position': 'minister'},
+            'position': 'minister/deputy'},
             {'year': 2000,
             'attended': 60,
             'total': 63,

--- a/pombola/south_africa/views/person.py
+++ b/pombola/south_africa/views/person.py
@@ -324,7 +324,7 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
                         'attended': attendance,
                         'total': meeting_count,
                         'percentage': percentage,
-                        'position': position,
+                        'position': position if position == 'mp' else 'minister/deputy',
                     }
                 )
 


### PR DESCRIPTION
Person attendance page:
Changed MINISTER to read MINISTRY, and added some notes on the attendance methodology.

@mhl 