### PR TITLE
[WriteInPublic] Fix error when committee has multiple emails

### DIFF
--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from django.utils.dateparse import parse_datetime
 from django.forms import ModelMultipleChoiceField, ModelChoiceField
 
-from pombola.core.models import Person
+from pombola.core.models import Person, Organisation, OrganisationKind, ContactKind
 
 from . import client
 from .models import Configuration
@@ -221,6 +221,19 @@ class CommitteeAdapterTest(TestCase):
             ),
             {'content': 'Dear Test Name,\n\n'}
         )
+
+    def test_get_form_kwargs_when_committee_has_multiple_emails(self):
+        adapter = CommitteeAdapter()
+
+        na_committee_kind = OrganisationKind.objects.create(name='National Assembly Committees', slug='national-assembly-committees')
+        email_kind = ContactKind.objects.create(name='Email', slug='email')
+        committee = Organisation.objects.create(kind=na_committee_kind)
+        committee.contacts.create(kind=email_kind, value='test@example.org')
+        committee.contacts.create(kind=email_kind, value='test@example.com')
+
+        form_kwargs = adapter.get_form_kwargs('recipients')
+        self.assertEqual(len(form_kwargs['queryset']), 1)
+        self.assertEqual(form_kwargs['queryset'][0], committee)
 
 
 class RecipientFormTest(TestCase):

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -84,7 +84,7 @@ class CommitteeAdapter(object):
                 'queryset': Organisation.objects.filter(
                     kind__name='National Assembly Committees',
                     contacts__kind__slug='email'
-                ),
+                ).distinct(),
                 'multiple': False,
             },
         }


### PR DESCRIPTION
When a committee has multiple email addresses it was being returned as multiple rows from the form's queryset. By adding a `.distinct()` call to that we ensure we're only getting back one row per committee.

Fixes #2402 