### PR TITLE
[ZA] Set number of members in the assembly and NCOP to be static

### DIFF
--- a/pombola/core/migrations/0012_organisation_seats.py
+++ b/pombola/core/migrations/0012_organisation_seats.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0011_organisation_alter_short_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='organisation',
+            name='seats',
+            field=models.IntegerField(blank=True, help_text=b'The number of seats this organisation nominally has.', null=True, validators=[django.core.validators.MinValueValidator(1)]),
+        ),
+    ]

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 
 from django.core import exceptions
 from django.core.urlresolvers import reverse
+from django.core.validators import MinValueValidator
 
 from django.db.models import Q
 from django.db import transaction
@@ -745,6 +746,13 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
     kind = models.ForeignKey('OrganisationKind')
     started = ApproximateDateField(blank=True, help_text=date_help_text)
     ended = ApproximateDateField(blank=True, help_text=date_help_text)
+
+    seats = models.IntegerField(
+        null=True,
+        blank=True,
+        validators=[MinValueValidator(1)],
+        help_text="The number of seats this organisation nominally has."
+    )
 
     fields_to_whitespace_normalize = ['name']
 

--- a/pombola/core/templates/core/organisation_list_item.html
+++ b/pombola/core/templates/core/organisation_list_item.html
@@ -16,10 +16,9 @@
 
   <div class="kind">{{ object.kind.name }}</div>
 
-  {% if object.num_positions %}
-    <p class="meta">{{ object.num_positions }} related positions</p>
+  {% if object.num_position_holders %}
+    <p class="meta">{{ object.num_position_holders }} related positions</p>
   {% endif %}
 
   <div class="read-more-wrap"><a href="{{ object.get_absolute_url }}" class="read-more">read more</a></div>
 </section>
-

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -676,8 +676,8 @@ class OrganisationKindList(SlugRedirectMixin, SingleObjectMixin, ListView):
             self.object
                 .organisation_set
                 .all()
-                .annotate(num_positions = Count('position'))
-                .order_by('-num_positions', 'name')
+                .annotate(num_position_holders=Count('position'))
+                .order_by('-num_position_holders', 'name')
         )
         return orgs
 

--- a/pombola/search/templates/search/items/organisation.html
+++ b/pombola/search/templates/search/items/organisation.html
@@ -18,8 +18,8 @@
 
     <div class="kind">{{ object.kind.name }}</div>
 
-    {% if object.num_positions %}
-      <p class="meta">{{ object.num_positions }} related positions</p>
+    {% if object.num_position_holders %}
+      <p class="meta">{{ object.num_position_holders }} related positions</p>
     {% endif %}
   </section>
 

--- a/pombola/south_africa/templates/core/organisation_list_item.html
+++ b/pombola/south_africa/templates/core/organisation_list_item.html
@@ -18,8 +18,6 @@
 
   <div class="kind">{{ object.kind.name }}</div>
 
-  {% if object.num_positions %}
-    <p class="meta">{{ object.num_positions }} related positions</p>
+  {% if object.num_position_holders %}
+    <p class="meta">{{ object.num_position_holders }} related positions</p>
   {% endif %}
-
-

--- a/pombola/south_africa/templates/core/parliament_list_item.html
+++ b/pombola/south_africa/templates/core/parliament_list_item.html
@@ -1,8 +1,8 @@
 <a class="house-splash {{ object.slug }}" href="{{ object.get_absolute_url }}">
     <div class="house-title">
         <h1>{{ object.name }}</h1>
-      {% if object.num_position_holders %}
-        <p class="kind-of-subtitle">{{ object.num_position_holders }} members</p>
+      {% if object.seats %}
+        <p class="kind-of-subtitle">{{ object.seats }} seats</p>
       {% endif %}
     </div>
 </a>

--- a/pombola/south_africa/templates/core/parliament_list_item.html
+++ b/pombola/south_africa/templates/core/parliament_list_item.html
@@ -1,8 +1,8 @@
 <a class="house-splash {{ object.slug }}" href="{{ object.get_absolute_url }}">
     <div class="house-title">
         <h1>{{ object.name }}</h1>
-      {% if object.num_positions %}
-        <p class="kind-of-subtitle">{{ object.num_positions }} members</p>
+      {% if object.num_position_holders %}
+        <p class="kind-of-subtitle">{{ object.num_position_holders }} members</p>
       {% endif %}
     </div>
 </a>

--- a/pombola/surveys/migrations/0002_auto_20190319_1101.py
+++ b/pombola/surveys/migrations/0002_auto_20190319_1101.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('surveys', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='survey',
+            options={'get_latest_by': 'created'},
+        ),
+    ]


### PR DESCRIPTION
Adds a new `seats` field to `Organisation`s, representing the nominal number of seats. Displays this instead of the number of position holders (which has renamed variables elsewhere for clarity).

Closes #2556 

---

![image](https://user-images.githubusercontent.com/22996/54610327-b075f080-4a4c-11e9-88fb-d2dd4a95674f.png)
