### PR TITLE
Use a Google Maps Geocoding API key if supplied in general.yml

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -114,3 +114,8 @@ EMAIL_HOST_USER: ''
 EMAIL_HOST_PASSWORD: ''
 EMAIL_PORT: 0
 EMAIL_USE_TLS: false
+
+# Some Pombola instances need a Google Maps Geocoding API to map
+# addresses to longitude / latitude. You can specify the key to use
+# here:
+GOOGLE_MAPS_GEOCODING_API_KEY: ''

--- a/pombola/search/geocoder.py
+++ b/pombola/search/geocoder.py
@@ -1,10 +1,15 @@
+from django.conf import settings
 from pygeocoder import Geocoder
 
 
 def geocoder(country, q, decimal_places=3):
 
     components = "country:" + country
-    response = Geocoder.geocode(q, components=components)
+    if settings.GOOGLE_MAPS_GEOCODING_API_KEY:
+        geocoder = Geocoder(settings.GOOGLE_MAPS_GEOCODING_API_KEY)
+        response = geocoder.geocode(q, components=components)
+    else:
+        response = Geocoder.geocode(q, components=components)
 
     results = []
 

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -644,3 +644,5 @@ SHELL_PLUS_APP_PREFIXES = {
     'interests_register': 'interests',
     'place_data': 'place_data',
 }
+
+GOOGLE_MAPS_GEOCODING_API_KEY = config.get('GOOGLE_MAPS_GEOCODING_API_KEY', '')


### PR DESCRIPTION
We have been getting lots of:

   GeocoderError: Error OVER_QUERY_LIMIT

... errors from pombola/search/geocoder.py, which we should deal with by
paying for usage of the API. This requires using an an API key to
identify us, hence this change.

Part of the fix for #2313