### PR TITLE
WriteInPublic: Redirect to pending message page at end of wizard

### DIFF
--- a/pombola/writeinpublic/templates/writeinpublic/pending.html
+++ b/pombola/writeinpublic/templates/writeinpublic/pending.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}WriteInPublic message pending{% endblock %}
+
+{% block content %}
+
+{% include 'writeinpublic/flash_messages.html' %}
+
+<div class="infopage">
+
+  <h2>Thanks for your message</h2>
+
+  <p>It will appear on the site once it has been approved by the site admins.</p>
+
+</div>
+
+{% endblock %}
+
+{% block correct_this_page %}
+<a class="feedback-button button" href="{% url "writeinpublic-new-message" %}">Return to Write to my MP</a>
+{% endblock %}

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -153,9 +153,9 @@ class WriteInPublicNewMessageViewTest(TestCase):
         # GET the done step
         response = self.client.get(response.url)
 
-        # Check that we're redirected to the newly created message
+        # Check that we're redirected to the pending message page
         self.assertRedirects(
             response,
-            reverse('writeinpublic-message', kwargs={'message_id': '42'}),
+            reverse('writeinpublic-pending'),
             fetch_redirect_response=False
         )

--- a/pombola/writeinpublic/urls.py
+++ b/pombola/writeinpublic/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.views.generic import TemplateView
 
 from . import views
 
@@ -6,6 +7,11 @@ from . import views
 write_message_wizard = views.WriteInPublicNewMessage.as_view(url_name='writeinpublic-new-message-step')
 
 urlpatterns = (
+    url(
+        r'^pending/$',
+        TemplateView.as_view(template_name='writeinpublic/pending.html'),
+        name='writeinpublic-pending',
+    ),
     url(
         r'^message/(?P<message_id>\d+)/$',
         views.WriteInPublicMessage.as_view(),

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -106,8 +106,8 @@ class WriteInPublicNewMessage(WriteInPublicMixin, NamedUrlSessionWizardView):
             )
             if response.ok:
                 message_id = response.json()['id']
-                messages.success(self.request, 'Success, your message has now been sent.')
-                return redirect('writeinpublic-message', message_id=message_id)
+                messages.success(self.request, 'Success, your message has been accepted.')
+                return redirect('writeinpublic-pending')
             else:
                 messages.error(self.request, 'Sorry, there was an error sending your message, please try again. If this problem persists please contact us.')
                 return redirect('writeinpublic-new-message')


### PR DESCRIPTION
We've enabled moderation on the WriteInPublic instance, which means that the message isn't available via the API immediately. Rather than redirecting to a message page instead we redirect to a pending message page which lets the user know that their message needs to be approved.

This isn't the prettiest page at the moment, but it will at least stop the immediate errors.

Fixes https://github.com/mysociety/pombola/issues/2378