### PR TITLE
[WriteInPublic] Handle errors when retrieving messages

### DIFF
--- a/pombola/south_africa/templates/core/organisation_detail.html
+++ b/pombola/south_africa/templates/core/organisation_detail.html
@@ -36,7 +36,7 @@
 
   {% endif %}
 
-  {% if object.kind.slug == 'national-assembly-committees' %}
+  {% if contactable_via_writeinpublic %}
     
 
     <div class="contact-actions">

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1416,6 +1416,29 @@ class SAOrganisationDetailViewTest(WebTest):
 
 
 @attr(country='south_africa')
+class SAOrganisationDetailViewWriteInPublicTest(TestCase):
+    def setUp(self):
+        na_committee_kind = models.OrganisationKind.objects.create(name='National Assembly Committees', slug='national-assembly-committees')
+        self.committee = models.Organisation.objects.create(slug='test-committee', kind=na_committee_kind)
+
+    def test_not_contactable_via_writeinpublic_with_no_email(self):
+        response = self.client.get(reverse('organisation', kwargs={'slug': self.committee.slug}))
+        self.assertFalse(response.context['contactable_via_writeinpublic'])
+
+    def test_contactable_via_writeinpublic_with_email(self):
+        email_contact_kind = models.ContactKind.objects.create(name='Email', slug='email')
+        self.committee.contacts.create(kind=email_contact_kind, value='test@example.com')
+        response = self.client.get(reverse('organisation', kwargs={'slug': self.committee.slug}))
+        self.assertTrue(response.context['contactable_via_writeinpublic'])
+
+    def test_contactable_via_writeinpublic_not_committee(self):
+        org_kind = models.OrganisationKind.objects.create(name='Test', slug='test')
+        org = models.Organisation.objects.create(slug='test-org', kind=org_kind)
+        response = self.client.get(reverse('organisation', kwargs={'slug': org.slug}))
+        self.assertFalse(response.context['contactable_via_writeinpublic'])
+
+
+@attr(country='south_africa')
 class SAOrganisationDetailViewTestParliament(WebTest):
 
     def setUp(self):

--- a/pombola/south_africa/views/organisations.py
+++ b/pombola/south_africa/views/organisations.py
@@ -63,6 +63,11 @@ class SAOrganisationDetailView(CommentArchiveMixin, OrganisationDetailView):
         except EmptyPage:
             context['positions'] = paginator.page(paginator.num_pages)
 
+        # Determine if this org is a committee that can be contacted
+        context['contactable_via_writeinpublic'] = \
+            self.object.kind.name == 'National Assembly Committees' \
+            and self.object.contacts.filter(kind__slug='email').exists()
+
         return context
 
     def add_parliament_counts_to_context_data(self, context):

--- a/pombola/writeinpublic/client.py
+++ b/pombola/writeinpublic/client.py
@@ -89,7 +89,12 @@ class WriteInPublic(object):
             'api_key': self.api_key,
             'person__popolo_uri': person_popolo_uri,
         }
-        response = requests.get(url, params=params)
-        response.raise_for_status()
-        messages = response.json()['objects']
-        return [Message(m, adapter=self.adapter) for m in messages]
+        try:
+            response = requests.get(url, params=params)
+            if response.status_code == 404:
+                return []
+            response.raise_for_status()
+            messages = response.json()['objects']
+            return [Message(m, adapter=self.adapter) for m in messages]
+        except requests.exceptions.RequestException as err:
+            raise self.WriteInPublicException(unicode(err))


### PR DESCRIPTION
If the committee that we're requesting message for doesn't exist in the WiP instance then it will return a 404. We want to ignore this error and just use an empty list of messages in the context in that case.

Fixes #2399