### PR TITLE
Support multiple Vagrant boxes for different countries

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.provider "virtualbox" do |v|
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
-    v.name   = 'vagrant-pombola'
+    v.name   = 'vagrant-pombola-' + ( ENV['COUNTRY_APP'] || "kenya" )
     v.memory = 4096
     v.cpus   = 2
   end


### PR DESCRIPTION
Trying to install multiple Vagrant boxes for different countries results in:

```
A VirtualBox machine with the name 'vagrant-pombola' already exists.
Please use another name or delete the machine with the existing
name, and try again.
```

This PR avoids this collision by adding the country name to the Vagrant box name.