### PR TITLE
Check for mismatch in hidden field when merging people

### DIFF
--- a/pombola/core/management/commands/core_merge_people.py
+++ b/pombola/core/management/commands/core_merge_people.py
@@ -17,6 +17,7 @@ class Command(PersonSpeakerMappingsMixin, MergeCommandBase):
         'gender',
         'summary',
         'title',
+        'hidden',
     )
     model_class = core_models.Person
 

--- a/pombola/core/management/merge.py
+++ b/pombola/core/management/merge.py
@@ -34,7 +34,7 @@ def check_basic_fields(basic_fields, to_keep, to_delete):
             delete_value = getattr(to_delete, basic_field)
             keep_value = getattr(to_keep, basic_field)
 
-        if delete_value and (keep_value != delete_value):
+        if keep_value != delete_value:
             # i.e. there's some data that might be lost:
             safe_to_delete = False
             message = "Mismatch in '%s': '%s' ({%d}) and '%s' (%d)"

--- a/pombola/core/tests/test_commands.py
+++ b/pombola/core/tests/test_commands.py
@@ -255,6 +255,17 @@ class MergeObjectsCommandTest(TestCase):
             with no_stdout_or_stderr():
                 call_command('core_merge_people', **options)
 
+    def test_merge_people_differing_hidden_states(self):
+        self.person_a.hidden = False
+        self.person_a.save()
+
+        self.person_b.hidden = True
+        self.person_b.save()
+
+        with self.assertRaises(CommandError):
+            with no_stdout_or_stderr():
+                call_command('core_merge_people', **self.options)
+
     def test_merge_orgs(self):
         # This one should succeed:
         with no_stdout_or_stderr():


### PR DESCRIPTION
Without this check you can accidentally merge someone that's hidden into someone who isn't and they'll also end up hidden.

Fixes https://github.com/mysociety/pombola/issues/2425