### PR TITLE
Change ordering of committees to alphabetical.

### DIFF
--- a/pombola/core/migrations/0008_sort_organisations_by_name.py
+++ b/pombola/core/migrations/0008_sort_organisations_by_name.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0007_add_preferred_contact_option'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='organisation',
+            options={'ordering': ['name']},
+        ),
+    ]

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -753,7 +753,7 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
         return ('organisation', [self.slug])
 
     class Meta:
-       ordering = ["slug"]
+       ordering = ["name"]
 
     def is_ongoing(self):
         """Return True or False for whether the organisation is currently ongoing"""


### PR DESCRIPTION
Changes the default sort order of committees to be alphabetical by `name` instead of `slug`.

* Closes #2406 