### PR TITLE
Update WriteInPublic views to use configuration values

### DIFF
--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -273,7 +273,8 @@ urlpatterns += (
     url(
         r'^person/(?P<person_slug>[-\w]+)/messages/$',
         WriteToRepresentativeMessages.as_view(),
+        kwargs={'configuration_slug': 'south-africa-assembly'},
         name='sa-person-write-all'
     ),
-    url(r'^write/', include('pombola.writeinpublic.urls')),
+    url(r'^write/', include('pombola.writeinpublic.urls'), kwargs={'configuration_slug': 'south-africa-assembly'}),
 )

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -11,6 +11,7 @@ from pombola.core.models import Person
 
 from .forms import RecipientForm, DraftForm, PreviewForm
 from .client import WriteInPublic
+from .models import Configuration
 
 
 def person_everypolitician_uuid_required(function):
@@ -26,14 +27,15 @@ def person_everypolitician_uuid_required(function):
 
 
 class WriteInPublicMixin(object):
-    def __init__(self, *args, **kwargs):
+    def dispatch(self, *args, **kwargs):
+        configuration = Configuration.objects.get(slug=kwargs['configuration_slug'])
         self.client = WriteInPublic(
-            settings.WRITEINPUBLIC_URL,
-            settings.WRITEINPUBLIC_USERNAME,
-            settings.WRITEINPUBLIC_API_KEY,
-            settings.WRITEINPUBLIC_INSTANCE_ID
+            configuration.url,
+            configuration.username,
+            configuration.api_key,
+            configuration.instance_id
         )
-        super(WriteInPublicMixin, self).__init__(*args, **kwargs)
+        return super(WriteInPublicMixin, self).dispatch(*args, **kwargs)
 
 
 FORMS = [


### PR DESCRIPTION
Following on from #2367 this changes the view to get the configuration from the database, rather than the config file.

Follows on from #2367 
Second part of https://github.com/mysociety/pombola/issues/2365

## Notes to merger

Please do the following before merging

- [x] Once #2367 has been merged change the base branch to `master`
- [x] Deploy #2367 to the production and create a `Configuration` instance in the DB with the current production settings using the slug "south-africa-assembly".