### PR TITLE
[ZA] Add fuzzy search operator to searches.

### DIFF
--- a/pombola/search/tests/fuzzy.py
+++ b/pombola/search/tests/fuzzy.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+
+from django.test import TestCase
+
+from haystack.inputs import Raw
+
+from pombola.search.views import SearchBaseView
+
+
+class FuzzyQueryStringTest(TestCase):
+
+    def test_alphanumeric_string_fuzzed(self):
+
+        query_string = 'foo bar baz'
+
+        expected_string = 'foo~1 bar~1 baz~1'
+
+        search = SearchBaseView()
+
+        self.assertEqual(
+            str(search.generate_fuzzy_query_object(query_string)),
+            expected_string
+        )
+
+    def test_complex_string_unfuzzed(self):
+
+        query_string = 'fü bár bâz'
+
+        expected_string = 'fü bár bâz'
+
+        search = SearchBaseView()
+
+        self.assertEqual(
+            str(search.generate_fuzzy_query_object(query_string)),
+            expected_string
+        )


### PR DESCRIPTION
Haystack prevents us from easily applying a [fuzziness to the whole search](https://www.elastic.co/guide/en/elasticsearch/reference/0.90/query-dsl-fuzzy-query.html),
so this is a workaround which checks to see if a string is entirely
alphanumeric ASCII characters and spaces, then applies the fuzzy query
string operator to individual words if so. If not, `AutoQuery()` handles
escaping special characters and turning boolean patterns such as `AND` into
actual structured query objects.

For future reference, this workaround is necessary without radically re-working search throughout Pombola to use less Haystack magic and allow us to modify search kwargs as [suggested on Stack Overflow](https://stackoverflow.com/questions/18000714/how-can-i-do-a-fuzzy-search-using-django-haystack-and-the-elasticsearch-backend). @mhl and I spent quite a bit of time digging through exactly what was going on, and this appears to be the most logical solution without serious work.

This does have the following caveats:

* Anything which deviates from a boring alphanumeric ASCII query will not be fuzzed at all.
* Trying to include boolean patterns via keywords (`OR`) rather than operators (`|`) will break, since the keywords will also be fuzzed.
* We have no way to adjust any value other than the edit distance (currently set at 1) using query string operators.

For anybody stumbling this way in future, we discovered:

* `build_search_kwargs()` as part of an extended `ElasticsearchSearchBackend` class is definitely where you _would_ logically tell ElasticSearch to make a search fuzzy, however;
* `AutoQuery()` turns a string into a Haystack structured query object, which when it gets passed to `build_search_kwargs()` makes it nigh-on impossible to extract the original term to use as a value in providing a fuzzy argument, and;
* Haystack, in `elasticsearch_backend.py` goes back and stomps over your kwargs in unexpected ways.

Recommendations for the future are:

* Move away from ElasticSearch 0.90 at an opportune moment (probably an architecture refresh, this is quite a lot of work to do purely for its own sake), and;
* Use that opportunity to overhaul searching in Pombola, and move from Haystack to [elasticsearch-dsl](https://elasticsearch-dsl.readthedocs.io/en/latest/).

Closes #2249