### PR TITLE
[WriteInPublic] Make view more generic

### DIFF
--- a/pombola/writeinpublic/client.py
+++ b/pombola/writeinpublic/client.py
@@ -3,12 +3,12 @@ import requests
 from django.utils.dateparse import parse_datetime
 
 
-class PersonMixin(object):
-    def parse_everypolitician_uuid(self, resource_uri):
+class RecipientMixin(object):
+    def parse_id(self, resource_uri):
         return resource_uri.split('#')[-1].split('-', 1)[-1]
 
 
-class Message(PersonMixin, object):
+class Message(RecipientMixin, object):
     def __init__(self, params, adapter):
         self.id = params['id']
         self.author_name = params['author_name']
@@ -22,13 +22,13 @@ class Message(PersonMixin, object):
         return self.adapter.filter(ids=self._recipient_ids())
 
     def _recipient_ids(self):
-        return [self.parse_everypolitician_uuid(p['resource_uri']) for p in self._params['people']]
+        return [self.parse_id(p['resource_uri']) for p in self._params['people']]
 
     def answers(self):
-        return [Answer(a, person=self.adapter.get(self.parse_everypolitician_uuid(a['person']['resource_uri']))) for a in self._params['answers']]
+        return [Answer(a, person=self.adapter.get(self.parse_id(a['person']['resource_uri']))) for a in self._params['answers']]
 
 
-class Answer(PersonMixin, object):
+class Answer(RecipientMixin, object):
     def __init__(self, params, person):
         self.content = params['content']
         self.created_at = parse_datetime(params['created'])

--- a/pombola/writeinpublic/forms.py
+++ b/pombola/writeinpublic/forms.py
@@ -9,15 +9,11 @@ from .client import WriteInPublic
 class RecipientForm(forms.Form):
     persons = ModelMultipleChoiceField(queryset=None)
 
+    # Dynamic queryset so we can show either people or committees
     def __init__(self, *args, **kwargs):
+        queryset = kwargs.pop('queryset')
         super(RecipientForm, self).__init__(*args, **kwargs)
-        # This is set dynamically because the script which syncs
-        # EveryPolitician UUIDs is run at a regular interval, and we want to
-        # pick up any new people that appear.
-        self.fields['persons'].queryset = Person.objects.filter(
-            identifiers__scheme='everypolitician',
-            identifiers__identifier__isnull=False,
-        )
+        self.fields['persons'].queryset = queryset
 
 
 class DraftForm(forms.Form):

--- a/pombola/writeinpublic/templates/writeinpublic/message.html
+++ b/pombola/writeinpublic/templates/writeinpublic/message.html
@@ -12,7 +12,7 @@
             <dt>To</dt>
             <dd>
               {% for person in message.people %}
-                <a href="{% url 'person' slug=person.slug %}">{{ person.name }}</a>{% if not forloop.last %},{% endif %}
+                <a href="{{ person.get_absolute_url }}">{{ person.name }}</a>{% if not forloop.last %},{% endif %}
               {% endfor %}
             </dd>
             <dt>From</dt>
@@ -32,7 +32,7 @@
         <dl class="person-write-message__meta">
           <dt>From</dt>
           <dd>
-          <a href="{% url 'person' slug=reply.person.slug %}">{{ reply.person.name }}</a>
+          <a href="{{ reply.person.get_absolute_url }}">{{ reply.person.name }}</a>
           </dd>
           <dt>Date</dt>
           <dd>{{ reply.created_at|date:"j F Y f a" }}</dd>


### PR DESCRIPTION
Rather than hardcoding the `Person` class all over the place this instead uses an adapter approach, which means we can pass in different adapters to the view which can use different models to get the required information.

This will allow us to have two different WriteInPublic instances, one that uses `Person` models to write to people and another, which is yet to be added, which will allow you to write to a committee, which is represented by the `Organisation` model.

Part of https://github.com/mysociety/pombola/issues/2328