### PR TITLE
[KE] Fix error clicking Next unassigned entry button in Hansard admin

### DIFF
--- a/pombola/hansard/admin.py
+++ b/pombola/hansard/admin.py
@@ -1,6 +1,6 @@
 from ajax_select import make_ajax_form
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import redirect, render_to_response
 from django.conf.urls import patterns
@@ -111,8 +111,5 @@ class AliasAdmin(admin.ModelAdmin):
             alias = unassigned[0]
             return redirect( '/admin/hansard/alias/' + str(alias.id) + '/' )
         except IndexError:
-            return render_to_response(
-                'admin/hansard/alias',
-                {},
-                context_instance=RequestContext(request)
-            )
+            messages.add_message(request, messages.INFO, 'There are no more unassigned aliases.')
+            return redirect('/admin/hansard/alias/')

--- a/pombola/hansard/admin.py
+++ b/pombola/hansard/admin.py
@@ -13,7 +13,7 @@ import models
 # from django.core.urlresolvers import reverse
 # from django.contrib.contenttypes.admin import GenericTabularInline
 # from django import forms
-# 
+#
 # def create_admin_link_for(obj, link_text):
 #     return u'<a href="%s">%s</a>' % ( obj.get_admin_url(), link_text )
 
@@ -23,7 +23,7 @@ class SourceAdmin(admin.ModelAdmin):
     list_display  = [ 'name', 'date', 'last_processing_success', 'last_processing_attempt' ]
     list_filter = ('date', 'last_processing_success')
     date_hierarchy = 'date'
-    
+
 
 @admin.register(models.Venue)
 class VenueAdmin(admin.ModelAdmin):
@@ -35,26 +35,26 @@ class SittingAdmin(admin.ModelAdmin):
     list_display  = [ 'start_date', 'start_time', 'end_date', 'end_time', 'source' ]
     list_filter = ['start_date']
     date_hierarchy = 'start_date'
-    
+
 
 @admin.register(models.Entry)
 class EntryAdmin(admin.ModelAdmin):
     list_display  = [ 'sitting', 'type', 'speaker_name', 'speaker',  '__unicode__' ]
-    
+
 
 # # When we have Django 1.4
 # from django.contrib.admin import SimpleListFilter
-# 
+#
 # class AliasStatusListFilter(SimpleListFilter):
 #     title = _('alias status')
 #     parameter_name = 'status'
-# 
+#
 #     def lookups(self, request, model_admin):
 #         return (
 #             ('unassigned', 'unassigned'),
 #             # ('90s', _('in the nineties')),
 #         )
-# 
+#
 #     def queryset(self, request, queryset):
 #         if self.value() == 'unassigned':
 #             return queryset.unassigned()
@@ -73,10 +73,10 @@ class AliasAdmin(admin.ModelAdmin):
         {
             'person':       'person_name',
         }
-    )    
+    )
 
     actions = ["ignore_aliases",]
-    
+
     def ignore_aliases(self, request, queryset):
         for alias in queryset:
             alias.ignored = True
@@ -84,7 +84,7 @@ class AliasAdmin(admin.ModelAdmin):
 
         self.message_user(request, "Ignored the aliases")
     ignore_aliases.short_description = "Ignore the selected aliases"
-    
+
 
     def get_urls(self):
         urls = super(AliasAdmin, self).get_urls()
@@ -92,7 +92,7 @@ class AliasAdmin(admin.ModelAdmin):
             ( r'^next_unassigned/$', self.next_unassigned ),
         )
         return my_urls + urls
-        
+
 
     @method_decorator(staff_member_required)
     def next_unassigned(self, request):
@@ -105,7 +105,7 @@ class AliasAdmin(admin.ModelAdmin):
         # onwards another. Not implemented now as it is not certain that this
         # is actually a problem.
         unassigned = models.Alias.objects.all().unassigned().order_by('-created')
-        
+
 
         try:
             alias = unassigned[0]


### PR DESCRIPTION
Turns out the error was because the template that was supposed to be rendered when there are no more unassigned aliases didn't exist, and from what I can tell never has existed.

To fix this I've switched to showing a flash message when there are no more aliases to assign.

Fixes #2501 

![image](https://user-images.githubusercontent.com/22996/48274114-8d05be00-e43a-11e8-81bc-a1d06316da96.png)

