### PR TITLE
Grid layout for Keyna reps

### DIFF
--- a/pombola/core/static/sass/_common.scss
+++ b/pombola/core/static/sass/_common.scss
@@ -29,19 +29,79 @@ ul.ui-autocomplete {
     float: right;
 }
 
-.grid-listing-item {
-    float: left;
-    width: 210px;
-    margin: 10px;
-    padding: 5px;
-    overflow: hidden;
+.grid-listing {
+    overflow: auto;
 
-    span.name {
-        font-size: 120%;
-        display: block;
-        height: 2.5em;
-        overflow: hidden;
+    @include display-flex();
+    @include flex-wrap(wrap);
+
+    @media (min-width: 40em){
+        margin: -10px;
     }
 
-    @include box-shadow(rgba(0, 0, 0, 0.3) 1px 1px 12px);
+    * {
+        box-sizing: border-box;
+    }
+}
+
+.grid-listing-item {
+    box-sizing: border-box;
+    float: left;
+    width: 100%;
+    padding: 10px;
+
+    @media (min-width: 20em){
+        width: 50%;
+    }
+
+    @media (min-width: 30em){
+        width: 33%;
+    }
+
+    @media (min-width: 45em){
+        width: 25%;
+    }
+
+    a {
+        display: block;
+        padding: 10px;
+        @include box-shadow(rgba(0, 0, 0, 0.2) 0 1px 2px);
+        background-color: #f2f0e7;
+        height: 100%;
+
+        @media (min-width: 40em){
+            padding: 1em;
+        }
+
+        &:hover,
+        &:focus {
+            background-color: darken(#f2f0e7, 5%);
+
+            .parent-place {
+                color: inherit;
+            }
+        }
+    }
+
+    img {
+        max-width: 100%;
+        height: auto;
+    }
+
+    .name {
+        font-size: 120%;
+        display: block;
+        margin-top: 0.5em;
+    }
+
+    .place {
+        display: block;
+        margin-top: 0.5em;
+    }
+
+    .parent-place {
+        display: block;
+        color: #a7a28d;
+        margin-top: 0.1em;
+    }
 }

--- a/pombola/core/static/sass/admin.scss
+++ b/pombola/core/static/sass/admin.scss
@@ -1,3 +1,3 @@
 // very general styling
-@import "compass";
+@import "core";
 @import "common";

--- a/pombola/core/templates/core/position_detail_grid.html
+++ b/pombola/core/templates/core/position_detail_grid.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load staticfiles %}
+{% load pipeline %}
 {% load thumbnail %}
 {% load switch %}
 {% load hidden %}
@@ -28,7 +29,12 @@
             <div class="grid-listing-item">
                 {% maybehidden position.person user %}
                     {% thumbnail position.person.primary_image "210x210" crop="center" as im %}
-                        <img src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}"/>
+                        <img src="{% static 'images/person-210x210.jpg' %}"
+                             data-src="{{ im.url }}"
+                             width="{{ im.width }}"
+                             height="{{ im.height }}"
+                             alt="{{ position.person.name }}">
+                        <noscript><img src="{{ im.url }}" alt="{{ object.name }}" width="{{ im.width }}" height="{{ im.height }}" /></noscript>
                     {% empty %}
                         <img src="{% static 'images/person-210x210.jpg' %}" />
                     {% endthumbnail %}
@@ -43,5 +49,10 @@
 
     <br clear="both" />
 
+{% endblock %}
+
+{% block js_end_of_body %}
+  {{ block.super }}
+  {% javascript 'lazy-loaded-images' %}
 {% endblock %}
 

--- a/pombola/core/templates/core/position_detail_grid.html
+++ b/pombola/core/templates/core/position_detail_grid.html
@@ -25,7 +25,8 @@
     <div class="content_box">
         {% include 'core/_position_session_links.html' %}
 
-        {% for position in positions %}
+        <div class="grid-listing">
+          {% for position in positions %}
             <div class="grid-listing-item">
                 {% maybehidden position.person user %}
                     {% thumbnail position.person.primary_image "210x210" crop="center" as im %}
@@ -42,9 +43,18 @@
                     <span class="name">
                         {{ position.person.name }}
                     </span>
+                    <span class="place">
+                        {{ position.place.name }}
+                    </span>
+                  {% if position.place.parent_place %}
+                    <span class="parent-place">
+                        {{ position.place.parent_place.name }} {{ position.place.parent_place.kind.name }}
+                    </span>
+                  {% endif %}
                 {% endmaybehidden %}
             </div>
-        {% endfor %}
+          {% endfor %}
+        </div>
     </div>
 
     <br clear="both" />

--- a/pombola/kenya/static/js/lazy-loaded-images.js
+++ b/pombola/kenya/static/js/lazy-loaded-images.js
@@ -1,0 +1,3 @@
+window.blazy = new Blazy({
+    selector: 'img[data-src]'
+});

--- a/pombola/kenya/templates/menu_entries.html
+++ b/pombola/kenya/templates/menu_entries.html
@@ -43,11 +43,11 @@
 
 
 <li class="has-submenu">
-  <a href="{% url "position_pt" pt_slug='member-national-assembly' %}" role="menuitem" {% if include_sub_menu_entries %}aria-haspopup="true"{% endif %}>MPs</a>
+  <a href="{% url "position_pt" pt_slug='member-national-assembly' %}?view=grid" role="menuitem" {% if include_sub_menu_entries %}aria-haspopup="true"{% endif %}>MPs</a>
   {% if include_sub_menu_entries %}
   <ul id="parliament-overview" class="js-hover-dropdown" role="menu">
-    <li><a href="{% url "position_pt" pt_slug='member-national-assembly' %}" role="menuitem">NA Members</a></li>
-    <li><a href="{% url "position_pt" pt_slug='senator' %}" role="menuitem">Senators</a></li>
+    <li><a href="{% url "position_pt" pt_slug='member-national-assembly' %}?view=grid" role="menuitem">NA Members</a></li>
+    <li><a href="{% url "position_pt" pt_slug='senator' %}?view=grid" role="menuitem">Senators</a></li>
     <li><a href="{% url "female-reps" %}" role="menuitem">Women</a></li>
     <li><a href="{% url "young-reps" %}" role="menuitem">Youthful MPs</a></li>
     <li><a href="{% url "organisation_kind" slug='coalition' %}" role="menuitem">Coalitions</a></li>

--- a/pombola/settings/kenya_base.py
+++ b/pombola/settings/kenya_base.py
@@ -74,6 +74,13 @@ COUNTRY_JS = {
         ),
         'output_filename': 'js/collapse-responsibilities.js',
     },
+    'lazy-loaded-images': {
+        'source_filenames': (
+            'js/libs/blazy.js',
+            'js/lazy-loaded-images.js',
+        ),
+        'output_filename': 'js/lazy-loaded-images.js',
+    },
 }
 
 HANSARD_NAME_MATCHING_ALGORITHM = NAME_SUBSTRING_MATCH


### PR DESCRIPTION
Fixes #2423.

Sorry, I don‘t have any representative’s photos on my local machine, so there are lots of anonymous placeholder images in the screenshots below. Obviously, on the live site, those images will be replaced by people’s faces :-)

# Narrow screens

![screen shot 2018-07-05 at 13 59 33](https://user-images.githubusercontent.com/739624/42324861-50d1f68e-805c-11e8-8e5d-43b471f46b04.png)

# Bigger screens

![screen shot 2018-07-05 at 14 00 58](https://user-images.githubusercontent.com/739624/42324788-16e4edb4-805c-11e8-9d9a-907f64524a13.png)

The images now lazy-load, meaning the page should be _fairly_ fast to load the first time, and members’ images will only be pulled in as the user scrolls down.