### PR TITLE
[ZA] Always load messages on person profile page

### DIFF
--- a/pombola/south_africa/static/js/person-messages-ajax.js
+++ b/pombola/south_africa/static/js/person-messages-ajax.js
@@ -3,28 +3,14 @@ $(function(){
 
     $('.js-person-messages-ajax').each(function() {
         var $tab = $(this);
-        var $tabsWidget = $tab.parents('.ui-tabs');
+        var $panel = $($tab.attr('href'));
         var url = $tab.data('ajax-url');
-
-        // Ajax the message list the first time that this tab is activated.
-        // You can't bind to the "activate" event of a single tab, so we
-        // listen for *all* activations in this tab's parent widget, and
-        // only act if it's the right tab, and the message list content
-        // hasn't already been ajaxed in.
-        $tabsWidget.on("tabsbeforeactivate", function(event, ui) {
-            var activatingThisTab = $('a', ui.newTab).is($tab);
-            var contentNotYetLoaded = $(messagesSelector, ui.newPanel).length == 0;
-
-            if ( activatingThisTab && contentNotYetLoaded ) {
-                $.ajax({
-                    url: url
-                }).done(function(html) {
-                    ui.newPanel.html( $(html).find(messagesSelector) );
-                }).fail(function() {
-                    // Something went wrong with ajax. Fallback to page load.
-                    location.href = url;
-                });
-            }
+        $.ajax({
+            url: url
+        }).done(function(html) {
+            $panel.html( $(html).find(messagesSelector) );
+        }).fail(function() {
+            $panel.html('<p>Error: Unable to load messages at this time. Please try again later.</p>');
         });
     });
 });


### PR DESCRIPTION
When the messages section of a person page was linked to directly the messages weren't loading because the `tabsbeforeactivate` event wasn't being triggered.

To workaround this problem we're now just loading the messages on page load, rather than waiting for the tab to be activated.

Fixes #2353 