### PR TITLE
[KE] Hansard: Detect nominated reps and lookup by name

### DIFF
--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -141,6 +141,11 @@ class Entry(HansardModelBase):
         """
 
         name = self.speaker_name
+
+        # Nominated reps don't have a unique speaker name, so fall back to the speaker title
+        if re.split(r'[,\s]+', self.speaker_name)[0] == 'Nominated':
+            name = self.speaker_title
+
         name = Alias.clean_up_name( name )
 
         # First check for a matching alias that is not ignored


### PR DESCRIPTION
The speaker_title is ambiguous for Nominated reps, because some parties have multiple nominated people. So detect these people and fallback to looking up by name using the speaker_title field.

Part of #2473 