### PR TITLE
[ZA] Quick fixes for Province page tab styling

### DIFF
--- a/pombola/core/templatetags/active_class.py
+++ b/pombola/core/templatetags/active_class.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 @register.simple_tag
 def active_class(request_path, name, **kwargs):
-    """ Return the string ' active ' current request.path is same as name
+    """ Return jQuery UI active classes if current request.path is same as name
 
     Keyword aruguments:
     request  -- Django request object
@@ -16,6 +16,6 @@ def active_class(request_path, name, **kwargs):
     path = reverse(name, kwargs=kwargs)
 
     if request_path == path:
-        return ' active '
+        return ' ui-tabs-active ui-state-active '
 
     return ''

--- a/pombola/core/tests/test_templatetags.py
+++ b/pombola/core/tests/test_templatetags.py
@@ -70,7 +70,7 @@ class ActiveClassTest(TestCase):
 
         for current_url, route_name, kwargs in tests:
             actual = active_class(current_url, route_name, **kwargs)
-            self.assertEqual(' active ', actual)
+            self.assertEqual(' ui-tabs-active ui-state-active ', actual)
 
         self.assertEqual(active_class('/foo', 'home'), '')
 

--- a/pombola/south_africa/templates/core/place_detail.html
+++ b/pombola/south_africa/templates/core/place_detail.html
@@ -26,23 +26,6 @@
         </p>
     {% endif %}
 
-    {# because I can't see how to store the length of an array we'll have to pass the array around instead #}
-    {% with people_related=object.related_people %}
-        {% if people_related|length %}
-          <div class="clearfix">
-            <p style="float: right;">
-              <a class="js-reveal-all-link" href="#">Expand all subsections</a>
-            </p>
-
-            <p>
-            There {{ people_related|length|pluralize:"is,are"}} {{ people_related|length }} {{ people_related|length|pluralize:"person,people"}} related to {{ object.name }}.
-            </p>
-          </div>
-        {% endif %}
-    {% endwith %}
-
-
-
     <a class="js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#provinicial-legislature-people">Members of the Provincial Legislature ({{ legislature_people_count }})</a>
 
     <div id="provinicial-legislature-people" class="person-panel js-hide-reveal">

--- a/pombola/south_africa/templates/south_africa/_place_tabs.html
+++ b/pombola/south_africa/templates/south_africa/_place_tabs.html
@@ -1,22 +1,33 @@
 {% load active_class %}
-<div class="tabs">
-<ul class="tab-links">
 
-    <li><a class="{% active_class request.path "place" slug=object.slug %}" href="{% url "place" slug=object.slug %}">People</a></li>
+<div class="ui-tabs ui-widget">
+<ul class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header">
+
+    <li class="ui-state-default {% active_class request.path "place" slug=object.slug %}">
+        <a class="ui-tabs-anchor" href="{% url "place" slug=object.slug %}">People</a>
+    </li>
 
     {% if object.has_scorecards %}
-    <li><a class="{% active_class request.path "place_scorecard" slug=object.slug %}" href="{% url "place_scorecard" slug=object.slug %}">Scorecard</a></li>
+    <li class="ui-state-default {% active_class request.path "place_scorecard" slug=object.slug %}">
+        <a class="ui-tabs-anchor" href="{% url "place_scorecard" slug=object.slug %}">Scorecard</a>
+    </li>
     {% endif %}
 
     {# <li><a href="{% url "place_people" slug=object.slug %}">People</a></li> #}
-    <li><a class="{% active_class request.path "place_places" slug=object.slug %}" href="{% url "place_places" slug=object.slug %}">Constituency Offices</a></li>
+    <li class="ui-state-default {% active_class request.path "place_places" slug=object.slug %}">
+        <a class="ui-tabs-anchor" href="{% url "place_places" slug=object.slug %}">Constituency Offices</a>
+    </li>
 
     {% if settings.ENABLED_FEATURES.place_data and object.placedata %}
-    <li><a class="{% active_class request.path "place_data" slug=object.slug %}" href="{% url "place_data" slug=object.slug %}">Data</a></li>
+    <li class="ui-state-default {% active_class request.path "place_data" slug=object.slug %}">
+        <a class="ui-tabs-anchor" href="{% url "place_data" slug=object.slug %}">Data</a>
+    </li>
     {% endif %}
 
     {% if settings.ENABLED_FEATURES.projects and object.is_constituency %}
-    <li><a class="{% active_class request.path "place_projects" slug=object.slug %}" href="{% url "place_projects" slug=object.slug %}">CDF Projects ({{ object.project_set.count }})</a></li>
+    <li class="ui-state-default {% active_class request.path "place_projects" slug=object.slug %}">
+        <a class="ui-tabs-anchor" href="{% url "place_projects" slug=object.slug %}">CDF Projects ({{ object.project_set.count }})</a>
+    </li>
     {% endif %}
 
 </ul>

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1879,7 +1879,6 @@ class SAPlaceDetailViewTest(WebTest):
         self.assertEqual(1, resp.context['legislature_people_count'])
 
         self.assertEqual(3, len(resp.context['related_people']))
-        self.assertContains(resp, "There are 3 people related to Test Place.")
 
     def test_multiple_positions(self):
 
@@ -1915,7 +1914,6 @@ class SAPlaceDetailViewTest(WebTest):
         self.assertEqual(0, resp.context['legislature_people_count'])
 
         self.assertEqual(1, len(resp.context['related_people']))
-        self.assertContains(resp, "There is 1 person related to Test Place.")
 
     def test_ncop_delegate(self):
 
@@ -1942,7 +1940,6 @@ class SAPlaceDetailViewTest(WebTest):
         self.assertEqual(0, resp.context['legislature_people_count'])
 
         self.assertEqual(1, len(resp.context['related_people']))
-        self.assertContains(resp, "There is 1 person related to Test Place.")
 
     def test_former_positions(self):
 


### PR DESCRIPTION
It turns out combining the [/place/&lt;name&gt;](https://www.pa.org.za/place/eastern-cape/) and [/place/&lt;name&gt;/places](https://www.pa.org.za/place/eastern-cape/places/) views was trickier than anticipated.

So while I wait for @chrismytton to find some time for that, here’s a super quick fix for the broken tab styling and extraneous membership total that the PMG folks wanted fixed as part of #2475.

![screen shot 2018-10-09 at 17 46 43](https://user-images.githubusercontent.com/739624/46684639-56464900-cbeb-11e8-9dbd-057621e708b6.png)
