### PR TITLE
[Kenya] Add question model for this week's SMS question

### DIFF
--- a/pombola/sms/admin.py
+++ b/pombola/sms/admin.py
@@ -1,11 +1,10 @@
 from django.contrib import admin
-from .models import Message
+from .models import Message, Question
 
 
 class MessageAdmin(admin.ModelAdmin):
     list_display = ('text', 'msisdn', 'datetime', 'status')
     list_filter = ('status',)
-    # list_display_links = None
     actions = ['mark_as_accepted', 'mark_as_rejected']
     date_hierarchy = 'datetime'
     readonly_fields = ('text', 'msisdn', 'datetime')
@@ -27,3 +26,9 @@ class MessageAdmin(admin.ModelAdmin):
 
 admin.site.disable_action('delete_selected')
 admin.site.register(Message, MessageAdmin)
+
+
+class QuestionAdmin(admin.ModelAdmin):
+    list_display = ('text', 'created')
+
+admin.site.register(Question, QuestionAdmin)

--- a/pombola/sms/migrations/0002_auto_20181003_1515.py
+++ b/pombola/sms/migrations/0002_auto_20181003_1515.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sms', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Question',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('text', models.TextField()),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'ordering': ['-created'],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name='message',
+            options={'ordering': ['-datetime']},
+        ),
+    ]

--- a/pombola/sms/models.py
+++ b/pombola/sms/models.py
@@ -22,3 +22,12 @@ class Message(models.Model):
     class Meta:
         unique_together = ('text', 'msisdn', 'datetime')
         ordering = ['-datetime']
+
+
+class Question(models.Model):
+    text = models.TextField()
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ['-created']


### PR DESCRIPTION
This adds a new model which will contain the SMS question that will be displayed on the homepage.

At the moment this is just a very simple model with a `text` field for storing the question text. We might want to add a published flag or have some more advanced controls in the future, but I think for now we can just pull the most recently created question and display it on the homepage.

Part of #2462