### PR TITLE
Import new National Assembly emails post 2019 elections

### DIFF
--- a/pombola/south_africa/data/elections/2019/committee-emails.csv
+++ b/pombola/south_africa/data/elections/2019/committee-emails.csv
@@ -1,0 +1,29 @@
+Name of Committee,Email address
+"Agriculture, Land Reform and Rural Development",akakaza@parliament.gov.za
+Basic Education,lbrown@parliament.gov.za
+Communications,tngoma@parliament.gov.za
+Constitutional Review Committee,pgwebu@parliament.gov.za
+Cooperative Governance and Traditional Affairs,scassiem@parliament.gov.za
+Defence and Military Veterans,bmantyi@parliament.gov.za
+Employment and Labour,zsakasa@parliament.gov.za
+"Environment, Forestry and Fisheries",tmadubela@parliament.gov.za
+Finance,awicomb@parliament.gov.za
+Health,vmajalamba@parliament.gov.za
+"Higher Education, Science and Technology",akabingesi@parliament.gov.za
+Home Affairs,emathonsi@parliament.gov.za
+"Human Settlements, Water and Sanitation",kpasiya-mndende@parliament.gov.za
+International Relations and Cooperation,lsigwela@parliament.gov.za
+Justice and Correctional Services,vramaano@parliament.gov.za
+Mineral Resources and Energy,aboss@parliament.gov.za
+Police,bmbengo@parliament.gov.za
+Public Accounts,nnkabinde@parliament.gov.za
+Public Enterprises,dmocumi@parliament.gov.za
+Public Service and Administration,mzibeko@parliament.gov.za
+Public Works and Infrastructure,njobodwana@parliament.gov.za
+Small Business Development,kkunene@parliament.gov.za
+Social Development,lntsabo@parliament.gov.za
+"Sports, Arts and Culture",amtiya@parliament.gov.za
+Tourism,jmboltina@parliament.gov.za
+Trade and Industry,ahermans@parliament.gov.za
+Transport,vcarelse@parliament.gov.za
+"Women, Youth and Persons with Disabilities",nnobatana@parliament.gov.za

--- a/pombola/south_africa/data/elections/2019/na-emails.csv
+++ b/pombola/south_africa/data/elections/2019/na-emails.csv
@@ -1,0 +1,401 @@
+SURNAME,NAMES,EMAIL ADDRESS
+ABRAHAM,PHOEBE NOXOLO,pabraham@parliament.gov.za
+ABRAHAMS,ALEXANDRA LILIAN AMELIA,alexandra.abrahams@gmail.com
+ADAMS,RACHEL CECILIA,radams@parliament.gov.za
+ADOONS,NOMBUYISELO GLADYS,nadoons@parliament.gov.za
+APRIL,HEINRICH GIOVANNI,hapril@parliament.gov.za
+ARRIES,LAETITIA HELOISE,larries@parliament.gov.za
+AUGUST,SHAUN NIGEL,saugust@parliament.gov.za
+BAGRAIM,MICHAEL,michael@bagraims.co.za
+BAPELA,KOPENG OBED,unathis@cogta.gov.za
+BASSON,LEONARD JONES,leonb@da.org.za
+BERGMAN,DARREN,bergman.darren@gmail.com
+BESANI,SIBONGILE JEREMIA,sbesani@parliament.gov.za
+BEUKES,ALEXANDRA JENNIFER,abeukes@parliament.gov.za
+BILANKULU,JOHN HLENGANI,jbilankulu@parliament.gov.za
+BILANKULU,NKHENSANI KATE,kbilankulu@parliament.gov.za
+BREEDT,TAMARIN,tammy.wessels@outlook.com
+BREYTENBACH,GLYNNIS,glynis.breytenbach@gmail.com
+BRINK,CILLIERS,cilliers.brink@me.com
+BOGOPANE-ZULU,HENRIETTA,HlangananiM@dsd.gov.za
+BONGO,BONGANI THOMAS,bbongo@parliament.gov.za
+BOROTO,MMATLALA GRACE,mboroto@parliament.gov.za
+BOSHOFF,WYNAND JOHANNES,boshoff7@telkomsa.net
+BOTES,ALVIN,SattarZ@dirco.gov.za / alvinbotes@hotmail.com
+BOZZOLI,BELINDA,bbozzoli@global.co.za
+BUTHELEZI,ELPHAS MFAKAZELENI,ebuthelezi@parliament.gov.za
+BUTHELEZI,MANGOSUTHU GATSHA,lyndithw@ifp.co.za
+BUTHELEZI,NORBERT SFISO,nbuthelezi@parliament.gov.za
+CACHALIA ,GHALEB KAENE YUSUF,gkyc@icon.co.za
+CAPA,NDUMISO,ncapa@parliament.gov.za
+CAPA,ROSEMARY NOKUZOLA,BSelao@dsbd.gov.za
+CARDO,MICHAEL JOHN,mikecardo@yahoo.com
+CEBEKHULU,RUSSEL NSIKAYEZWE,rcebekhulu@parliament.gov.za
+CELE,BHEKOKWAKHE HAMILTON,GaehlerSMK@saps.gov.za
+CEZA,KHANYA ,kceza@parliament.gov.za
+CHABANE,MOSA STEVE,mchabane@parliament.gov.za
+CHABANGU,MAKOSINI MISHACK,mchabangu@parliament.gov.za
+CHETTY,MERGAN,mkctaj@hotmail.com
+CHIKUNGA,LYDIA SINDISIWE,Esther.Rammutla@dpsa.gov.za
+CHIRWA,NALEDI NOKUKHANYA,nchirwa@parliament.gov.za
+CLARKE ,MICHÉLE ODETTE,michelec@da.org.za
+CREECY,BARBARA DALLAS,fshaik@environment.gov.za
+CUTHBERT ,MATHEW JOHN,mj_cuthbert@yahoo.com
+DE FREITAS,MANUEL SIMÃO FRANCA,manny@democratic-alliance.co.za
+DE LILLE,PATRICIA,Nombini.Ngubo@dpw.gov.za
+DE VILLIERS,JAN NAUDÉ,jan@keycapital.co.za
+DIDIZA,ANGELA THOKOZILE,PA.Minister@daff.gov.za
+DIKGALE,MASEFAKO CLARAH,mdikgale@parliament.gov.za
+DIREKO,DIKELEDI ROSEMARY,ddireko@parliament.gov.za
+DIRKS,MERVYN ALEXANDER,mdirks@parliament.gov.za
+DHLOMO,SIBONGISENI MAXWELL,sdhlomo@parliament.gov.za
+DLAKUDE,DORRIES EUNICE,sthwala@parliament.gov.za
+DLAMINI,DORAH DUNANA,ddlamini@parliament.gov.za
+DLAMINI,MARSHALL MZINGISI,marshalldlamini40@yahoo.com
+DLAMINI,SIDUMO MBONGENI,COSMIN@daff.gov.za
+DLAMINI-ZUMA,NKOSAZANA CLARICE,GeorginaS@cogta.gov.za
+DLODLO,AYANDA,intmin@mweb.co.za
+DLULANE,BEAUTY NOMVUZO,bdlulane@parliament.gov.za
+DUNJWA,MARY-ANN LINDELWA,mdunjwa@parliament.gov.za
+DYANTYI,PUMZA PATRICIA,pdyantyi@parliament.gov.za
+DYANTYI,QUBUDILE RICHARD,qdyantyi@parliament.gov.za
+FABER,WILLEM FREDERIK,willemffaber007@gmail.com
+FAKU,ZUKISA CHERYL,zfaku@@parliament.gov.za
+FROLICK,CEDRIC THOMAS,cfrolick@parliament.gov.za
+GALO,MANDLENKOSI PHILLIP,mandlagalo@aic.org.za
+GANTSHO,NQABISA,ngantsho@parliament.gov.za
+GARDEE,GODRICH AHMED,effmastermail@gmail.com
+GELA,ANNAH,agela@parliament.gov.za
+GEORGE,DION TRAVERS,diontgeorge@gmail.com
+GINA,NOMALUNGELO,ngina@parliament.gov.za
+GOMBA,MATSHIDISO MELINA,mgomba@parliament.gov.za
+GONDWE,MIMMY MARTHA,mgondwe@parliament.gov.za
+GORDHAN,PRAVIN JAMNADAS,busi.sokhulu@dpe.gov.za
+GRAHAM ,SAMANTHA JANE,samanthajgraham27@gmail.com
+GROENEWALD,IGNATIUS MICHAEL,groenewaldm@vfplus.org.za
+GROENEWALD,PETRUS JOHANNES,pjgr@vodamail.co.za
+GUMBI,HLANGANANI SIPHELELE,siphelelegumbi@gmail.com
+GUMBU,TSHILIDZI THOMAS,tgumbu@parliament.gov.za
+GUMEDE,SIBUSISO NIGEL,sgumede@parliament.gov.za
+GUNGUBELE,MONDLI,mgungubele@parliament.gov.za
+GWARUBE,SIVIWE,siviweg@da.org.za
+HADEBE,BHEKI MATHEWS,bhadebe@parliament.gov.za
+HENDRICKS,MOGAMAD GANIEF EBRAHIM ,mhendricks@parliament.gov.za
+HERMANS,JUDY,jherman@parliament.gov.za
+HERMANS,NOMBULELO LILIAN,nhermans@parliament.gov.za
+HICKLIN ,MADELEINE BERTINE,mpmadeleinehicklin@gmail.com
+HILL-LEWIS,GEORDIN GWYN,geordinh@gmail.com
+HINANA,NCEBA EPHRAIM,nhinana@parliament.gov.za
+HLENGWA,MAGDALENA DUDUZILE,mhlengwa@parliament.gov.za
+HLENGWA,MKHULEKO,hlengwamm@ifp.org.za
+HLONGO,ALTIA STHEMBILE,ahlongo@parliament.gov.za
+HLONGWA,BAVELILE GLORIA,kefilwe.chibogo@dmr.gov.za
+HLONYANA,KHONZIWE NTOKOZO FORTUNATE,hlonyananontokozo@gmail.com / ntokozonn@webmail.co.za
+HOLOMISA,BANTUBONKE HARRINGTON,bholomisa@udm.org.za
+HOLOMISA,SANGO PATEKILE,Phumla.mkula@dcs.gov.za
+HOOSEN,MOHAMMED HANIFF,haniffh1477@gmail.com
+HORN,WERNER,wernerh@da.org.za / whorn@parliament.gov.za
+HUNSINGER,CHRISTIAN HANS HEINRICH,chunsinger33@gmail.com
+ISMAIL,HASEENA,ihaseenabanu@parliament.gov.za
+JACOBS,FAIEZ,fjacobs@parliament.gov.za
+JACOBS,KENNETH LEONARD,kjacobs@parliament.gov.za
+JAMES,TYOTYO HUBERT,tjames@parliament.gov.za
+JEFFERY,JOHN HAROLD,jmhlarhi@justice.gov.za
+JOEMAT-PETTERSSON,TINA MONICA,tjoemat-petterson@parliament.gov.za
+JORDAAN,HELOISE,heloise@vfplus.org.za
+JOSEPH,DENIS,denisjoseph77@yahoo.com
+JULIUS,JACQUES WARREN WILLIAM,jjulius@parliament.gov.za
+KEETSE,PHUTI PETER,pketse@parliament.gov.za
+KEKANA,PINKY SHARON,Nobusi@doc.gov.za
+KHALIPHA,THANDUXOLO DAVID,tkhalipha@parliament.gov.za
+KHANYILE,THEMBISILE ANGEL,khanyileta@gmail.com
+KHAWULA,MAKOTI SIBONGILE,mkhawula@parliament.gov.za
+KIBI,MIRRIAM THENJIWE,mkibi@parliament.gov.za
+KING,CHANTEL VALENCIA,kingchantel39@yahoo.com
+KIVIET,NOXOLO,nazley.davids@dpw.gov.za
+KODWA,NCEDISO GOODENOUGH,DianaM@ssa.gov.za
+KOHLER,DIANNE,dianne.kohler.barnard@gmail.com
+KOMANE,ROSINA NTSHETSANA,rkomane@parliament.gov.za
+KOORNHOF,GERHARDUS WILLEM,gkoornho@mweb.co.za
+KOPANE,SEMAKALENG PATRICIA,skopane@parliament.gov.za
+KRÜGER,HENDRIK CHRISTIAAN CRAFFORD,smme@mweb.co.za
+KRUMBOCK,GREGORY RUDY,gregk@da.org.za
+KUBAYI-NGUBANE,MMAMOLOKO TRYPHOSA,mkubayi-ngubane@parliament.gov.za
+KUBHEKA,NOMSA JOSEPHINA,zndudane@tourism.gov.za
+KULA,SIBUSISO MACDONALD,skula@parliament.gov.za
+KWANKWA,NQABAYOMZI LAWRENCE SAZISO,kwankwayomzi@gmail.com
+LAMOLA,RONALD OZZY,ShAfrika@justice.gov.za
+LANGA,THOKOZANI MAKHOSONKE,tlanga@parliament.gov.za
+LEES,ROBERT ALFRED,alf@leeskzn.co.za
+LEGWASE,TIDIMALO INNOCENTIA,tlegwase@parliament.gov.za
+LEKOTA,MOSIUOA GERARD PATRICK,tmosia@gmail.com
+LESOMA,REGINA MINA MPONTSENG,mlesoma@parliament.gov.za
+LETSIE,WALTER TEBOGO,rlewletsie@parliament.gov.za
+LORIMER,JAMES ROBERT BOURNE,shrikem@mweb.co.za
+LOTRIET,ANNELIE,anneliel@da.org.za
+LUBENGO,MARUBINI LOURANE,mlubengo@parliament.gov.za
+LUTHULI,BHEKIZIZWE NIVARD,bluthuli@parliament.gov.za
+LUZIPO,SAHLULELE,sluzipo@parliament.gov.za
+MAAKE,JEROME JOSEPH,jmaake@parliament.gov.za
+MABE,BERTHA PEACE,bmabe@parliament.gov.za
+MABHENA,THAMSANQA BHEKOKWAKHE,thami.mabhena@yahoo.com
+MABIKA,MANDLENKOSI SICELO,scelom9@gmail.com
+MABILETSA,MAIDI DOROTHY,mmabiletsa@parliament.gov.za
+MABUZA,DAVID DABEDE,yasmeen@presidency.gov.za
+MACKENZIE,CAMERON,mackenzie@sentinel360.co.za
+MACPHERSON,DEAN WILLIAM,dean@eduform.co.za
+MADISHA,WILLIAM MOTHIPA,wmadisha@parliament.gov.za
+MADLINGOZI,BRIAN SINDILE,bmadlingozi@parliament.gov.za
+MAFANYA,WASHINGTON TSEKO ISAAC,tsekomafanya@gmail.com
+MAFU,NOCAWE NONCEDO,deputym@dac.gov.za
+MAGADZI,DIKELEDI PHILLISTUS,NkosiJ@dot.gov.za
+MAGAXA,KHAYALETHU ELVIS,kmagadzi@parliament.gov.za
+MAGWANISHE,GRATITUDE,gmagwanishe@parliament.gov.za
+MAHAMBEHLALA,TANDI,tmoiwp@me.com
+MAHLALELA,AMOS FISH,l@tourism.gov.za
+MAHLATSI,KATHLEEN DIBOLELO,kmahlatsi@parliament.gov.za
+MAHLAULE,MIKATEKO GOLDEN,mmahlaule@parliament.gov.za
+MAHLO,NHLAGONGWE PATRICIA,nmahlo@parliament.gov.za
+MAHLOBO,MBANGISENI DAVID,dmahlobo@webmail.co.za
+MOHAMED,HISAMODIEN,hmahomed@parliament.gov.za
+MAHUMAPELO,SUPRA OBAKENG RAMOELETSI,smahumapelo@parliament.gov.za
+MAIMANE,MMUSI ALOYSIAS,Leader@da.org.za
+MAINE,MOKONE COLLEN,mmaine@parliament.gov.za
+MAJODINA,PEMMY CASTELINA PAMELA,gdhlamini@parliament.gov.za
+MAJOLA,FIKILE ZACHARIAH,PMbanyana@thedti.gov.za
+MAJOLA,THEMBEKILE RICHARD,richardmajola1@gmail.com
+MAJOZI,ZANDILE,zmajozi@parliament.gov.za
+MAKHUBELA-MASHELE,LUSIZO SHARON,lmakhubela-mashele@parliament.gov.za
+MAKWETLA,SAMPSON PHATHAKGE,michael.kunene@dod.mil.za
+MALATJI,THLOLOGELO,tmalatji@parliament.gov.za
+MALATSI,MMOBA SOLOMON,malatsi.solly@gmail.com
+MALEMA,JULIUS SELLO,slindokuhle.njapha@effonline.org
+MALINGA,VALENTIA THOKOZILE,vmalinga@parliament.gov.za
+MALOMANE,VUYISILE PROMISE,vmalomane@parliament.gov.za
+MALULEKE,BOITUMELO,bmaluleke@parliament.gov.za
+MAMABOLO,JACOB BOY,jmamabolo@parliament.gov.za
+MANAMELA,KGWARIDI BUTI,Malale.i@dhet.gov.za
+MANANISO,JANE SEBOLETSWE,jmananiso@parliament.gov.za
+MANDELA,ZWELIVELILE MANDLESIZWE DALIBHUNGA,nkosizwelivelile@gmail.com / zmandela@parliament.gov.za
+MANELI,BOYCE MAKHOSONKE,bmaneli@parliament.gov.za
+MANGANYE,JANE,jmanganye@parliament.gov.za
+MANGCU,LISA NKOSINATHI,lmangcu@parliament.gov.za
+MANTASHE,PRISCILLA TOZAMA,tmantashe@parliament.gov.za
+MANTASHE,SAMSON GWEDE,princess.duma@energy.gov.za
+MAPHATSOE,EMMANUEL RAMAOTOANA KEBBY,emaphatsoe@parliament.gov.za
+MAPISA-NQAKULA,NOSIVIWE NOLUTHANDO,nmapisa-nqakula@parliament.gov.za
+MAPULANE,MOHLOPI PHILEMON,pmapulane@parliament.gov.za / mapulanep@vodamail.com
+MARAIS,ERIK JOHANNES,emarais@parliament.gov.za
+MARAIS,SAREL JACOBUS FRANCOIS ,befco@mweb.co.za
+MARAWU,THANDISWA LINNEN,tmarawu@parliament.gov.za
+MASANGO ,BRIDGET STAFF,masangobridget11@gmail.com
+MASEKO-JELE,NOMATHEMBA HENDRIETTA,nmaseko-jele@parliament.gov.za
+MASHABELA,NGWANAMAKWETLE RENEILOE,reneilomashabela@gmail.com
+MASHEGO,MFANA ROBERT,mmashego@parliament.gov.za
+MASHEGO-DLAMINI,KWATI CANDITH,istainz@dirco.gov.za
+MASHELE,TIMOTHY VICTOR,tmashele@parliament.gov.za
+MASIKO,FIKILE ANDISWA,fmasiko@parliament.gov.za
+MASIPA,NOKO PHINEAS,nokomasipa1@gmail.com
+MASONDO,DAVID,Santie.Ascenso@treasury.gov.za
+MASONDO,THABILE SYLVIA,tmasondo@parliament.gov.za
+MASUALLE,GODFREY PHUMULO,Maleshoane.Selokoe@energy.gov.za
+MASWANGANYI,MKHACANI JOSEPH,mmaswanganyi@parliament.gov.za
+MATHAFA,OSCAR MASARONA,omathafa@parliament.gov.za
+MATHALE,CASSEL CHARLIE,mgxajif@saps.gov.za
+MATHEBULA,ELPHUS FANI,emathebula@parliament.gov.za
+MATIASE,NTHAKO SAM,sam.matiase@gmail.com
+MAZZONE,NATASHA WENDY ANITA,Natasham@da.org.za
+MBABAMA,THANDEKA MOLOKO,mbabamatm@gmail.com
+MBATHA,SIMPHIWE GCWELE NOMVULA,smbatha@parliament.gov.za
+MBALULA,FIKILE APRIL,mulangal@dot.gov.za
+MBHELE,ZAKHELE NJABULO,voxprimus@gmail.com
+MBINQO-GIGABA,BONGIWE PRICILLA,bmbinqo-gigaba@parliament.gov.za
+MBOWENI,TITO TITUS,minreg@treasury.gov.za
+MBUYANE,SIMANGA HAPPY,smbuyane@parliament.gov.za
+MC DONALD,LAWRENCE EDWARD,lmcdonald@parliament.gov.za
+MC GLUWA,JOSEPH JOB,joem@da.org.za
+MCHUNU,EDWARD SENZO,Jacobus.Henning@dpsa.gov.za
+MCHUNU,THEMBEKA VUYISILE BUYISILE,tmchunu@parliament.gov.za
+MDABE,SIBUSISO WELCOME,sndabe@parliament.gov.za
+MENTE,NTOMBOVUYO VERONICA,Zovuyom8@gmail.com
+MESHOE,KENNETH RASELABE JOSEPH,president@acdp.org.za /  abouwer@parliament.gov.za
+MEY,PIETER,pmey@parliament.gov.za
+MGWEBA,TELISWA,tmgweba@parliament.gov.za
+MHAULE,MAKGABO REGINAH,kgari.i@dbe.gov.za
+MHLONGO,TSEPO WINSTON,tsepomhlongo@yahoo.com
+MILEHAM,KEVIN JOHN,kmileham@gmail.com
+MJOBO,LINDIWE NTOMBIKAYISE,lmjobo@parliament.gov.za
+MKHALIPHI,HLENGIWE OCTAVIA,effmastermail@gmail.com
+MKHATSHWA,NOMPENDULO THOBILE,nmkhatshwa@parliament.gov.za
+MKHIZE,HLENGIWE BUHLE,hmkhize@parliament.gov.za
+MKHIZE,ZWELINI LAWRENCE,SethoM@health.gov.za
+MKHWANAZI,JABULILE CYNTHIA NIGHTINGALE,jmkhwanazi@parliament.gov.za
+MLENZANA,ZOLA,zmlenzana@parliament.gov.za
+MMUTLE,THABO NELSON,mmutle@parliament.gov.za
+MOATSHE,RAESIBE MARTHA,rmoatshe@parliament.gov.za
+MODISE,MOLEBOHENG,mmodise@parliament.gov.za
+MODISE,PHILLIP MATSAPOLE POGISO,pmodise@parliament.gov.za
+MODISE,THANDI RUTH,framosana@parliament.gov.za
+MOELA,DESMOND LAWRENCE,dmoela@parliament.gov.za
+MOFOKENG,JACQUELINE MOTLAGOMANG,jmofokeng@parliament.gov.za
+MOHLALA,MATHIBE REBECCA,mmohlala@parliament.gov.za
+MOKAUSE,MMABATHO OLIVE,mmokausem@gmail.com
+MOKGOTHO,SHIRLEY MOTSHEGOANE,shirleymokgotho@yahoo.co.za
+MOKOENA,LEHLOHONOLO GOODWILL,mokoena.fana@gmail.com
+MOKWELE,TEBOGO JOSEPHINE,moremitj@yahoo.com
+MOLALA,LESIBA EZEKIEL,lmolala@parliament.gov.za
+MOLEKWA,MATHEDI ASNATH,mmolekwa@parliament.gov.za
+MOLOI,BOITUMELO ELIZABETH,nontobeko.yako@labour.gov.za
+MONTWEDI,MOTHUSI KENNETH,mmontwedi@parliament.gov.za
+MOROATSHEHLA,PATAMEDI RONALD,pmoroatshehla@parliament.gov.za
+MOROLONG,ITISENG KENNETH,imorolong@parliament.gov.za
+MOTAUNG,ANASTASIA,amotaung@ parliament.gov.za
+MOTAUNG,NOMASONTO EVELYN,nmotaung@ parliament.gov.za
+MOTEKA,PEBANE GEORGE,taukasebele@gmail.com
+MOTSEPE,CILIESTA CATHERINE SHOANA,lebeyaas@yahoo.com
+MOTSHEKGA,MATHOLE SEROFO,mmotshekga@parliament.gov.za
+MOTSHEKGA,MATSIE ANGELINA,mabua.s@dbe.gov.za
+MOTSOALEDI,PAKISHE AARON,thabo.mokgola@dha.gov.za
+MPAMBO-SIBHUKWANA,TANDI GLORIA,thandi.mpa.sbhuks65@gmail.com
+MPANZA,TERENCE SKHUMBUZO,tmpanza@parliament.gov.za
+MPHITHI,LUYOLO,luyolo.revolution@gmail.com
+MPUMZA,GORDON GCINIKHAYA,gmpumza@parliament.gov.za
+MSANE,THEMBI PORTIA,msanethembi@gmail.com
+MSIMANG,CHRISTIAN THEMBA,cmsimang@parliament.gov.za
+MTHEMBU,ALICE HLEBANI,amthembu@parliament.gov.za
+MTHEMBU,JACKSON MPHIKWA,malebo@presidency.gov.za
+MTHENJANE,DUMISANI FANNIE,dmthenjane@parliament.gov.za
+MTHETHWA,EMMANUEL NKOSINATHI,minister@dac.gov.za
+MULAUDZI,THILIVHALI ELPHUS,mulaudziet@webmail.co.za
+MULDER,CORNELIUS PETRUS,zemfira@mweb.co.za
+MULDER,FREDERIK JACOBUS,fjm@lantic.net
+MUNYAI,TSHILIDZI BETHUEL,tmunyani@parliament.gov.za
+MUTHAMBI,AZWIHANGWISI FAITH,amuthambi@parliament.gov.za
+MVANA,NONKOSI QUEENIE,nmvana@parliament.gov.za
+MYENI,ERNEST THOKOZANI,emyeni@parliament.gov.za
+NDABA,CLAUDIA NONHLANHLA,nondaba@parliament.gov.za
+NDABENI-ABRAHAMS,STELLA TEMBISA,ministry@dtps.gov.za
+NDLOZI,MBUYISENI QUINTIN,communications@effonline.org
+NEWHOUDT-DRUCHEN,WILMA SUSAN,wnewhoudt@parliament.gov.za
+NGCOBO,SIBONGISENI,sibongiseni.ngcobo@gmail.com
+NGCOBO,SIPHOSETHU LINDINKOSI,sngcobo@parliament.gov.za
+NGWENYA,DELISILE BLESSING,delisilengwenya@yahoo.com
+NGWEZI,XOLANI,xngwezi@parliament.gov.za
+NKABANE,NOBUHLE PAMELA,nnkabane@parliament.gov.za
+NKOANA-MASHABANE,MAITE EMILY,sindiswa@dwcpd.gov.za
+NKOMO,ZANELE,znkomo@parliament.gov.za
+NKOSI,BEKIZWE SIMON,bnkosi@parliament.gov.za
+NKOSI,DUMA MOSES,dnkosi@parliament.gov.za
+NODADA,BAXOLILE BABONGILE,baxolilenodada@gmail.com
+NOLUTSHUNGU,NONTANDO JUDITH,nolutshungunontando@gmail.com
+NONTSELE,MNCEDISI,mnontsele@parliament.gov.za
+NQOLA,XOLA,xngqola@parliament.gov.za
+NTLANGWINI,ELSABE NATASHA,tashalouw@gmail.com
+NTOBONGWANA,NOLITHA,nntobongwana@parliament.gov.za
+NTOMBELA,MADALA LOUIS DAVID,mntombela@parliament.gov.za
+NTSHAVHENI,KHUMBUDZO PHOPHI SILENCE,JBooysen@dsbd.gov.za
+NTSHAYISA,LULAMA MAXWELL,lntshayisa@parliament.gov.za
+NTULI,MAKHONI MARIA,mntuli@parliament.gov.za
+NXESI,THEMBELANI WALTERMADE THULAS,pamella.salusalu@labour.gov.za
+NXUMALO,MTHOKOZISI NKULULEKO,mnxumalo@parliament.gov.za
+NYHONTSO,MZWANELE ,mmyhontso@parliament.gov.za
+NZIMANDE,BONGINKOSI EMMANUEL,Maraba.A@dhet.gov.za
+NZUZA,NJABULO BHEKA,thabo.mokgola@dha.gov.za
+OPPERMAN,GIZELLA,platinum4life@gmail.com
+PAMBO,VUYANI,vpambo@parliament.gov.za
+PANDOR,GRACE NALEDI MANDISA,Minister@dirco.gov.za
+PAPO,ANTHONY HOPE MANKWANA,apapo@parliament.gov.za
+PATEL,EBRAHIM,ineethling@thedti.gov.za
+PATREIN,SIPHOKUHLE,spatrein@parliament.gov.za
+PAULSEN,MOGAMAD NAZIER,umcedi@gmail.com
+PEACOCK,NTAOLENG PATRICIA,npeacock@parliament.gov.za
+PETER,ZAMUXOLO JOSEPH,zpeter@parliament.gov.za
+PETERS,ELIZABETH DIPUO,epeters@parliament.gov.za
+PHAAHLA,MATHUME JOSEPH,manduy@health.gov.za
+PHILLIPS,CHERYL,rustenburgward16@gmail.com
+PHIRI,CAROL MOKGADI,cphiri@parliament.gov.za
+PILANE-MAJAKE,MAKGATHATSO CHARLOTTE CHANA,epowell@parliament.gov.za
+POWELL,EMMA LOUISE,powellemmalouise@gmail.com
+QAYISO,XOLISILE SHINARS,xqayiso@parliament.gov.za
+RADEBE,BHEKIZIZWE ABRAM,bradebe@parliament.gov.za
+RAMADWA,MATODZI MIRRIAM,mramadwa@parliament.gov.za
+ROOS,ADRIAN CHRISTOPHER,roosa@parliament.gov.za
+SARUPEN,ASHOR NICK,ashors@da.org.za
+SCHREIBER,LEON AMOS,leon.schreiberei@gmail.com
+SEABI,ALBERT MAMMOGA,aseabi@parliament.gov.za
+SELFE,JAMES,fedexchair@da.org.za
+SEITLHOLO,ISAAC SELLO,sellos@da.org.za
+SEMENYA,MACHWENE ROSINA,msemenya@parliament.gov.za
+SHABALALA,LIZZIE FIKELEPHI,lshabalala@parliament.gov.za
+SHABALALA,NOMVUZO FRANCISCA,nshabalala@parliament.gov.za
+SHARIF,NAZLEY KHAN,nazleykhan@gmail.com
+SHELEMBE,MALIYAKHE LYMON,maliyakhezn@gmail.com
+SHEMBENI,HENRY ANDRIES,hshembeniparliament.gov.za
+SHIVAMBU,NYIKO FLOYD,floydn@gmail.com
+SIBISI,CHRISTOPHER HOWARD MZWAKHE ,csibisi@parliament.gov.za
+SIBIYA,DUDUZILE PATRICIA,dsibiya@parliament.gov.za
+SIHLWAYI,NOMADEWUKA NANCY,nsihlwayi@parliament.gov.za
+SINDANE,PATRICK,psindane@parliament.gov.za
+SINGH,NAREND,nsingh@parliament.gov.za
+SISULU,LINDIWE NONCEBA,PitsoC@dwa.gov.za
+SITHOLE,KHETHAMABALA PETROS,ksithole@parliament.gov.za
+SIWELA,ELVIS KHOLWANA,esiwela@parliament.gov.za
+SIWELA,VIOLET SIZANI,vsiwela@parliament.gov.za
+SIWEYA,RHULANI THEMBI,malebo@presidency.gov.za
+SIWISA,ANNACLETA MATHAPELO,mathapelosiwisa@gmail.com
+SKOSANA,GIJIMANI JIM,gskosana@parliament.gov.za
+SKWATSHA,MCEBISI,COSMIN@daff.gov.za
+SOKATSHA,MXOLISA SIMON,msokatsha@parliament.gov.za
+SOMYO,SAKHUMZI STOFFELS,ssomyo@parliament.gov.za
+SONTI,NOKULUNGA PRIMROSE,nsonti@parliament.gov.za
+SOTYU,MAKHOTSO MAGDELINE,ntiko@environment.gov.za
+SPIES,ELEANORE ROCHELLE JACQUELENE,espies@parliament.gov.za
+STEENHUISEN,JOHN HENRY,dawhip@da.org.za
+STEYN,ANNETTE,anett@xsinet.co.za
+STOCK,DIKGANG MATHEWS,dstock@parliament.gov.za
+SUKERS,MARIE ELIZABETH,msukers@parliament.gov.za
+SWART,STEVEN NICHOLAS,sswart@parliament.gov.za
+SWARTS,BERNICE,bswarts@parliament.gov.za
+TARABELLA MARCHESI,NOMSA INNOCENCIA,nomsam@da.org.za
+TERBLANCHE,OCKERT STEFANUS,terblancheokkie@gmail.com
+THEMBEKWAYO,SOPHIE SUZAN,thembekwayos@gmail.com
+THRING,WAYNE MAXIM, waynemthring@gmail.com
+TITO,LORATO FLORENCE,rato4mpho@gmail.com
+TLHAPE,MANKETSI MAMOABI EMILY,mtlhape@parliament.gov.za
+TLHOMELANG,KEITUMETSE BRIDGETTE,ktlhomelang@parliament.gov.za
+TLOU,MOLOKO MAGGIE,mtlou@parliament.gov.za
+TOLASHE,NOKUZOLA GLADYS,ntolashe@parliament.gov.za
+TONGWANE,TSHOGANETSO MPHO ADOLPHINA,ttongwane@parliament.gov.za
+TSEKE,GRACE KEKULU,gtseke@parliament.gov.za
+TSEKI,MOHATLA ALFRED,mtseki@parliament.gov.za
+TSENOLI,SOLOMON LECHESA,pmasiza@parliament.gov.za
+TSHABALALA,JUDITH,jtshabalala@parliament.gov.za
+TSHWAKU,MGCINI,mtshwaku@yahoo.com
+TSHWETE,BUSISIWE,btshwete@parliament.gov.za
+TSHWETE,PAMELA,Eartha.Scholtz@dhs.gov.za
+VAN DAMME,PHUMZILE THELMA,phumzilevd@da.org.za
+VAN DER MERWE,LIEZL LINDA,liezl@ifp.co.za
+VAN DER WALT,DÉSIRÉE,desireevdw@da.org.za
+VAN DYK,VERONICA,v.vandyk1@gmail.com
+VAN MINNEN,BENEDICTA MARIA,benvm@mweb.co.za
+VAN STADEN,PHILIPPUS ADRIAAN,pvanstaden@parliament.gov.za
+WALTERS,THOMAS CHARLES RAVENSCROFT,tcrwalters@gmail.com
+WATERS,MICHAEL,mwaters@democratic-alliance.co.za
+WEBER,ANNERIE MARIA MAGDALENA,annerieweber@gmail.com
+WESSELS,WOUTER WYNAND,wwessels@parliament.gov.za
+WHITFIELD,ANDREW GRANT,whitfield.andrew@gmail.com
+WINKLER,HANNAH SHAMEEMA,hannahw@dakzn.org.za
+WILSON,EVELYN RAYNE,wilsonworx@webmail.co.za
+WOLMARANS,MATTHEWS JOHANNES,mwolmarans@parliament.gov.za
+XABA,VUSUMUZI CYRIL,vxaba@parliament.gov.za
+XABA-NTSHABA,PHINDISILE PRETTY,pxaba-ntshaba@parliament.gov.za
+XASA,FIKILE DEVILLIERS,fxasa@parliament.gov.za
+XEGO,SHEILLA TEMBALAM,sxego@parliament.gov.za
+YABO,BAFUZE SICELO,byabo@parliament.gov.za
+YAKO,YOLISWA NOMAMPONDOMISE,yoliswa.yako@gmail.com
+ZIBULA,BEAUTY THULANI,bzibula@parliament.gov.za
+ZULU,LINDIWE DAPHNE,ZamaK@dsd.gov.za
+ZUMA,AUDREY SBONGILE,azuma@parliament.gov.za
+ZUNGU,THANDIWE ROSE MARRY,tzungu@parliament.gov.za
+ZUNGULA,VUYOLWETHU,vzungula@parliament.gov.za
+ZWANE,MOSEBENZI JOSEPH,mzwane@parliament.gov.za

--- a/pombola/south_africa/management/commands/south_africa_import_email_addresses_elections_2019.py
+++ b/pombola/south_africa/management/commands/south_africa_import_email_addresses_elections_2019.py
@@ -1,0 +1,39 @@
+import re
+
+import unicodecsv as csv
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from pombola.core.models import Organisation, Person, ContactKind
+
+
+class Command(BaseCommand):
+    help = "One-off command to import new emails for National Assembly MPs after the 2019 elections"
+
+    def handle(self, *args, **options):
+        na_emails_filename = "pombola/south_africa/data/elections/2019/na-emails.csv"
+
+        source = "Data provided by PMG"
+        contact_kind_email = ContactKind.objects.get(slug="email")
+
+        # National Assembly
+        with open(na_emails_filename) as csvfile:
+            rows = csv.DictReader(csvfile)
+            for row in rows:
+                name = re.sub(r"\s+", " ", row["NAMES"] + " " + row["SURNAME"]).strip()
+                emails = [email.strip() for email in row["EMAIL ADDRESS"].split("/")]
+                matching_people = Person.objects.filter(
+                    Q(legal_name__icontains=name)
+                    | Q(alternative_names__alternative_name__iexact=name)
+                ).distinct()
+                for person in matching_people:
+                    for email in emails:
+                        _, created = person.contacts.get_or_create(
+                            kind=contact_kind_email,
+                            value=email,
+                            defaults={"source": source, "preferred": True},
+                        )
+                        if created:
+                            print "Added {} to".format(email),
+                            print (name)


### PR DESCRIPTION
This adds the CSVs containing new email addresses for MPs and committees after the 2019 elections. It also contains a management command for importing the National Assembly emails into the database. I haven't added a similar command for the committees yet, I'll do that in a separate pull request.

Part of https://github.com/mysociety/pombola/issues/2593