### PR TITLE
Add position column to minister attendance table

### DIFF
--- a/pombola/south_africa/static/js/attendance-table.js
+++ b/pombola/south_africa/static/js/attendance-table.js
@@ -2,7 +2,7 @@ jQuery (function($) {
   $(document).ready(function(){
       var order_by;
       if (POSITION == 'ministers') {
-        order_by = [2, "desc"]
+        order_by = [3, "desc"]
       }
       $('#mp-attendance').DataTable({
         "paging": false,

--- a/pombola/south_africa/templates/south_africa/mp_attendance.html
+++ b/pombola/south_africa/templates/south_africa/mp_attendance.html
@@ -103,6 +103,7 @@
       <th>Name</th>
       <th>Party</th>
       {% if position == 'ministers' %}
+      <th>Position</th>
       <th>Present</th>
       {% else %}
       <th>Meetings</th>
@@ -118,6 +119,10 @@
       <td><a href="{{ member.pa_url }}">{{ member.name }}</td>
       <td>{{ member.party_name }}</td>
       {% if position == 'ministers' %}
+      <td>
+        {% if member.position == 'minister' %}Minister{% endif %}
+        {% if member.position == 'deputy-minister' %}Deputy minister{% endif %}
+      </td>
       <td>{{ member.present }}</td>
       {% else %}
       <td>{{ member.total }}</td>


### PR DESCRIPTION
This adds a position column to the table when viewing attendance for ministers in order to differentiate between ministers and deputies.

When we retrieve the ministerial positions, we sort by person, then by start date, in order to group by person, and have their latest position last when iterating over the list and setting their position in the attendance records. 