### PR TITLE
[KE] Various hansard name matching fixes and enhancements

### DIFF
--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -243,6 +243,9 @@ class Entry(HansardModelBase):
         if len(party_initials) == 0:
             return None, None
         place_name = ' '.join([p.strip() for p in parts[:parts.index(party_initials[0])] if p not in party_initials])
+        # Party name should appear at the end of the name.
+        if party_initials[-1] != parts[-1]:
+            return None, None
         return place_name, party_initials
 
     def find_person_from_constituency_and_party_reference(self, place_name, party_initials):

--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -212,9 +212,11 @@ class Entry(HansardModelBase):
                 )
 
         if len(results) == 0:
-            matches = self.find_person_from_constituency_and_party_reference(name)
-            if matches:
-                results = matches
+            place_name, party_initials = self.place_name_and_party_initials_from_hansard_name(name)
+            if place_name and party_initials:
+                matches = self.find_person_from_constituency_and_party_reference(place_name, party_initials)
+                if matches:
+                    results = matches
 
         found_one_result = len(results) == 1
 
@@ -232,15 +234,18 @@ class Entry(HansardModelBase):
 
         return results
 
-    def find_person_from_constituency_and_party_reference(self, name):
+    def place_name_and_party_initials_from_hansard_name(self, name):
         # Remove spaces from around dashes (both ASCII and Unicode) and normalise to ASCII
         name = re.sub(ur'(?:\s+)?[\u2013\-](?:\s+)?', '-', name)
         parts = re.split(r'[,\s]+', name)
         party_initials_re = re.compile(r'^[A-Z-]{2,}$')
         party_initials = [p for p in parts if party_initials_re.match(p) or p == 'Independent']
         if len(party_initials) == 0:
-            return
+            return None, None
         place_name = ' '.join([p.strip() for p in parts[:parts.index(party_initials[0])] if p not in party_initials])
+        return place_name, party_initials
+
+    def find_person_from_constituency_and_party_reference(self, place_name, party_initials):
         sessions = ParliamentarySession.objects.filter(start_date__lte=self.sitting.start_date, end_date__gte=self.sitting.end_date, name__contains=self.sitting.venue.name)
         if len(sessions) != 1:
             return

--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -236,7 +236,7 @@ class Entry(HansardModelBase):
         # Remove spaces from around dashes (both ASCII and Unicode) and normalise to ASCII
         name = re.sub(ur'(?:\s+)?[\u2013\-](?:\s+)?', '-', name)
         parts = re.split(r'[,\s]+', name)
-        party_initials_re = re.compile(r'^[A-Z-]+$')
+        party_initials_re = re.compile(r'^[A-Z-]{2,}$')
         party_initials = [p for p in parts if party_initials_re.match(p) or p == 'Independent']
         if len(party_initials) == 0:
             return

--- a/pombola/hansard/models/entry.py
+++ b/pombola/hansard/models/entry.py
@@ -218,6 +218,10 @@ class Entry(HansardModelBase):
                 matches = self.find_person_from_constituency_and_party_reference(place_name, party_initials)
                 if matches:
                     results = matches
+                else:
+                    # Create alias so admins can manually match
+                    Alias.objects.get_or_create(alias=name)
+                    return []
 
         found_one_result = len(results) == 1
 


### PR DESCRIPTION
This adds a few enhancements to the Hansard place/party name matching.

- Extract a couple of methods to make logic slightly easier to follow
- Ignore names with month names in
- Change party initials regex to require 2+ capital letters
- Create aliases for anything that we think matches the correct format, but can't be matched in the DB.

Part of https://github.com/mysociety/pombola/issues/2473