### PR TITLE
Remove ./manage.py syncdb from bin/prepare_environment.bash

### DIFF
--- a/bin/prepare_environment.bash
+++ b/bin/prepare_environment.bash
@@ -40,8 +40,7 @@ CFLAGS="-O0" pip install -r requirements.txt
 # make sure that there is no old code (the .py files may have been git deleted)
 find . -name '*.pyc' -delete
 
-# get the database up to speed
-./manage.py syncdb --noinput
+# run any pending database migrations
 ./manage.py migrate
 
 # Install gems in order to compile the CSS


### PR DESCRIPTION
This effectively just runs the migrations, which means we're running migrations twice on each deploy. Also the syncdb command is being removed in an upcoming version of Django, so we'd need to remove it then anyway.