### PR TITLE
[WriteInPublic] Fix PersonAdapter NameError

### DIFF
--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -12,6 +12,7 @@ from pombola.core.models import Person
 
 from . import client
 from .models import Configuration
+from .views import PersonAdapter
 
 
 @requests_mock.Mocker()
@@ -192,3 +193,11 @@ class WriteInPublicNewMessageViewTest(TestCase):
             reverse('writeinpublic:writeinpublic-pending'),
             fetch_redirect_response=False
         )
+
+
+class PersonAdapterTest(TestCase):
+    def test_get(self):
+        adapter = PersonAdapter()
+        person = Person.objects.create()
+        person.identifiers.create(scheme='everypolitician', identifier='test')
+        self.assertEqual(adapter.get('test'), person)

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -37,7 +37,7 @@ class PersonAdapter(object):
     def get(self, object_id):
         return Person.objects.get(
             identifiers__scheme='everypolitician',
-            identifiers__identifier=person_id,
+            identifiers__identifier=object_id,
         )
 
     def get_by_id(self, object_id):


### PR DESCRIPTION
The person adapter's `get` method was referencing a variable that didn't exist. I've fixed it to use the correct variable name and added a regression test.

Fixes https://github.com/mysociety/pombola/issues/2391