### PR TITLE
Sync EveryPolitician UUID to Person model

### DIFF
--- a/pombola/south_africa/management/commands/south_africa_sync_everypolitician_uuid.py
+++ b/pombola/south_africa/management/commands/south_africa_sync_everypolitician_uuid.py
@@ -1,0 +1,46 @@
+from everypolitician import EveryPolitician
+
+from django.core.management.base import BaseCommand
+
+from pombola.core.models import Person
+
+
+class Command(BaseCommand):
+    help = "Sync EveryPolitician UUID to Person's identifiers array"
+
+    def add_arguments(self, parser):
+        parser.add_argument('everypolitician_countries_json_git_ref',
+                            default='master', nargs='?',
+                            help="A git ref from the everypolitician-data repo")
+
+    def handle(self, **options):
+        verbose_level = options['verbosity']
+
+        url_template = ('https://cdn.rawgit.com/everypolitician/everypolitician-data/'
+                        '{git_ref}/countries.json')
+
+        url = url_template.format(git_ref=options['everypolitician_countries_json_git_ref'])
+
+        ep = EveryPolitician(countries_json_url=url)
+        south_africa_assembly = ep.country('South-Africa').legislature('Assembly').popolo()
+
+        id_lookup = {}
+        for popolo_person in south_africa_assembly.persons:
+            id_lookup[popolo_person.identifier_value('peoples_assembly')] = popolo_person.id
+
+        error_msg = u"No EveryPolitician UUID found for {0.id} {0.name} https://www.pa.org.za/person/{0.slug}/\n"
+        for person in Person.objects.filter(hidden=False):
+            uuid = id_lookup.get(str(person.id))
+            if uuid is None:
+                verbose_level > 1 and self.stderr.write(error_msg.format(person))
+                continue
+            identifier, created = person.identifiers.get_or_create(
+                scheme='everypolitician',
+                identifier=uuid,
+            )
+            if verbose_level > 0:
+                if created:
+                    msg = u"Created new identifier for {name}: {identifier}"
+                else:
+                    msg = u"Existing identifier found for {name}: {identifier}"
+                self.stdout.write(msg.format(name=person.name, identifier=identifier.identifier))

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,3 +173,7 @@ gunicorn==19.4.5
 whitenoise==2.0.6
 
 cffi
+
+# everypolitician packages
+everypolitician==0.0.13
+everypolitician-popolo==0.0.11


### PR DESCRIPTION
Add a management command add EveryPolitician UUIDs to the Person model.

### ~~Blocked waiting for EveryPolitician South Africa import to be fixed~~

~~This is currently using the `south-africa-update-peoples-assembly` branch of everypolitician-data, which has the required UUIDs but is also losing some data, so can't be merged in its current state. So before this can be merged we need to fix the problems described in https://github.com/everypolitician/everypolitician-data/issues/42096.~~

To work around this problem I've made the git ref that we use to fetch `countries.json` configurable. This means we can point to the branch that has the data we need for now, then when things are fixed upstream we can use a different ref to point to the fixed data.

I've also split the bit that adds a cronjob for this into a separate pull request https://github.com/mysociety/pombola/pull/2342 so we can hold off merging that until we've got the data in EveryPolitician up-to-date, but we can still merge this in the meantime.

Fixes https://github.com/mysociety/pombola/issues/2330