### PR TITLE
Add WriteInPublic API client

### DIFF
--- a/pombola/writeinpublic/client.py
+++ b/pombola/writeinpublic/client.py
@@ -1,0 +1,99 @@
+import requests
+
+from django.utils.dateparse import parse_datetime
+
+from pombola.core.models import Person
+
+
+class PersonMixin(object):
+    def parse_everypolitician_uuid(self, resource_uri):
+        return resource_uri.split('#')[-1].split('-', 1)[-1]
+
+
+class Message(PersonMixin, object):
+    def __init__(self, params):
+        self.id = params['id']
+        self.author_name = params['author_name']
+        self.subject = params['subject']
+        self.content = params['content']
+        self.created_at = parse_datetime(params['created'])
+        self._params = params
+
+    def people(self):
+        return Person.objects.filter(
+            identifiers__scheme='everypolitician',
+            identifiers__identifier__in=self._recipient_ids(),
+        )
+
+    def _recipient_ids(self):
+        return [self.parse_everypolitician_uuid(p['resource_uri']) for p in self._params['people']]
+
+    def answers(self):
+        return [Answer(a) for a in self._params['answers']]
+
+
+class Answer(PersonMixin, object):
+    def __init__(self, params):
+        self.content = params['content']
+        self.created_at = parse_datetime(params['created'])
+        self.person = Person.objects.get(
+            identifiers__scheme='everypolitician',
+            identifiers__identifier=self.parse_everypolitician_uuid(params['person']['resource_uri']),
+        )
+
+
+class WriteInPublic(object):
+    class WriteInPublicException(Exception):
+        pass
+
+    def __init__(self, url, username, api_key, instance_id):
+        self.url = url
+        self.username = username
+        self.api_key = api_key
+        self.instance_id = instance_id
+
+    def create_message(self, author_name, author_email, subject, content, persons):
+        url = '{url}/api/v1/message/'.format(url=self.url)
+        params = {
+            'format': 'json',
+            'username': self.username,
+            'api_key': self.api_key,
+        }
+        payload = {
+            'author_name': author_name,
+            'author_email': author_email,
+            'subject': subject,
+            'content': content,
+            'writeitinstance': "/api/v1/instance/{}/".format(self.instance_id),
+            'persons': persons,
+        }
+        try:
+            response = requests.post(url, json=payload, params=params)
+            response.raise_for_status()
+            return response
+        except requests.exceptions.RequestException as err:
+            raise self.WriteInPublicException(unicode(err))
+
+    def get_message(self, message_id):
+        url = '{url}/api/v1/message/{message_id}/'.format(url=self.url, message_id=message_id)
+        params = {
+            'format': 'json',
+            'username': self.username,
+            'api_key': self.api_key,
+        }
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+        return Message(response.json())
+
+    def get_messages(self, person_popolo_uri):
+        url = '{url}/api/v1/instance/{instance_id}/messages/'.format(url=self.url, instance_id=self.instance_id)
+        params = {
+            'format': 'json',
+            'username': self.username,
+            'api_key': self.api_key,
+            'person__popolo_uri': person_popolo_uri,
+        }
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+        messages = response.json()['objects']
+        return [Message(m) for m in messages]

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -1,0 +1,86 @@
+import requests_mock
+
+from django.test import TestCase
+from django.utils.dateparse import parse_datetime
+
+from . import client
+
+
+@requests_mock.Mocker()
+class ClientTest(TestCase):
+    def setUp(self):
+        self.writeinpublic = client.WriteInPublic('https://example.com', 'test', '123', '42')
+
+    def test_create_message(self, m):
+        m.post('/api/v1/message/')
+        self.writeinpublic.create_message(
+            author_name='Alice',
+            author_email='alice@example.org',
+            subject='Test subject',
+            content='Hello, testing.',
+            persons='https://example.net/p.json#person-1',
+        )
+        expected_json = {
+            'writeitinstance': '/api/v1/instance/42/',
+            'author_email': 'alice@example.org',
+            'author_name': 'Alice',
+            'content': 'Hello, testing.',
+            'persons': 'https://example.net/p.json#person-1',
+            'subject': 'Test subject',
+        }
+        expected_url = 'https://example.com/api/v1/message/?username=test&api_key=123&format=json'
+        last_request = m._adapter.last_request
+        self.assertEqual(last_request.json(), expected_json)
+        self.assertEqual(last_request.url, expected_url)
+
+    def test_get_message(self, m):
+        message_json = {
+            'id': '1',
+            'author_name': 'Alice',
+            'subject': 'Test message',
+            'content': 'Test content',
+            'created': '2017-11-14T04:01:05.799658',
+        }
+        m.get('/api/v1/message/1/', json=message_json)
+        message = self.writeinpublic.get_message(1)
+        self.assertEqual(message.id, '1')
+        self.assertEqual(message.author_name, 'Alice')
+        self.assertEqual(message.subject, 'Test message')
+        self.assertEqual(message.content, 'Test content')
+        self.assertEqual(message.created_at, parse_datetime(message_json['created']))
+
+        # TODO: Add tests for message.people() and message.answers() methods
+
+    def test_get_messages(self, m):
+        messages_json = {
+            'objects': [
+                {
+                    'id': '1',
+                    'author_name': 'Alice',
+                    'subject': 'Test message',
+                    'content': 'Test content',
+                    'created': '2017-11-14T04:01:05.799658',
+                },
+                {
+                    'id': '2',
+                    'author_name': 'Bob',
+                    'subject': 'Another test message',
+                    'content': 'More test content',
+                    'created': '2017-11-15T05:05:04.345258',
+                },
+            ],
+        }
+        m.get('/api/v1/instance/42/messages/', json=messages_json)
+        popolo_uri = 'https://example.net/p.json#person-1'
+        messages = self.writeinpublic.get_messages(popolo_uri)
+        last_request = m._adapter.last_request
+        expected_qs = {
+            'username': ['test'],
+            'api_key': ['123'],
+            'format': ['json'],
+            'person__popolo_uri': [popolo_uri],
+        }
+        self.assertEqual(last_request.qs, expected_qs)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].subject, 'Test message')
+        self.assertEqual(messages[1].subject, 'Another test message')

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,7 @@ yanc==0.2.4
 httplib2==0.9
 WebTest==2.0.15
 django-webtest==1.7.8
+requests-mock==1.4.0
 
 # For Ghana:
 python-openid


### PR DESCRIPTION
This is a very simple wrapper around the WriteInPublic API. Currently it only implements the features that we need for integrating it into Pombola.

I've added some tests for the basic functionality, but in the interests of time I've skipped writing tests for the `.people()` and `.answers()` methods, so will need to revisit that at some point in the future.

Extracted from #2329 
Part of #1682 