### PR TITLE
[WriteInPublic] Use URL namespaces to allow multiple app instances

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -31,7 +31,7 @@
     <div class="contact-actions">
       {% if person.everypolitician_uuid %}
         <div class="contact-actions__wip">
-            <a href="{% url 'writeinpublic-new-message' %}?person_id={{ person.pk }}">Write a public message to this MP</a>
+            <a href="{% url 'writeinpublic-mps:writeinpublic-new-message' %}?person_id={{ person.pk }}">Write a public message to this MP</a>
         </div>
       {% elif email_contacts %}
         <div class="contact-actions__email">

--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -99,12 +99,14 @@
             </h2>
         </div>
         <div class="home__actions__secondary">
-            <a href="{% url 'writeinpublic-new-message' %}" class="button button--low-case button--write button--write--rep">Write to an MP</a>
+            <a href="{% url 'writeinpublic-mps:writeinpublic-new-message' %}" class="button button--low-case button--write button--write--rep">Write to an MP</a>
             <span class="fake-button-wrapper">
                 <span class="button button--low-case button--write button--write--committee button--fake-button">Write to a committee</span>
                 <i>Coming soon</i>
             </span>
-            <!--<a href="{% url 'writeinpublic-new-message' %}" class="button button--low-case button--write button--write--committee">Write to a committee</a> -->
+            {% comment %}
+            <a href="{% url 'writeinpublic-committees:writeinpublic-new-message' %}" class="button button--low-case button--write button--write--committee">Write to a committee</a>
+            {% endcomment %}
         </div>
     </div>
 </div>

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -276,7 +276,7 @@ urlpatterns += (
         kwargs={'configuration_slug': 'south-africa-assembly'},
         name='sa-person-write-all'
     ),
-    url(r'^write/', include('pombola.writeinpublic.urls'), kwargs={'configuration_slug': 'south-africa-assembly'}),
+    url(r'^write/', include('pombola.writeinpublic.urls', namespace='writeinpublic-mps', app_name='writeinpublic'), kwargs={'configuration_slug': 'south-africa-assembly'}),
 )
 
 urlpatterns += (

--- a/pombola/writeinpublic/templates/writeinpublic/message.html
+++ b/pombola/writeinpublic/templates/writeinpublic/message.html
@@ -48,5 +48,5 @@
 {% endblock %}
 
 {% block correct_this_page %}
-<a class="feedback-button button" href="{% url "writeinpublic-new-message" %}">Return to Write to my MP</a>
+<a class="feedback-button button" href="{% url "writeinpublic:writeinpublic-new-message" %}">Return to Write to my MP</a>
 {% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/messages.html
+++ b/pombola/writeinpublic/templates/writeinpublic/messages.html
@@ -8,12 +8,12 @@
   {% for message in messages %}
     <div>
         <h3>
-            <a href="{% url 'writeinpublic-message' message_id=message.id %}">{{ message.subject }}</a>
+            <a href="{% url 'writeinpublic:writeinpublic-message' message_id=message.id %}">{{ message.subject }}</a>
             &ndash; <small>{{ message.created_at|date:"d M Y" }}</small>
         </h3>
         <p>
             {{ message.content|truncatewords:30 }}
-            <a href="{% url 'writeinpublic-message' message_id=message.id %}">(Read more)</a>
+            <a href="{% url 'writeinpublic:writeinpublic-message' message_id=message.id %}">(Read more)</a>
         </p>
     </div>
   {% empty %}

--- a/pombola/writeinpublic/templates/writeinpublic/pending.html
+++ b/pombola/writeinpublic/templates/writeinpublic/pending.html
@@ -17,5 +17,5 @@
 {% endblock %}
 
 {% block correct_this_page %}
-<a class="feedback-button button" href="{% url "writeinpublic-new-message" %}">Return to Write to my MP</a>
+<a class="feedback-button button" href="{% url "writeinpublic:writeinpublic-new-message" %}">Return to Write to my MP</a>
 {% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-draft.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-draft.html
@@ -49,7 +49,7 @@
         </div>
     </div>
 
-    <a class="button secondary-button" href="{% url 'writeinpublic-new-message-step' step='recipients' %}">Change recipients</a>
+    <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='recipients' %}">Change recipients</a>
     <input type="submit" value="Preview message" class="button pull-right">
 </form>
 {% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -29,7 +29,7 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <a class="button secondary-button" href="{% url 'writeinpublic-new-message-step' step='draft' %}">Edit message</a>
+    <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
     <input type="submit" value="Send message" class="button pull-right">
 </form>
 {% endblock %}

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -108,45 +108,45 @@ class WriteInPublicNewMessageViewTest(TestCase):
         )
         person = Person.objects.create()
         person.identifiers.create(scheme='everypolitician', identifier='test')
-        response = self.client.get(reverse('writeinpublic-new-message'))
-        self.assertRedirects(response, reverse('writeinpublic-new-message-step', kwargs={'step': 'recipients'}))
+        response = self.client.get(reverse('writeinpublic:writeinpublic-new-message'))
+        self.assertRedirects(response, reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'recipients'}))
 
         # GET the recipients step
         response = self.client.get(response.url)
         self.assertEquals(response.status_code, 200)
 
         # POST to the recipients step
-        response = self.client.post(reverse('writeinpublic-new-message-step', kwargs={'step': 'recipients'}), {
+        response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'recipients'}), {
             'write_in_public_new_message-current_step': 'recipients',
             'recipients-persons': person.id,
         })
-        self.assertRedirects(response, reverse('writeinpublic-new-message-step', kwargs={'step': 'draft'}))
+        self.assertRedirects(response, reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'draft'}))
 
         # GET the draft step
         response = self.client.get(response.url)
         self.assertEquals(response.status_code, 200)
 
         # POST to the draft step
-        response = self.client.post(reverse('writeinpublic-new-message-step', kwargs={'step': 'draft'}), {
+        response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'draft'}), {
             'write_in_public_new_message-current_step': 'draft',
             'draft-subject': 'Test',
             'draft-content': 'Test',
             'draft-author_name': 'Test',
             'draft-author_email': 'test@example.com',
         })
-        self.assertRedirects(response, reverse('writeinpublic-new-message-step', kwargs={'step': 'preview'}))
+        self.assertRedirects(response, reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'preview'}))
 
         # GET the preview step
         response = self.client.get(response.url)
         self.assertEquals(response.status_code, 200)
 
         # POST to the preview step
-        response = self.client.post(reverse('writeinpublic-new-message-step', kwargs={'step': 'preview'}), {
+        response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'preview'}), {
             'write_in_public_new_message-current_step': 'preview',
         })
         self.assertRedirects(
             response,
-            reverse('writeinpublic-new-message-step', kwargs={'step': 'done'}),
+            reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'done'}),
             fetch_redirect_response=False
         )
 
@@ -156,6 +156,6 @@ class WriteInPublicNewMessageViewTest(TestCase):
         # Check that we're redirected to the pending message page
         self.assertRedirects(
             response,
-            reverse('writeinpublic-pending'),
+            reverse('writeinpublic:writeinpublic-pending'),
             fetch_redirect_response=False
         )

--- a/pombola/writeinpublic/urls.py
+++ b/pombola/writeinpublic/urls.py
@@ -4,7 +4,7 @@ from django.views.generic import TemplateView
 from . import views
 
 
-write_message_wizard = views.WriteInPublicNewMessage.as_view(url_name='writeinpublic-new-message-step')
+write_message_wizard = views.WriteInPublicNewMessage.as_view(url_name='writeinpublic:writeinpublic-new-message-step')
 
 urlpatterns = (
     url(


### PR DESCRIPTION
Namespacing the URLs allows us to "mount" multiple instances of the writeinpublic app in the URL config. This means we can have one instance for writing to MPs and another for writing to committees.

This adds namespacing support to the `writeinpublic` app without changing the way it works. This change doesn't add support for committees, that will be added in a separate pull request.

Part of https://github.com/mysociety/pombola/issues/2351