### PR TITLE
Don't include writeinpublic_configuration in public DB dumps

### DIFF
--- a/pombola/core/management/commands/core_database_dump.py
+++ b/pombola/core/management/commands/core_database_dump.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
             # other data in the database; it can be recreated with
             # the popolo_name_resolver_init management command.
             'popolo_name_resolver_entityname',
+            'writeinpublic_configuration',
         ])
         if settings.COUNTRY_APP in ('nigeria',):
             # In the past I think the hansard application was in use


### PR DESCRIPTION
This came up in an error email as an unexpected table (it was created by
a recent migration) so no database dump was created. This table contains
sensitive data, so this commit adds it to the tables_to_ignore list.