### PR TITLE
[ZA] Fix intermittent problem with Ward Councillor lookups

### DIFF
--- a/pombola/south_africa/views/geolocalization.py
+++ b/pombola/south_africa/views/geolocalization.py
@@ -96,8 +96,15 @@ class LatLonDetailBaseView(BasePlaceDetailView):
         mapit_json = r.json()
         if not mapit_json:
             return []
-        ward_id = mapit_json.values()[0]['codes']['MDB']
-        muni_id = mapit_json.values()[1]['codes']['MDB']
+        ward = None
+        muni = None
+        for item in mapit_json.values():
+            if item['type_name'] == 'Ward':
+                ward = item
+            elif item['type_name'] == 'Municipality':
+                muni = item
+        ward_id = ward['codes']['MDB']
+        muni_id = muni['codes']['MDB']
 
         # Then find the ward councillor from that ward ID. There
         # should only be one at the moment, but make it a list in case


### PR DESCRIPTION
This code was making a bad assumption about the order of things in the response from the code4sa mapit API. It was assuming that ward would always come first, and then municipality. But it seems that was not the case, the order of results from mapit is actually random and shouldn't be relied on.

So this change adds some extra checks to ensure we're using the correct bits of the JSON for the ward and municipality.

Fixes #2548 

## Notes to deployer

Once this has been deployed we need to reply to the email thread about this problem and let JD at Open Up and PMG know that this has been fixed.