### PR TITLE
Admin attendance toggle for ZA parties

### DIFF
--- a/pombola/core/admin.py
+++ b/pombola/core/admin.py
@@ -261,6 +261,7 @@ class OrganisationAdmin(StricterSlugFieldMixin, admin.ModelAdmin):
     list_display = ['slug', 'name', 'kind']
     list_filter = ['kind']
     search_fields = ['name']
+    exclude = ['show_attendance']
 
 
 @admin.register(models.OrganisationKind)

--- a/pombola/core/migrations/0013_organisation_show_attendance.py
+++ b/pombola/core/migrations/0013_organisation_show_attendance.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+def show_attendance_true_for_major_za_parties(apps, schema_editor):
+    if settings.COUNTRY_APP == 'south_africa':
+        Organisation = apps.get_model('core', 'Organisation')
+        parties = Organisation.objects.filter(kind__slug='party')
+
+        for party in parties:
+            if party.slug in ['anc', 'da', 'eff']:
+                party.show_attendance = True
+                party.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0012_organisation_seats'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='organisation',
+            name='show_attendance',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(show_attendance_true_for_major_za_parties)
+    ]

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -754,6 +754,10 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
         help_text="The number of seats this organisation nominally has."
     )
 
+    show_attendance = models.BooleanField(
+        default=False,
+        help_text="Toggles attendance records on person detail pages for people who belong to this organization.")
+
     fields_to_whitespace_normalize = ['name']
 
     objects = OrganisationQuerySet.as_manager()

--- a/pombola/south_africa/admin.py
+++ b/pombola/south_africa/admin.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+
+from pombola.south_africa import models
+
+@admin.register(models.AttendanceForOrganisationToggle)
+class AttendanceForOrganisationToggleAdmin(admin.ModelAdmin):
+    actions = None
+
+    fields = ['name', 'show_attendance']
+    readonly_fields = ['name']
+    list_display = ['slug', 'name', 'kind', 'show_attendance']
+    search_fields = ['name']
+
+    def get_queryset(self, request):
+        """Only allow attendance to be toggled for parties."""
+        qs = super(AttendanceForOrganisationToggleAdmin, self).get_queryset(request)
+        return qs.filter(kind__slug='party')
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/pombola/south_africa/models.py
+++ b/pombola/south_africa/models.py
@@ -23,4 +23,10 @@ class ZAPlace(Place):
                 org_rels_as_a__organisation_b=self.organisation,
                 kind__slug='party',
                 )
-            
+
+
+class AttendanceForOrganisationToggle(Organisation):
+    class Meta:
+        proxy = True
+        verbose_name = 'Toggle attendance for party'
+        verbose_name_plural = 'Toggle attendance for parties'

--- a/pombola/south_africa/views/person.py
+++ b/pombola/south_africa/views/person.py
@@ -400,11 +400,16 @@ class SAPersonDetail(PersonSpeakerMappingsMixin, PersonDetail):
         if self.object.date_of_death is not None:
             context['former_parties'] = self.get_former_parties(self.object)
 
-        try:
-            context['attendance'], context['latest_meetings_attended'] = \
-                self.get_attendance_data_for_display()
-        except AttendanceAPIDown:
-            context['attendance'] = context['latest_meetings_attended'] = \
-                'UNAVAILABLE'
+        show_attendance = False
+        for party in self.object.parties():
+            if party.show_attendance:
+                show_attendance = True
+        if show_attendance:
+            try:
+                context['attendance'], context['latest_meetings_attended'] = \
+                    self.get_attendance_data_for_display()
+            except AttendanceAPIDown:
+                context['attendance'] = context['latest_meetings_attended'] = \
+                    'UNAVAILABLE'
 
         return context


### PR DESCRIPTION
This allows the admin users of the ZA instance to toggle displaying attendance records on the person detail pages for people belonging to a specific party.

The migration sets the field to True fro the three major parties which they would like to have display the records.

The admin page excludes the field in `core`, and allows a ZA user to toggle the field in a different section based on a proxy of the `Organization` model. Only parties are shown on the list page, and users can only edit the objects - not add or delete.

An example of a person detail page affected by this change is:
https://www.pa.org.za/person/liezl-linda-van-der-merwe/