### PR TITLE
Only include the public schema in the database dumps

### DIFF
--- a/bin/vagrant-install.bash
+++ b/bin/vagrant-install.bash
@@ -67,10 +67,14 @@ esac
 
 if [ -n "$LIVE_URL" ]; then
   echo "Downloading and loading database dump for ${COUNTRY_APP}..."
+  TMP_SCHEMA=$(mktemp /var/tmp/schema.XXXXX)
   TMP_DATA=$(mktemp /var/tmp/data.XXXXX)
-  curl -o ${TMP_DATA} ${LIVE_URL}/media_root/dumps/pg-dump_data.sql.gz
+  curl -s -S -o ${TMP_SCHEMA} ${LIVE_URL}/media_root/dumps/pg-dump_schema.sql.gz
+  curl -s -S -o ${TMP_DATA} ${LIVE_URL}/media_root/dumps/pg-dump_data.sql.gz
+  gunzip -c ${TMP_SCHEMA} | psql ${DB_NAME}
   gunzip -c ${TMP_DATA} | psql ${DB_NAME}
   rm $TMP_DATA
+  rm $TMP_SCHEMA
 else
   echo "Skipping live database import."
 fi

--- a/pombola/core/management/commands/core_database_dump.py
+++ b/pombola/core/management/commands/core_database_dump.py
@@ -229,6 +229,7 @@ publicly) add them to 'tables_to_ignore'.'''
                 'pg_dump',
                 '--no-owner',
                 '--no-acl',
+                '--schema=public',
             ]
 
             command.append({


### PR DESCRIPTION
Newer installations may include PostGIS extensions that cause permissions issues when dumping the schema as a non-superuser. This limits the schema dump to the public schema.

When creating a database to restore into, the `postgis` and `postgis_topology` extensions will need to be activated during provisioning.
