### PR TITLE
Allow places to have images associated with them

### DIFF
--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -211,6 +211,7 @@ class PlaceAdmin(StricterSlugFieldMixin, admin.ModelAdmin):
     search_fields = ('name', 'organisation__name')
     inlines = (
         InformationSourceInlineAdmin,
+        ImageAdminInline,
         ScorecardInlineAdmin,
         IdentifierInlineAdmin,
         )

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -847,7 +847,7 @@ class PlaceQuerySet(models.query.GeoQuerySet):
         return self.order_by('-kind__name', 'name')
 
 
-class Place(ModelBase, ScorecardMixin, BudgetsMixin, IdentifierMixin):
+class Place(ModelBase, HasImageMixin, ScorecardMixin, BudgetsMixin, IdentifierMixin):
     name = models.CharField(max_length=200)
     slug = models.SlugField(
         max_length=200,
@@ -868,6 +868,7 @@ class Place(ModelBase, ScorecardMixin, BudgetsMixin, IdentifierMixin):
     fields_to_whitespace_normalize = ['name']
 
     identifiers = GenericRelation(Identifier)
+    images = GenericRelation(Image)
 
     objects = PlaceQuerySet.as_manager()
     is_overall_scorecard_score_applicable = False


### PR DESCRIPTION
This adds the relevant bits to the Place model so that it can have images associated with it. It works in the same way as images for people and organisations, you can add images in the admin and then access them in the template with `.primary_image()`.

It seems that the template for the places list already handles displaying images for places, including generating an appropriately sized thumbnail.

Fixes #2496 