### PR TITLE
Ignore .ruby-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tmp/
 /data/*
 !/data/.gitkeep
 .vagrant/
+.ruby-version


### PR DESCRIPTION
We're temporarily using a version of Ruby from rbenv on the mySociety servers until we upgrade to stretch, so ignore the generated `.ruby-version` file.

Related to https://github.com/mysociety/pombola/issues/2596