### PR TITLE
Use get_object_or_404 in election province view

### DIFF
--- a/pombola/south_africa/views/elections.py
+++ b/pombola/south_africa/views/elections.py
@@ -323,7 +323,7 @@ class SAElectionProvinceCandidatesView(TemplateView):
 
         # Get the province object, so we can use its details
         province_kind = models.PlaceKind.objects.get(slug='province')
-        context['province'] = models.Place.objects.get(
+        context['province'] = get_object_or_404(models.Place,
             kind=province_kind,
             slug=province_name)
 


### PR DESCRIPTION
This means we can avoid a 500 error if a province doesn't exist.

Fixes https://github.com/mysociety/pombola/issues/1900