### PR TITLE
[ZA] Add API endpoint to serve committee Popolo JSON

### DIFF
--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -278,3 +278,11 @@ urlpatterns += (
     ),
     url(r'^write/', include('pombola.writeinpublic.urls'), kwargs={'configuration_slug': 'south-africa-assembly'}),
 )
+
+urlpatterns += (
+    url(
+        r'^api/committees/popolo.json$',
+        views.CommitteesPopoloJson.as_view(),
+        name='sa-committees-popolo-json'
+    ),
+)

--- a/pombola/south_africa/views/__init__.py
+++ b/pombola/south_africa/views/__init__.py
@@ -10,3 +10,4 @@ from .person import *
 from .positions import *
 from .search import *
 from .speechviews import *
+from .api import *

--- a/pombola/south_africa/views/api.py
+++ b/pombola/south_africa/views/api.py
@@ -1,0 +1,28 @@
+from django.http import JsonResponse
+from django.views.generic import ListView
+
+from pombola.core.models import Organisation
+
+
+# Output Popolo JSON suitable for WriteInPublic for any committees that have an
+# email address.
+class CommitteesPopoloJson(ListView):
+    queryset = Organisation.objects.filter(
+        kind__name='National Assembly Committees',
+        contacts__kind__slug='email'
+    )
+
+    def render_to_response(self, context, **response_kwargs):
+        return JsonResponse(
+            {
+                'persons': [
+                    {
+                        'id': committee.id,
+                        'name': committee.name,
+                        'email': committee.contacts.filter(kind__slug='email')[0].value,
+                        'contact_details': []
+                    }
+                    for committee in context['object_list']
+                ]
+            }
+        )


### PR DESCRIPTION
This adds an API endpoint which serves up Popolo JSON suitable for feeding into WriteInPublic. This means that any changes to committee email addresses will automatically be reflected in WiP when the datasource is synced.

## Notes to reviewer

Currently there aren't any committees with an email address in the production pa.org.za deploy. I added email addresses to a couple of committees locally to test this. Below is an example of the JSON that this call produces, note that the empty `contact_details` array is needed for WriteInPublic, otherwise an error is produced on import.

```json
{
  "persons": [
    {
      "email": "test@example.com",
      "contact_details": [],
      "id": 1410,
      "name": "Ad Hoc Committee on Funding of Political Parties"
    },
    {
      "email": "committee@example.org",
      "contact_details": [],
      "id": 141,
      "name": "Ad Hoc Committee on Code of Judicial Conduct on Disclosure of Interests (NA)"
    }
  ]
}
```

Part of https://github.com/mysociety/pombola/issues/2324