### PR TITLE
[ZA] WriteInPublic: Return a 404 error when a message can't be found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ notifications:
   email: false
 
 language: python
+python: 2.7
 cache: pip
 
 addons:

--- a/pombola/writeinpublic/client.py
+++ b/pombola/writeinpublic/client.py
@@ -77,9 +77,12 @@ class WriteInPublic(object):
             'username': self.username,
             'api_key': self.api_key,
         }
-        response = requests.get(url, params=params)
-        response.raise_for_status()
-        return Message(response.json(), adapter=self.adapter)
+        try:
+            response = requests.get(url, params=params)
+            response.raise_for_status()
+            return Message(response.json(), adapter=self.adapter)
+        except requests.exceptions.RequestException as err:
+            raise self.WriteInPublicException(unicode(err))
 
     def get_messages(self, person_popolo_uri):
         url = '{url}/api/v1/instance/{instance_id}/messages/'.format(url=self.url, instance_id=self.instance_id)

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -240,7 +240,10 @@ class WriteInPublicMessage(WriteInPublicMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(WriteInPublicMessage, self).get_context_data(**kwargs)
-        context['message'] = self.client.get_message(self.kwargs['message_id'])
+        try:
+            context['message'] = self.client.get_message(self.kwargs['message_id'])
+        except self.client.WriteInPublicException:
+            raise Http404("Couldn't find message with that ID")
         context['app_name'] = self.app_name
         return context
 


### PR DESCRIPTION
Previously an HTTPError was being raised, which was causing the view to
return a 500 error when a message couldn't be found. This change means
we correctly return a 404 error when a message isn't found.

Fixes #2589 