### PR TITLE
[ZA] Fix display of people on constituency office page

### DIFF
--- a/pombola/south_africa/templatetags/za_people_display.py
+++ b/pombola/south_africa/templatetags/za_people_display.py
@@ -8,6 +8,8 @@ MEMBER_ORGS = ('parliament', 'national-assembly', )
 
 @register.assignment_tag()
 def should_display_place(organisation):
+    if not organisation:
+        return True
     return organisation.slug not in NO_PLACE_ORGS
 
 


### PR DESCRIPTION
This template tag was being called without an organisation, so in production it was just silently failing, but in development it was raising an exception.

This adds an extra check so that if there is no organisation then we just short circuit and return `True`.

Fixes https://github.com/mysociety/pombola/issues/2528
Part of https://github.com/mysociety/pombola/issues/2475