### PR TITLE
Shorten displayed committee names in some contexts

### DIFF
--- a/pombola/core/migrations/0009_organisation_short_name.py
+++ b/pombola/core/migrations/0009_organisation_short_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0008_sort_organisations_by_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='organisation',
+            name='short_name',
+            field=models.CharField(max_length=200, null=True, editable=False),
+        ),
+    ]

--- a/pombola/core/migrations/0010_organisation_update_short_name.py
+++ b/pombola/core/migrations/0010_organisation_update_short_name.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import re
+
+
+def shorten_name(name):
+
+    strip_phrases = [
+        'Portfolio Committee on',
+        'Standing Committee on',
+    ]
+
+    for phrase in strip_phrases:
+        name = re.sub('(?i)' + re.escape(phrase), '', name)
+
+    return name.strip()
+
+
+def resave_organisations(apps, schema_editor):
+    Organisation = apps.get_model('core', 'Organisation')
+    organisations = Organisation.objects.all()
+
+    for organisation in organisations:
+        organisation.short_name = shorten_name(organisation.name)
+        organisation.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0009_organisation_short_name'),
+    ]
+
+    operations = [
+        migrations.RunPython(resave_organisations),
+    ]

--- a/pombola/core/migrations/0011_organisation_alter_short_name.py
+++ b/pombola/core/migrations/0011_organisation_alter_short_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0010_organisation_update_short_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organisation',
+            name='short_name',
+            field=models.CharField(max_length=200, editable=False),
+        ),
+    ]

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -726,6 +726,7 @@ class OrganisationQuerySet(models.query.GeoQuerySet):
 
 class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
     name = models.CharField(max_length=200)
+    short_name = models.CharField(max_length=200, editable=False)
     slug = models.SlugField(
         max_length=200,
         unique=True,
@@ -766,6 +767,24 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
             now = datetime.date.today()
             now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
             return now_approx <= self.ended
+
+    def __shorten_name(self):
+
+        name = self.name
+
+        strip_phrases = [
+            'Portfolio Committee on',
+            'Standing Committee on',
+        ]
+
+        for phrase in strip_phrases:
+            name = re.sub('(?i)' + re.escape(phrase), '', name)
+
+        return name.strip()
+
+    def save(self, *args, **kwargs):
+        self.short_name = self.__shorten_name()
+        super(Organisation, self).save(*args, **kwargs)
 
 
 class PlaceKind(ModelBase):

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -23,7 +23,7 @@
         <li class="list-of-things-item {{ committee.css_class }}-list-item{% if not committee.show_active %} inactive{% endif %}">
             <p>
                 <a href="{{ committee.get_absolute_url }}" class="committee-list__name">
-                {{ committee.name }}
+                {{ committee.short_name }}
                 </a>
             </p>
            

--- a/pombola/south_africa/views/api.py
+++ b/pombola/south_africa/views/api.py
@@ -18,7 +18,7 @@ class CommitteesPopoloJson(ListView):
                 'persons': [
                     {
                         'id': str(committee.id),
-                        'name': committee.name,
+                        'name': committee.short_name,
                         'email': committee.contacts.filter(kind__slug='email')[0].value,
                         'contact_details': []
                     }

--- a/pombola/south_africa/views/committees.py
+++ b/pombola/south_africa/views/committees.py
@@ -7,7 +7,7 @@ class SACommitteesView(ListView):
     queryset = Organisation.objects.filter(
         kind__name='National Assembly Committees',
         contacts__kind__slug='email'
-    ).distinct()
+    ).distinct().order_by('short_name')
     context_object_name = 'committees'
     template_name = 'south_africa/committee_list.html'
 

--- a/pombola/writeinpublic/forms.py
+++ b/pombola/writeinpublic/forms.py
@@ -10,12 +10,14 @@ class RecipientForm(forms.Form):
     # Dynamicly create fields so we can show either people or committees
     def __init__(self, *args, **kwargs):
         queryset = kwargs.pop('queryset')
+        choicefield = kwargs.pop('choicefield', ModelChoiceField(queryset=queryset))
+        multiplechoicefield = kwargs.pop('multiplechoicefield', ModelMultipleChoiceField(queryset=queryset))
         multiple = kwargs.pop('multiple', True)
         super(RecipientForm, self).__init__(*args, **kwargs)
         if multiple:
-            self.fields['persons'] = ModelMultipleChoiceField(queryset=queryset)
+            self.fields['persons'] = multiplechoicefield
         else:
-            self.fields['persons'] = ModelChoiceField(queryset=queryset)
+            self.fields['persons'] = choicefield
 
 
 class DraftForm(forms.Form):

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 
 from pombola.core.models import Person, Organisation
 
-from .forms import RecipientForm, DraftForm, PreviewForm
+from .forms import RecipientForm, DraftForm, PreviewForm, ModelChoiceField
 from .client import WriteInPublic
 from .models import Configuration
 
@@ -68,6 +68,11 @@ class PersonAdapter(object):
         return {}
 
 
+class CommitteeModelChoiceField(ModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.short_name
+
+
 class CommitteeAdapter(object):
     def filter(self, ids):
         return Organisation.objects.filter(id__in=ids)
@@ -79,12 +84,16 @@ class CommitteeAdapter(object):
         return self.get(object_id)
 
     def get_form_kwargs(self, step=None):
+
+        queryset = Organisation.objects.filter(
+            kind__name='National Assembly Committees',
+            contacts__kind__slug='email'
+        ).distinct().order_by('short_name')
+
         step_form_kwargs = {
             'recipients': {
-                'queryset': Organisation.objects.filter(
-                    kind__name='National Assembly Committees',
-                    contacts__kind__slug='email'
-                ).distinct(),
+                'queryset': queryset,
+                'choicefield': CommitteeModelChoiceField(queryset),
                 'multiple': False,
             },
         }


### PR DESCRIPTION
As per #2429, shortens the displayed committee names in the contexts of writing to committees via Write in Public.

Closes #2429