### PR TITLE
Remove whitenoise

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -139,7 +139,7 @@ MEDIA_ROOT = os.path.normpath( os.path.join( data_dir, "media_root/") )
 MEDIA_URL = '/media_root/'
 
 # Use django-pipeline for handling static files
-STATICFILES_STORAGE = 'pombola.whitenoise_pipeline.GzipManifestPipelineStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files

--- a/pombola/whitenoise_pipeline.py
+++ b/pombola/whitenoise_pipeline.py
@@ -1,6 +1,0 @@
-# Suggestion from: https://github.com/mozilla/playdoh/issues/173
-from pipeline.storage import PipelineMixin
-from whitenoise.django import GzipManifestStaticFilesStorage
-
-class GzipManifestPipelineStorage(PipelineMixin, GzipManifestStaticFilesStorage):
-    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -160,7 +160,6 @@ babel==2.6.0
 # https://github.com/certifi/python-certifi/issues/26
 certifi==2015.04.28
 
-whitenoise==2.0.6
 cffi
 
 # everypolitician packages


### PR DESCRIPTION
This was added as part of the Heroku support which has now been removed. It seems that this was actually always incorrectly configured, as I think this storage was only supposed to be used on Heroku, but was configured to work everywhere but Heroku.

Part of https://github.com/mysociety/pombola/issues/2603