### PR TITLE
Add Google Maps API key

### DIFF
--- a/pombola/core/static/js/map.js
+++ b/pombola/core/static/js/map.js
@@ -144,7 +144,7 @@ $(function () {
             'maps', '3',
             {
                 callback: initialize_map,
-                other_params:'sensor=false&key=AIzaSyCsI0iDUA5waenMFVuinV6dciKwkgaqQt8'
+                other_params:'key=AIzaSyCsI0iDUA5waenMFVuinV6dciKwkgaqQt8'
             }
         );
     }

--- a/pombola/core/static/js/map.js
+++ b/pombola/core/static/js/map.js
@@ -144,7 +144,7 @@ $(function () {
             'maps', '3',
             {
                 callback: initialize_map,
-                other_params:'sensor=false'
+                other_params:'sensor=false&key=AIzaSyCsI0iDUA5waenMFVuinV6dciKwkgaqQt8'
             }
         );
     }


### PR DESCRIPTION
API keys are now required, so add one.

For reference, I followed the [Get API Key guide](https://developers.google.com/maps/documentation/javascript/get-api-key) on the Google Maps JavaScript API documentation site. I created a "People's Assembly" project, then under that project I created an API key, which I've called "Used for Google Maps on the place pages of the pa.org.za website".

The API key is configured so that it will only work with the Maps JavaScript API, and only for the following referrers:

- `https://www.pa.org.za/*`
- `http://za-pombola.staging.mysociety.org/*`
- `http://localhost:8000/*`

I've checked it into the code directly, since it ends up being output in the client side JavaScript, and it's got restrictions on it so only we can use it.

After adding the API key I _then_ got a warning about the `sensor` parameter no longer being needed, so I've also removed that.

Fixes #2485 