### PR TITLE
[ZA] Add page with a list of NA committees

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -3411,3 +3411,26 @@ ul.attendance__notes {
 .list-of-committee-messages__item__read-link {
     font-size: 0.875em;
 }
+
+.committee-list {
+    p {
+        margin-bottom: 0.25em;
+    }
+}
+
+.committee-list__links {
+    margin-bottom: 0.5em;
+    a:link,
+    a:visited,
+    a {
+        font-size: 0.875em;
+        text-decoration: underline;
+        color: #e23d28;
+        margin-right: 0.5em;
+        display: inline-block;
+        &:hover {
+            color: #333;
+        }
+    }
+    
+}

--- a/pombola/south_africa/templates/menu_entries.html
+++ b/pombola/south_africa/templates/menu_entries.html
@@ -65,6 +65,7 @@
         </ul>
       </li>
       <li><a href="{% url "info_page" slug="petitions" %}" role="menuitem">Petitions</a></li>
+      <li><a href="{% url "sa-committees-list" %}" role="menuitem">National Assembly Committees</a></li>
     </ul>
   {% endif %}
 </li>

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+{% load pagination_tags %}
+
+{% block title %}{% if kind %}{{ kind.name }}{% endif %}{% endblock %}
+
+{% block content %}
+
+    <h1 class="page-title">
+        {% if kind %}
+            {{ kind.name }}
+        {% else %}
+            Committees
+        {% endif %}
+    </h1>
+
+    {% if committees %}
+
+        {% autopaginate committees %}
+
+        <ul class="unstyled-list">
+
+        {% for committee in committees %}
+        <li class="list-of-things-item {{ committee.css_class }}-list-item{% if not committee.show_active %} inactive{% endif %}">
+
+            <a href="{{ committee.get_absolute_url }}">
+              <span class="name">{{ committee.name }}</span>
+            </a>
+
+            <br>
+
+            <a href="{% url 'organisation_messages' slug=committee.slug %}">Messages</a>
+
+        </li>
+        {% endfor %}
+
+        </ul>
+
+        {% include "core/_search_pagination_text.html" %}
+
+        {% paginate %}
+
+    {% else %}
+        <p>No committees were found</p>
+    {% endif %}
+
+{% endblock %}

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -17,19 +17,20 @@
 
         {% autopaginate committees %}
 
-        <ul class="unstyled-list">
+        <ul class="unstyled-list committee-list">
 
         {% for committee in committees %}
         <li class="list-of-things-item {{ committee.css_class }}-list-item{% if not committee.show_active %} inactive{% endif %}">
-
-            <a href="{{ committee.get_absolute_url }}">
-              <span class="name">{{ committee.name }}</span>
-            </a>
-
-            <br>
-
-            <a href="{% url 'organisation_messages' slug=committee.slug %}">Messages</a>
-
+            <p>
+                <a href="{{ committee.get_absolute_url }}" class="committee-list__name">
+                {{ committee.name }}
+                </a>
+            </p>
+           
+            <div class="committee-list__links">
+                <a href="{% url 'organisation_messages' slug=committee.slug %}">View messages</a>
+                <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
+            </div>
         </li>
         {% endfor %}
 

--- a/pombola/south_africa/urls.py
+++ b/pombola/south_africa/urls.py
@@ -271,6 +271,11 @@ urlpatterns += (
 # WriteInPublic
 urlpatterns += (
     url(
+        r'^committees/$',
+        views.SACommitteesView.as_view(),
+        name='sa-committees-list'
+    ),
+    url(
         r'^person/(?P<person_slug>[-\w]+)/messages/$',
         WriteToRepresentativeMessages.as_view(),
         kwargs={'configuration_slug': 'south-africa-assembly'},

--- a/pombola/south_africa/views/__init__.py
+++ b/pombola/south_africa/views/__init__.py
@@ -1,4 +1,5 @@
 from .attendance import *
+from .committees import *
 from .constants import *
 from .elections import *
 from .geolocalization import *

--- a/pombola/south_africa/views/committees.py
+++ b/pombola/south_africa/views/committees.py
@@ -1,0 +1,17 @@
+from django.views.generic import ListView
+
+from pombola.core.models import Organisation, OrganisationKind
+
+
+class SACommitteesView(ListView):
+    queryset = Organisation.objects.filter(
+        kind__name='National Assembly Committees',
+        contacts__kind__slug='email'
+    ).distinct()
+    context_object_name = 'committees'
+    template_name = 'south_africa/committee_list.html'
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(SACommitteesView, self).get_context_data(*args, **kwargs)
+        context['kind'] = OrganisationKind.objects.get(name='National Assembly Committees')
+        return context


### PR DESCRIPTION
This page lists all NA committees that can be written to, along with a link to the page showing messages sent to a specific committee.

This page is being added in response to feedback from PMG:

> Currently PA does not have a ‘home’ for Committees where the messages can be viewed. Is it possible to create a link to these committees?

It would be good to talk to them about what exactly they want from this page, as at the moment it's quite bare.

Fixes https://github.com/mysociety/pombola/issues/2394
Fixes https://github.com/mysociety/pombola/issues/2328

## TODO

- [x] Styles for the new `/committees/` page
- [ ] Link to the new `/committees/` page from somewhere