### PR TITLE
Don't error on a ZERO_RESULTS exception from Google's geocoder

### DIFF
--- a/pombola/search/views.py
+++ b/pombola/search/views.py
@@ -14,6 +14,7 @@ from pombola.core import models
 from haystack.query import SearchQuerySet
 from haystack.inputs import AutoQuery, Raw
 
+from pygeolib import GeocoderError
 from sorl.thumbnail import get_thumbnail
 from .geocoder import geocoder
 
@@ -351,7 +352,13 @@ class GeocoderView(TemplateView):
         query = self.request.GET.get('q')
         if query:
             context['query'] = query
-            context['geocoder_results'] = geocoder(country=country_alpha2, q=query)
+            try:
+                context['geocoder_results'] = geocoder(country=country_alpha2, q=query)
+            except GeocoderError as e:
+                if e.status == GeocoderError.G_GEO_ZERO_RESULTS:
+                    context['geocoder_results'] = []
+                else:
+                    raise
 
         return context
 


### PR DESCRIPTION
Don't error on a ZERO_RESULTS exception from Google's geocoder
    
We're getting quite a lot of email errors on PA for people
searching for places which cause pygeocoder to return a
ZERO_RESULTS exception. Here's an example error:
    
    Internal Server Error: /search/location/
    Traceback (most recent call last):
      File "[...]/pombola-virtualenv/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
      File "[...]/pombola-virtualenv/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
        return self.dispatch(request, *args, **kwargs)
      File "[...]/pombola-virtualenv/lib/python2.7/site-packages/django/views/generic/base.py", line 89, in dispatch
        return handler(request, *args, **kwargs)
      File "[...]/pombola/pombola/south_africa/views/geolocalization.py", line 37, in get
        context = self.get_context_data(**kwargs)
      File "[...]/pombola/pombola/search/views.py", line 354, in get_context_data
        context['geocoder_results'] = geocoder(country=country_alpha2, q=query)
      File "[...]/pombola/pombola/search/geocoder.py", line 10, in geocoder
        response = geocoder.geocode(q, components=components)
      File "[...]/pombola-virtualenv/lib/python2.7/site-packages/pygeocoder.py", line 127, in geocode
        return GeocoderResult(self.get_data(params=params))
      File "[...]/pombola-virtualenv/lib/python2.7/site-packages/pygeocoder.py", line 212, in get_data
        raise GeocoderError(response_json['status'], response.url)
    GeocoderError: Error ZERO_RESULTS
    Query: https://maps.google.com/maps/api/geocode/json?key=[...]&language=&region=&bounds=&components=country%3Aza&address=Nonaliti&sensor=false
    
    Request repr():
    <WSGIRequest
    path:/search/location/,
    GET:<QueryDict: {u'q': [u'Nonaliti']}>,
   POST:<QueryDict: {}>,
    
This commit handles exceptions with that status instead, and treats them
like an empty list.
    
Fixes #2387
