### PR TITLE
[ZA] Select correct person page tab on pageload

### DIFF
--- a/pombola/south_africa/static/js/tabs.js
+++ b/pombola/south_africa/static/js/tabs.js
@@ -27,8 +27,13 @@ $(function() {
     });
   }
 
-  // Work out which tab should be active.
-  var activeTabIndex = $('.ui-tabs-active').prevAll().length || 0;
+  // Select a tab if it has been requested via URL hash fragment,
+  // otherwise, just pick a sensible default.
+  if ( $('.ui-tabs-panel' + window.location.hash).length ) {
+    var activeTabIndex = $('.ui-tabs-anchor[href="' + window.location.hash + '"]').parent().prevAll().length;
+  } else {
+    var activeTabIndex = $('.ui-tabs-active').prevAll().length || 0;
+  }
 
   $(".tabs").tabs({
     active: activeTabIndex


### PR DESCRIPTION
While working on #2329, I noticed that the selected tab on a person page wasn’t persisted across page refreshes, despite the tab ID being in the URL hash fragment.

This fixes that, and lets you, for example, share a link directly to a Representative’s "Positions", or "Appearances" … or (once #2329 is merged) "Messages".