### PR TITLE
Handle all types of lxml error in as_clean_html

### DIFF
--- a/pombola/core/templatetags/clean_html.py
+++ b/pombola/core/templatetags/clean_html.py
@@ -1,4 +1,4 @@
-from lxml.etree import XMLSyntaxError
+from lxml.etree import LxmlError
 from lxml.html.clean import Cleaner
 
 from django.template import Library
@@ -7,8 +7,7 @@ register = Library()
 
 @register.filter
 def as_clean_html(value):
-    value = value.strip()
-    if not value:
+    try:
+        return Cleaner(style=True, scripts=True).clean_html(value.strip())
+    except LxmlError:
         return '<p></p>'
-    cleaner = Cleaner(style=True, scripts=True)
-    return cleaner.clean_html(value)

--- a/pombola/core/tests/test_clean_html_templatetags.py
+++ b/pombola/core/tests/test_clean_html_templatetags.py
@@ -36,3 +36,10 @@ class CleanHTMLTest(TestCase):
         self.assertEqual(
             template.render(Context({'answer_text': '  '})),
             '<p></p>')
+
+    def test_string_with_all_closing_tags_should_not_error(self):
+        template = Template(
+            '{% load clean_html %}{{ answer_text|as_clean_html|safe }}')
+        self.assertEqual(
+            template.render(Context({'answer_text': '</strong></a></p>'})),
+            '<p></p>')


### PR DESCRIPTION
We were seeing errors when trying to clean a document that only contained three closing HTML tags. This fix refactors the `as_clean_html` template tag to handle any lxml errors and return an empty paragraph element.

Fixes #2574 