### PR TITLE
[ZA] Fix multiple active tabs on rep locator

### DIFF
--- a/pombola/south_africa/templates/south_africa/latlon_local_view.html
+++ b/pombola/south_africa/templates/south_africa/latlon_local_view.html
@@ -29,7 +29,7 @@
     <li class="ui-state-default">
       <a href="#councillors" class="ui-tabs-anchor" data-rep-locator-tooltip=".rep-locator-tooltip--councillors">{{ ward_data | length }} Ward Councillor{{ ward_data | length | pluralize }}</a>
     </li>
-    <li class="ui-state-default ui-tabs-active">
+    <li class="ui-state-default">
       <a href="#mps" class="ui-tabs-anchor" data-rep-locator-tooltip=".rep-locator-tooltip--mps">{{ mp_data | length }} MP{{ mp_data | length | pluralize }}</a>
     </li>
     <li class="ui-state-default">


### PR DESCRIPTION
The Ward Councillor tab is the default view when you search for an address, but for some reason the MPs tab was also being marked as active, which meant that two tabs were receiving the active class when the rep locator loaded.

This change removes the HTML class for active tabs and leaves it to the JS to control it.

Fixes https://github.com/mysociety/pombola/issues/2555

![image](https://user-images.githubusercontent.com/22996/54370021-d4ad8800-466e-11e9-91b6-f77734dde58c.png)
