### PR TITLE
Do not print empty "related people" list for constituency offices

### DIFF
--- a/pombola/south_africa/templates/south_africa/constituency_office_list_item.html
+++ b/pombola/south_africa/templates/south_africa/constituency_office_list_item.html
@@ -19,7 +19,7 @@
       </ul>
     </div>
     <div class="column">
-      {% if not skip_positions %}
+      {% if object.related_positions and not skip_positions %}
         <ul class="unstyled-list">
         {% for position in object.related_positions %}
           {% with object=position.person %}


### PR DESCRIPTION
I _think_ this should fix #2528, but I can’t tell because my local version of people’s assembly won’t render the constituency office page at all (`AttributeError: 'str' object has no attribute 'slug'` from `{% should_display_place organisation_kind as display_place %}` in `/vagrant/pombola/pombola/south_africa/templates/core/person_list_item.html:29`)

@chrismytton care to try it out?