### PR TITLE
Add WriteInPublic Configuration model

### DIFF
--- a/pombola/writeinpublic/migrations/0001_initial.py
+++ b/pombola/writeinpublic/migrations/0001_initial.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Configuration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('url', models.CharField(help_text=b'URL for the WriteInPublic API without instance subdomain, e.g. http://writeinpublic.pa.org.za', max_length=200)),
+                ('instance_id', models.PositiveIntegerField(help_text=b'Instance ID, can be found at /en/manage/settings/api/ on your instance subdomain')),
+                ('username', models.CharField(help_text=b'Username for the WriteInPublic instance you want to use', max_length=30)),
+                ('api_key', models.CharField(help_text=b'API key for the WriteInPublic instance you want to use', max_length=128)),
+                ('slug', models.CharField(help_text=b'A unique human-friendly identifier for this configuration', unique=True, max_length=30)),
+                ('person_uuid_prefix', models.CharField(help_text=b"The prefix for people's UUID", max_length=200)),
+            ],
+        ),
+    ]

--- a/pombola/writeinpublic/models.py
+++ b/pombola/writeinpublic/models.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+
+class Configuration(models.Model):
+    url = models.CharField(max_length=200, help_text="URL for the WriteInPublic API without instance subdomain, e.g. http://writeinpublic.pa.org.za")
+    instance_id = models.PositiveIntegerField(help_text="Instance ID, can be found at /en/manage/settings/api/ on your instance subdomain")
+    # Same max_length as Django's User model, to match write-it
+    username = models.CharField(max_length=30, help_text="Username for the WriteInPublic instance you want to use")
+    # Same max_length as tastypie, to match write-it
+    api_key = models.CharField(max_length=128, help_text="API key for the WriteInPublic instance you want to use")
+    slug = models.CharField(max_length=30, unique=True, help_text="A unique human-friendly identifier for this configuration")
+    person_uuid_prefix = models.CharField(max_length=200, help_text="The prefix for people's UUID")


### PR DESCRIPTION
This will contain the configuration to connect to a WriteInPublic instance. This will allow us to connect to multiple WriteInPublic instances, rather than just having one set of configuration values in `general.yml`.

First part of https://github.com/mysociety/pombola/issues/2365