### PR TITLE
Add admin for Parliamentary Sessions

### DIFF
--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -14,6 +14,8 @@ from slug_helpers.admin import StricterSlugFieldMixin
 from pombola.core import models
 from pombola.scorecards import models as scorecard_models
 
+admin.site.register(models.ParliamentarySession)
+
 
 def create_admin_link_for(obj, link_text):
     return u'<a href="{url}">{link_text}</a>'.format(


### PR DESCRIPTION
Adds the `ParliamentarySession` model to the admin interface, so that the 27th Parliament sessions can be added.