### PR TITLE
[ZA] Fit homepage actions onto a single line, on wide screens

### DIFF
--- a/pombola/core/static/sass/_core.scss
+++ b/pombola/core/static/sass/_core.scss
@@ -174,6 +174,72 @@
     }
 }
 
+@mixin display-flex() {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+}
+
+@mixin flex($values, $values2009: 0) {
+    -webkit-box-flex: $values2009;
+    -moz-box-flex: $values2009;
+    -webkit-box-flex: $values;
+    -moz-box-flex: $values;
+    -webkit-flex: $values;
+    -ms-flex: $values;
+    flex: $values;
+}
+
+@mixin flex-wrap($wrap) {
+    -webkit-box-wrap: $wrap;
+    -webkit-flex-wrap: $wrap;
+    -ms-flex-wrap: $wrap;
+    flex-wrap: $wrap;
+}
+
+@mixin align-items($alignment) {
+    -webkit-box-align: $alignment;
+    -webkit-align-items: $alignment;
+    -ms-flex-align: $alignment;
+    align-items: $alignment;
+}
+
+@mixin flex-direction($direction) {
+    @if ($direction == column) {
+        -webkit-box-orient: vertical;
+    } @elseif ($direction == row) {
+        -webkit-box-orient: horizontal;
+    }
+    -moz-flex-direction: $direction;
+    -ms-flex-direction: $direction;
+    -webkit-flex-direction: $direction;
+    flex-direction: $direction;
+}
+
+@mixin justify-content($alignment) {
+    -webkit-justify-content: $alignment;
+    -moz-justify-content: $alignment;
+    -ms-justify-content: $alignment;
+    justify-content: $alignment;
+}
+
+@mixin order($order) {
+  // 2009 syntax
+  -webkit-box-ordinal-group: $order;
+  -moz-box-ordinal-group: $order;
+
+   // 2011 syntax https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-order
+  -ms-flex-order: $order;
+  flex-order: $order;
+
+  // Modern syntax
+  -webkit-order: $order;
+  -ms-order: $order;
+  order: $order;
+}
+
 // .ellipsis {
 //   text-overflow: ellipsis;
 //   overflow: hidden;

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -972,48 +972,79 @@ body.home {
         color: inherit;
     }
 
+    // We add vertical margin to the children, because we need space between
+    // the h2 and the buttons at medium widths and also in non-flexbox clients
+    // but in a way that doesn't also break flexbox layout in modern clients.
+    // So we have to compensate for the 10px margin here.
+    .wrapper {
+        margin: -10px auto;
+    }
+
     h2 {
         color: inherit;
-        font-size: 2em;
-        @media (min-width: 640px) {
-            margin-bottom: 0;
-        }
+        font-size: 2em; // BIG!!
+        margin: 10px 16px 10px 0;
     }
 
     .button {
         box-sizing: border-box;
         -moz-box-sizing: border-box;
         -webkit-box-sizing: border-box;
-        width: 100%;
-        margin-top: 1em;
         text-align: left;
         box-shadow: 0 1px 2px 0 rgba(0,0,0,0.18);
         font-size: 1.125em;
+
+        // Full width buttons on narrow screens.
+        width: 100%;
+        margin: 10px 0;
+
+        // Line buttons up horizontally on wider screens.
         @media (min-width: 640px) {
             width: auto;
             margin-right: 16px;
         }
+
+        &:last-child {
+            margin-right: 0;
+        }
     }
-}
 
-.button--write {
-    background-size: 25px 18px;
-    background-repeat: no-repeat;
-    background-position: 16px center;
-    padding-left: 3.4em;
-}
-
-.button--write--rep {
-    background-image: url('/static/images/rep-icon.png');
-    @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-        background-image: url('/static/images/rep-icon@2.png');
+    .button--write {
+        background-size: 25px 18px;
+        background-repeat: no-repeat;
+        background-position: 20px center;
+        padding-left: 3.2em;
     }
-}
 
-.button--write--committee {
-    background-image: url('/static/images/committee-icon.png');
-    @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-        background-image: url('/static/images/committee-icon@2.png');
+    .button--write--rep {
+        background-image: url('/static/images/rep-icon.png');
+        @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+            background-image: url('/static/images/rep-icon@2.png');
+        }
+    }
+
+    .button--write--committee {
+        background-image: url('/static/images/committee-icon.png');
+        @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+            background-image: url('/static/images/committee-icon@2.png');
+        }
+    }
+
+    // Flexbox layout on wide screens, to get the h2 and buttons
+    // lined up horizontally, if there is space.
+    @media (min-width: 960px) {
+        .wrapper {
+            @include display-flex();
+            @include align-items(center);
+        }
+
+        h2 {
+            @include flex(1 1 auto);
+        }
+
+        .button {
+            @include flex(0 0 auto);
+        }
     }
 }
 

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2071,6 +2071,13 @@ li, div {
 
 .contact-actions {
     margin-top: 1.5em;
+
+    a {
+        @extend .button;
+        margin-bottom: 1em;
+        text-transform: none;
+        padding-left: 38px;
+    }
 }
 
 
@@ -2098,11 +2105,6 @@ $contact_icon_path: '../images/person-contact-icons';
         margin-right: 1em;
 
         a {
-            @extend .button;
-            margin-bottom: 1em;
-            text-transform: none;
-            padding-left: 38px;
-
             background: nth($site, 2) url('#{$contact_icon_path}/#{nth($site, 1)}-icon.png') no-repeat 14px 50%;
             background-image: url('#{$contact_icon_path}/#{nth($site, 1)}-icon.svg'), none;
             background-size: 18px 14px;


### PR DESCRIPTION
Fixes #2393.

Fits the two red buttons onto the same line as the heading, on wide screens, without reducing the font-size of the heading, or any of the dimensions of the buttons.

Buttons still break onto a new line, below the heading, on screens narrower than 960px.

While I was there, I also fixed a funky usage of `@extend` that was generating super bloated CSS selectors wherever a `.button` was referenced.

# After

![after](https://user-images.githubusercontent.com/739624/40125522-09a2f08e-5923-11e8-81d6-031eee3c6524.png)

# Before

![before](https://user-images.githubusercontent.com/739624/40125531-0d19505a-5923-11e8-9c68-e226cf931183.png)
