### PR TITLE
[ZA] Add surveys_survey to list of tables to dump

### DIFF
--- a/pombola/core/management/commands/core_database_dump.py
+++ b/pombola/core/management/commands/core_database_dump.py
@@ -171,6 +171,7 @@ class Command(BaseCommand):
                 'speeches_speech',
                 'speeches_speech_tags',
                 'speeches_tag',
+                'surveys_survey',
                 'za_hansard_answer',
                 'za_hansard_pmgcommitteeappearance',
                 'za_hansard_pmgcommitteereport',


### PR DESCRIPTION
Should fix this message from cron:

```
The following tables were found which weren't expected
and which hadn't been explicitly excluded.  If these are safe to make
available in a public database dump (in particular check that they
contain no personal information of site users) then add them to
'expected_table'. Otherwise (i.e. they should *not* be made available
publicly) add them to 'tables_to_ignore'.
  surveys_survey
```