### PR TITLE
Add link to MuniMoney on Rep results page

### DIFF
--- a/pombola/south_africa/templates/south_africa/latlon_local_view.html
+++ b/pombola/south_africa/templates/south_africa/latlon_local_view.html
@@ -18,6 +18,10 @@
     Ward councillor data is currently unavailable. Please try
     again later to find your ward councillor details.
   </div>
+{% else %}
+  <p>You can learn more about the finances for this ward's local municipality on
+    <a href="https://municipalmoney.gov.za/profiles/municipality-{{ ward_data.0.muni_id }}/" target="_blank">Municipal Money</a>
+  </p>
 {% endif %}
 
 <div class="tabs ui-tabs ui-widget rep-locator-container">

--- a/pombola/south_africa/views/geolocalization.py
+++ b/pombola/south_africa/views/geolocalization.py
@@ -84,7 +84,7 @@ class LatLonDetailBaseView(BasePlaceDetailView):
 
     def get_ward_councillors(self, location):
         # Look up the ward on MapIt:
-        url = 'http://mapit.code4sa.org/point/4326/{lon},{lat}?type=WD'.format(
+        url = 'http://mapit.code4sa.org/point/4326/{lon},{lat}?type=WD,MN'.format(
             lon=location.x, lat=location.y
         )
 
@@ -97,6 +97,7 @@ class LatLonDetailBaseView(BasePlaceDetailView):
         if not mapit_json:
             return []
         ward_id = mapit_json.values()[0]['codes']['MDB']
+        muni_id = mapit_json.values()[1]['codes']['MDB']
 
         # Then find the ward councillor from that ward ID. There
         # should only be one at the moment, but make it a list in case
@@ -137,6 +138,7 @@ class LatLonDetailBaseView(BasePlaceDetailView):
                 'element_id': 'ward-councillor-{ward_id}-0'.format(
                     ward_id=ward_id
                 ),
+                'muni_id': muni_id
             }
         ]
 


### PR DESCRIPTION
@mhl 

This requests extra info from the mapit API, and adds a link to the ward's local municipality on Municipal Money to the Rep Locator results page.

It seems there aren't any tests for this section of code. Can you please confirm that is the case?