### PR TITLE
[ZA] Activate WriteInPublic integration

### DIFF
--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -21,6 +21,7 @@ from pombola.core.urls import (
     place_patterns_path,
     )
 from pombola.search.urls import urlpatterns as search_urlpatterns
+from pombola.writeinpublic.views import WriteToRepresentativeMessages
 
 organisation_patterns = copy.copy(organisation_patterns)
 
@@ -265,4 +266,14 @@ urlpatterns += (
         views.SAMembersInterestsSource.as_view(),
         name='sa-interests-source'
     ),
+)
+
+# WriteInPublic
+urlpatterns += (
+    url(
+        r'^person/(?P<person_slug>[-\w]+)/messages/$',
+        WriteToRepresentativeMessages.as_view(),
+        name='sa-person-write-all'
+    ),
+    url(r'^write/', include('pombola.writeinpublic.urls')),
 )


### PR DESCRIPTION
This adds the `urls.py` entry to enable the WriteInPublic integration.

Follows on from #2346 
Extracted from #2329 
Part of #2326 

## Notes to merger

Before merging

- [x] Change base branch to `master` once #2346 has been merged
- [x] Make sure you are ready to launch the WriteInPublic integration