### PR TITLE
Add a URL for an empty page to reuse as a template for the blog

### DIFF
--- a/pombola/core/templates/template-for-blog.html
+++ b/pombola/core/templates/template-for-blog.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+
+{% block title %}<!-- TITLE HERE -->{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+   <!-- CONTENT HERE -->
+{% endblock %}

--- a/pombola/core/urls.py
+++ b/pombola/core/urls.py
@@ -163,4 +163,5 @@ urlpatterns += (
 
 urlpatterns += (
     url(r'version.json', VersionView.as_view(), name='version'),
+    url(r'template-for-blog.html', TemplateView.as_view(template_name='template-for-blog.html')),
 )


### PR DESCRIPTION
The Mzalendo blog is Wordpress-based, served from our orgsites
repository, and it's always been a problem keeping the header and footer
in that repository (which are largely copy-and-pasted from the Pombola
site, and reuse its CSS) in sync with updates made to the Pombola site
(i.e. in this repository).

To make it easier to generate the Wordpress header and footer from the
current site, this commit adds an endpoint which produces an empty page
we can easily rewrite.