### PR TITLE
[WriteInPublic] Make person_uuid_prefix configurable

### DIFF
--- a/pombola/writeinpublic/client.py
+++ b/pombola/writeinpublic/client.py
@@ -46,11 +46,12 @@ class WriteInPublic(object):
     class WriteInPublicException(Exception):
         pass
 
-    def __init__(self, url, username, api_key, instance_id):
+    def __init__(self, url, username, api_key, instance_id, person_uuid_prefix):
         self.url = url
         self.username = username
         self.api_key = api_key
         self.instance_id = instance_id
+        self.person_uuid_prefix = person_uuid_prefix
 
     def create_message(self, author_name, author_email, subject, content, persons):
         url = '{url}/api/v1/message/'.format(url=self.url)
@@ -59,13 +60,14 @@ class WriteInPublic(object):
             'username': self.username,
             'api_key': self.api_key,
         }
+        person_uris = [self.person_uuid_prefix.format(uuid) for uuid in persons]
         payload = {
             'author_name': author_name,
             'author_email': author_email,
             'subject': subject,
             'content': content,
             'writeitinstance': "/api/v1/instance/{}/".format(self.instance_id),
-            'persons': persons,
+            'persons': person_uris,
         }
         try:
             response = requests.post(url, json=payload, params=params)

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -14,7 +14,7 @@ from .models import Configuration
 @requests_mock.Mocker()
 class ClientTest(TestCase):
     def setUp(self):
-        self.writeinpublic = client.WriteInPublic('https://example.com', 'test', '123', '42')
+        self.writeinpublic = client.WriteInPublic('https://example.com', 'test', '123', '42', 'https://example.net/p.json#person-{}')
 
     def test_create_message(self, m):
         m.post('/api/v1/message/')
@@ -23,14 +23,14 @@ class ClientTest(TestCase):
             author_email='alice@example.org',
             subject='Test subject',
             content='Hello, testing.',
-            persons='https://example.net/p.json#person-1',
+            persons=['1'],
         )
         expected_json = {
             'writeitinstance': '/api/v1/instance/42/',
             'author_email': 'alice@example.org',
             'author_name': 'Alice',
             'content': 'Hello, testing.',
-            'persons': 'https://example.net/p.json#person-1',
+            'persons': ['https://example.net/p.json#person-1'],
             'subject': 'Test subject',
         }
         expected_url = 'https://example.com/api/v1/message/?username=test&api_key=123&format=json'

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -33,7 +33,8 @@ class WriteInPublicMixin(object):
             configuration.url,
             configuration.username,
             configuration.api_key,
-            configuration.instance_id
+            configuration.instance_id,
+            configuration.person_uuid_prefix
         )
         return super(WriteInPublicMixin, self).dispatch(*args, **kwargs)
 
@@ -93,8 +94,6 @@ class WriteInPublicNewMessage(WriteInPublicMixin, NamedUrlSessionWizardView):
     def done(self, form_list, form_dict, **kwargs):
         persons = form_dict['recipients'].cleaned_data['persons']
         person_ids = [p.everypolitician_uuid for p in persons]
-        person_uris = ["https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/data/South_Africa/Assembly/ep-popolo-v1.0.json#person-{}".format(uuid)
-                       for uuid in person_ids]
         message = form_dict['draft'].cleaned_data
         try:
             response = self.client.create_message(
@@ -102,7 +101,7 @@ class WriteInPublicNewMessage(WriteInPublicMixin, NamedUrlSessionWizardView):
                 author_email=message['author_email'],
                 subject=message['subject'],
                 content=message['content'],
-                persons=person_uris,
+                persons=person_ids,
             )
             if response.ok:
                 message_id = response.json()['id']


### PR DESCRIPTION
Rather than hardcoding the person_uuid_prefix in the WriteInPublic views this instead gets it from the Configuration model and then passes it into the client. The client then uses that prefix internally to prefix IDs, rather than expecting the IDs to already be prefixed.

Part of https://github.com/mysociety/pombola/issues/1682
Part of https://github.com/mysociety/pombola/issues/2328