### PR TITLE
Unify Disqus threads for single people / places / organizations

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -152,6 +152,14 @@ class ModelBase(models.Model):
         )
         return url
 
+    def get_disqus_thread_data(self, request):
+        return {
+            'disqus_canonical_url':
+            request.build_absolute_uri(self.get_absolute_url()),
+            'disqus_identifier':
+            '{0}-{1}'.format(self.css_class(), self.id)
+        }
+
     def get_popolo_id(self, id_scheme):
         table_name = self._meta.db_table
         return '{1}:{2}'.format(id_scheme, table_name, self.id)

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -148,7 +148,14 @@ class SubSlugRedirectMixin(SlugRedirectMixin):
         return redirect(url)
 
 
-class BasePersonDetailView(SkipHidden, DetailView):
+class BaseDetailView(DetailView):
+    def get_context_data(self, **kwargs):
+        context = super(BaseDetailView, self).get_context_data(**kwargs)
+        context.update(self.object.get_disqus_thread_data(self.request))
+        return context
+
+
+class BasePersonDetailView(SkipHidden, BaseDetailView):
     model = models.Person
 
     def get_context_data(self, **kwargs):
@@ -185,7 +192,7 @@ class PersonSpeakerMappingsMixin(object):
             return None
 
 
-class BasePlaceDetailView(DetailView):
+class BasePlaceDetailView(BaseDetailView):
     model = models.Place
 
     def get_context_data(self, **kwargs):
@@ -508,7 +515,7 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
     )
 
 
-class OrganisationDetailView(SlugRedirectMixin, DetailView):
+class OrganisationDetailView(SlugRedirectMixin, BaseDetailView):
     model = models.Organisation
 
     def get_context_data(self, **kwargs):
@@ -520,7 +527,7 @@ class OrganisationDetailView(SlugRedirectMixin, DetailView):
         return context
 
 
-class OrganisationDetailSub(SubSlugRedirectMixin, DetailView):
+class OrganisationDetailSub(SubSlugRedirectMixin, BaseDetailView):
     model = models.Organisation
     sub_page = None
 

--- a/pombola/hansard/views.py
+++ b/pombola/hansard/views.py
@@ -161,16 +161,17 @@ def person_summary(request, slug):
 
     lifetime_summary = entries_qs.monthly_appearance_counts()
 
-
+    context = {
+        'person':           person,
+        'entry_count':      entries_qs.count(),
+        'recent_entries':   entries_qs.all().order_by('-sitting__start_date')[0:5],
+        'lifetime_summary': lifetime_summary,
+    }
+    context.update(person.get_disqus_thread_data(request))
 
     return render_to_response(
         'hansard/person_summary.html',
-        {
-            'person':           person,
-            'entry_count':      entries_qs.count(),
-            'recent_entries':   entries_qs.all().order_by('-sitting__start_date')[0:5],
-            'lifetime_summary': lifetime_summary,
-        },
+        context,
         context_instance=RequestContext(request)
     )
 
@@ -180,6 +181,7 @@ class PersonAllAppearancesView(ListView):
     def get_context_data(self, **kwargs):
         context = super(PersonAllAppearancesView, self).get_context_data(**kwargs)
         context['object'] = self.person
+        context.update(self.person.get_disqus_thread_data(self.request))
         return context
 
     def get_queryset(self):

--- a/pombola/templates/disqus_javascript.html
+++ b/pombola/templates/disqus_javascript.html
@@ -29,7 +29,7 @@
       var dsq = document.createElement('script');
       dsq.type  = 'text/javascript';
       dsq.async = true;
-      dsq.src   = 'http://' + disqus_shortname + '.disqus.com/' + name + '.js';
+      dsq.src   = 'https://' + disqus_shortname + '.disqus.com/' + name + '.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
       disqusScriptTagsAdded[name] = true;
     }

--- a/pombola/templates/disqus_javascript.html
+++ b/pombola/templates/disqus_javascript.html
@@ -1,26 +1,17 @@
 {% if settings.DISQUS_SHORTNAME %}
 <script type="text/javascript">
 
-  var disqus_shortname = '{{ settings.DISQUS_SHORTNAME }}';
+  var disqus_shortname = '{{ settings.DISQUS_SHORTNAME|escapejs }}';
 
-  var disqus_identifier, disqus_developer;
-
-  {% if settings.STAGING %}
-    disqus_developer  = 1;
-  {% endif %}
-
-  {% if settings.DISQUS_USE_IDENTIFIERS %}
-    {% if object and object.css_class %}
-      {# If we have an object then we can use that to create a very robust identifier #}
-      disqus_identifier = '{{ object.css_class }}-{{ object.id }}';
-    {% else %}
-      {# If not object then use the page url pathname (ie without the fragment or query). This is most likely the right thing to do. #}
-      disqus_identifier = window.location.pathname;
+  var disqus_config = function () {
+    var disqus_identifier = '{{ disqus_identifier|escapejs }}';
+    this.page.url = '{{ disqus_canonical_url|escapejs }}';
+    {# The Disqus docs say the title must be unique, which seems weird, but better safe than sorry #}
+    this.page.title = '{{ object.name|escapejs }} (' + disqus_identifier + ')';
+    {% if settings.DISQUS_USE_IDENTIFIERS %}
+      this.page.identifier = disqus_identifier;
     {% endif %}
-  {% endif %}
-
-  {# A temporary fix, requested by evdb #}
-  disqus_identifier = undefined;
+  };
 
   var disqusScriptTagsAdded = {};
 


### PR DESCRIPTION
Confusingly, there were multiple Disqus threads for a single person (e.g. on the sub-pages for contact details or appearances). This pull requests sets Disqus's variable for the canonical URL that a thread should found from, updates to their latest suggested Javascript, and re-enables using a thread identifier instead of a URL to identify the threads (although we will only enable this after merging the threads).

Fixes #2468 