### PR TITLE
Add Person.everypolitician_uuid method

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -470,6 +470,10 @@ class Person(ModelBase, HasImageMixin, ScorecardMixin, IdentifierMixin):
         else:
             return self.legal_name
 
+    @property
+    def everypolitician_uuid(self):
+        return self.get_identifier('everypolitician')
+
     def additional_names(self, include_name_to_use=False):
         filter_args = {}
         if not include_name_to_use:

--- a/pombola/core/tests/test_models.py
+++ b/pombola/core/tests/test_models.py
@@ -719,3 +719,15 @@ class OverlappingPositionsTests(TestCase):
             person.delete()
             position.delete()
             i += 1
+
+
+class PersonEveryPoliticianUUIDTest(TestCase):
+    def setUp(self):
+        self.person = models.Person.objects.create(legal_name="Bob Smith", slug="bob-smith")
+
+    def test_returns_none_with_no_identifier(self):
+        self.assertEqual(self.person.everypolitician_uuid, None)
+
+    def test_returns_uuid(self):
+        self.person.identifiers.create(scheme='everypolitician', identifier='99795f75-d2fe-4353-a177-a4b8c8cfc01d')
+        self.assertEqual(self.person.everypolitician_uuid, '99795f75-d2fe-4353-a177-a4b8c8cfc01d')


### PR DESCRIPTION
Adds a method that returns the EveryPolitician UUID from the persons identifiers if there's one present.

This is needed for the WriteInPublic integration we're doing for South Africa. We're going to need to use the EP UUID quite a bit for that, so I think it makes sense to add a shortcut for accessing that information.

This was extracted from https://github.com/mysociety/pombola/pull/2329 and follows on from #2331.