### PR TITLE
Add postgresql-server-dev-9.6 to Travis CI apt packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
     packages:
     - yui-compressor
     - postgresql-9.6-postgis-2.3
+    # This is needed so that pg_config works for psycopg2's version detection
+    - postgresql-server-dev-9.6
 
 install:
   - wget ${ES_DOWNLOAD_URL}


### PR DESCRIPTION
This is needed so that psycopg2's version detection works correctly. Without this is uses the default pg_config, which is for 10.2 (at time of writing) which trips up psycopg2's version detection.

https://docs.travis-ci.com/user/database-setup/#Using-pg_config