### PR TITLE
WIP: Add blurb and header images to WriteInPublic pages

### DIFF
--- a/pombola/south_africa/static/sass/_person-write.scss
+++ b/pombola/south_africa/static/sass/_person-write.scss
@@ -1,8 +1,12 @@
+.person-write-form,
+.person-write-intro {
+    max-width: 40em;
+}
+
 .person-write-form {
     @include clearfix();
 
     @media (min-width: 640px) {
-        max-width: 714px; // match .house-intro
         margin: 2em 0 4em;
     }
 
@@ -16,7 +20,7 @@
 
         small {
             display: block;
-            color: $colour_middling_grey;
+            color: $colour_grey;
 
             @media (min-width: 640px) {
                 display: inline;
@@ -43,7 +47,7 @@
     textarea {
         padding: 0.5em 0.75em;
         border-radius: $border_radius;
-        border: 1px solid $colour_middling_grey;
+        border: 1px solid $colour_grey;
         font-family: inherit;
         font-size: 1em;
 
@@ -57,7 +61,7 @@
         .chosen-choices {
             padding: 0.5em 0.75em;
             border-radius: $border_radius;
-            border: 1px solid $colour_middling_grey;
+            border: 1px solid $colour_grey;
             background-image: none;
         }
     }
@@ -180,4 +184,22 @@
     li + li {
         margin-top: 1em;
     }
+}
+
+.person-write-intro {
+    margin-bottom: 2em;
+
+    p {
+        margin-bottom: 1.5em;
+    }
+}
+
+.person-write-intro__notice {
+    padding: 0 0 0 4.5em;
+    background: transparent url('../images/rep-locator-tooltip.png') 0 50% no-repeat;
+    @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+        background-image: url('../images/rep-locator-tooltip@2.png');
+    }
+    background-image: url('../images/rep-locator-tooltip.svg'), none;
+    background-size: 52px 52px;
 }

--- a/pombola/south_africa/static/sass/_person-write.scss
+++ b/pombola/south_africa/static/sass/_person-write.scss
@@ -2,9 +2,8 @@
     @include clearfix();
 
     @media (min-width: 640px) {
-        max-width: 48em;
-        margin: 2em auto 4em auto;
-        padding: 0 1em;
+        max-width: 714px; // match .house-intro
+        margin: 2em 0 4em;
     }
 
     p {

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -1809,7 +1809,7 @@ a.alphabet-links__link {
 
 .house-intro {
     font-size: 0.875em;
-    color: colour_blackish;
+    color: $colour_blackish;
     max-width: 714px;
     margin-bottom: 2em;
 }

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-recipients.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-recipients.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load pipeline %}
 
-{% block title %}Write to {{ object.name }}{% endblock %}
+{% block title %}Write to a Parliamentary Committee{% endblock %}
 
 {% block css_headers %}
   {{ block.super }}
@@ -14,6 +14,23 @@
 {% endblock %}
 
 {% block content %}
+
+{# TODO: Change `national-assembly` to something else #}
+<div class="house-splash national-assembly">
+  <div class="house-title">
+    <h1>Write to a Parliamentary Committee</h1>
+  </div>
+</div>
+
+<div class="house-intro">
+  <p>
+    The most important work of Parliament takes place in its committees. There
+    is a parliamentary committee responsible for overseeing each government
+    department. Write to a committee if you want to bring attention to the poor
+    service delivery or spending of a specific department. You can also lobby
+    the committee to introduce or change a law that deals with your concerns.
+  </p>
+</div>
 
 {% include 'writeinpublic/flash_messages.html' %}
 

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-recipients.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-recipients.html
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<div class="house-intro">
+<div class="person-write-intro">
   <p>
     The most important work of Parliament takes place in its committees. There
     is a parliamentary committee responsible for overseeing each government

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-recipients.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-recipients.html
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<div class="house-intro">
+<div class="person-write-intro">
   <p>
     MPs are your elected representatives - they must be accountable to the
     people and they must act in the public interest. Write to an MP if you want
@@ -30,7 +30,7 @@
     and only issues to do with government services), offer suggestions or
     support a campaign you feel strongly about.
   </p>
-  <p>
+  <p class="person-write-intro__notice">
     <strong>Before you contact an MP</strong>, note that their ability to assist
     is limited. Often the right person to contact will be a local councillor,
     the Presidential Hotline, National Anti-Corruption Hotline, or the Public

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-recipients.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-recipients.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load pipeline %}
 
-{% block title %}Write to {{ object.name }}{% endblock %}
+{% block title %}Write to an MP{% endblock %}
 
 {% block css_headers %}
   {{ block.super }}
@@ -15,6 +15,29 @@
 
 {% block content %}
 
+{# TODO: Change `national-assembly` to something else #}
+<div class="house-splash national-assembly">
+  <div class="house-title">
+    <h1>Write to an MP</h1>
+  </div>
+</div>
+
+<div class="house-intro">
+  <p>
+    MPs are your elected representatives - they must be accountable to the
+    people and they must act in the public interest. Write to an MP if you want
+    to petition or lobby them to assist you with a problem (no private disputes
+    and only issues to do with government services), offer suggestions or
+    support a campaign you feel strongly about.
+  </p>
+  <p>
+    <strong>Before you contact an MP</strong>, note that their ability to assist
+    is limited. Often the right person to contact will be a local councillor,
+    the Presidential Hotline, National Anti-Corruption Hotline, or the Public
+    Protector.
+  </p>
+</div>
+
 {% include 'writeinpublic/flash_messages.html' %}
 
 <form action="" method="post" class="person-write-form">{% csrf_token %}
@@ -22,7 +45,7 @@
 
     <p class="form-group">
     <label for="{{ form.persons.auto_id }}">
-      Search for recipients by name, or select from the drop-down.
+      Search for MPs by name, or select from the drop-down.
       <small class="new-line">You can send your message to up to 5 people.</small>
     </label>
     {{ form.persons.errors }}


### PR DESCRIPTION
**Not ready for review yet**

Fixes #2407.

This currently reuses the national assembly image from https://www.pa.org.za/organisation/national-assembly/ on both WriteInPublic pages. We need to check whether PMG had different images in mind.