### PR TITLE
Improve MP assets filter interaction

### DIFF
--- a/pombola/south_africa/static/js/interests-filter.js
+++ b/pombola/south_africa/static/js/interests-filter.js
@@ -10,4 +10,8 @@ jQuery (function($) {
         }
     });
     $('#display').trigger("change");
+
+    $('.group-select').on('click', function() {
+        $('#group-interests-form').submit();
+    });
 });

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2943,12 +2943,29 @@ ul.attendance__notes {
     }
 }
 
+#page {
+    .members-interest{
+        h3 {
+            background-color: $colour-lighter-grey;
+            padding: 0.6em;
+        }
+
+        h4 {
+            padding-left: 0.6em;
+        }
+    }
+}
+
 .members-interests {
     .members-interests-filter {
         padding: 1em;
         background-color: $colour_lighter_grey;
         vertical-align: top;
+        margin-bottom: 25px;
 
+        hr {
+            margin-bottom: 25px;
+        }
         label {
             width: 90px;
             display: inline-block;
@@ -2965,6 +2982,29 @@ ul.attendance__notes {
         select, input[type="text"] {
             vertical-align: top;
         }
+    }
+
+    #group-interests-form {
+        margin-bottom: 30px;
+        display: flex;
+        justify-content: center;
+    }
+
+    .group-select {
+        font-size: 0.8em;
+        opacity: 0.8;
+        background-color: $colour_grey;
+        flex: 1;
+        margin-right: 10px;
+    }
+
+    .selected {
+        background-color: $colour_terracotta;
+        opacity: 0.95;
+    }
+
+    sup {
+        font-size: 0.8em;
     }
 }
 
@@ -3514,5 +3554,5 @@ ul.attendance__notes {
             color: #333;
         }
     }
-    
+
 }

--- a/pombola/south_africa/templates/interests_register/index.html
+++ b/pombola/south_africa/templates/interests_register/index.html
@@ -18,66 +18,76 @@
     </div>
 </div>
 
-<h3>Filter</h3>
-
 <div class="members-interests-filter">
-<form action="{% url 'sa-interests-index' %}" method="get">
+  <div>
+    <form id="group-interests-form" action="{% url 'sa-interests-index' %}" method="get">
+      <button name="display" value="all" class="button group-select {% if display == 'all' %} selected{% endif %}">
+        All Declarations <br> per MP
+      </button>
+      <button name="display" value="numberbyrepresentative" class="button group-select {% if display == 'numberbyrepresentative' %} selected{% endif %}">
+        Number of Declarations <br> per MP
+      </button>
+      <button name="display" value="numberbysource"
+        class="button group-select {% if display == 'numberbysource' %} selected{% endif %}">
+        Number of Declarations <br> per Source
+      </button>
+    </form>
+    <hr>
+  </div>
 
-<div class="filter-option">
-    <label for="display">Display:</label>
-    <select name="display" id="display">
-        <option value="all"{% if display == "all" %} selected="selected"{% endif %}>
-            All Declarations
-        </option>
-        <option value="numberbyrepresentative"{% if display == "numberbyrepresentative" %} selected="selected"{% endif %}>
-            Number of Declarations per MP
-        </option>
-        <option value="numberbysource"{% if display == "numberbysource" %} selected="selected"{% endif %}>
-            Number of Declarations per Source (gifts, benefits, pensions, and sponsorships only)
-        </option>
-    </select>
-</div>
+  <form action="{% url 'sa-interests-index' %}" method="get">
+    <h3>Filter results by:</h3>
+    {% if display == "all" %}
+    <input type="hidden" name="display" value="all">
+    {% elif display == "numberbyrepresentative" %}
+    <input type="hidden" name="display" value="numberbyrepresentative">
+    {% elif display == "numberbysource" %}
+    <input type="hidden" name="display" value="numberbysource">
+    {% endif %}
 
-<div class="filter-option">
-    <label for="category">Category:</label>
-    <select name="category">
+    {% if display == "all" %}
+    <div class="filter-option">
+      <label for="party">Party:</label>
+      <select name="party" id="party">
+        <option value="all" {% if party == "all" %} selected="selected" {% endif %}>All</option>
+        {% for o in parties %}
+        <option value="{{ o.slug }}" {% if party == o.slug %} selected="selected" {% endif %}>
+          {{ o.name }}
+        </option>
+        {% endfor %}
+        <option value="other" {% if party == "other" %} selected="selected" {% endif %}>Other parties</option>
+      </select>
+    </div>
+    {% endif %}
+
+    <div class="filter-option">
+      <label for="category">Category:</label>
+      <select name="category">
         <option value="all"{% if category == "all" %} selected="selected"{% endif %}>All</option>
         {% for c in categories %}
           <option value="{{ c.slug }}"{% if category == c.slug %} selected="selected"{% endif %}>
               {{ c.name }}
           </option>
         {% endfor %}
-    </select>
-</div>
+      </select>
+      {% if display == 'numberbysource' %}
+      <sup>(Sponsorships, gifts, benefits and pensions only)</sup>
+      {% endif %}
+    </div>
 
-<div class="filter-option">
-    <label for="party">Party:</label>
-    <select name="party" id="party">
-        <option value="all"{% if party == "all" %} selected="selected"{% endif %}>All</option>
-        {% for o in parties %}
-          <option value="{{ o.slug }}"{% if party == o.slug %} selected="selected"{% endif %}>
-              {{ o.name }}
-          </option>
-        {% endfor %}
-        <option value="other"{% if party == "other" %} selected="selected"{% endif %}>Other parties</option>
-    </select>
-</div>
-
-<div class="filter-option">
-    <label for="release">Year:</label>
-    <select name="release">
-        <option value="all"{% if release == "all" %} selected="selected"{% endif %}>All</option>
+    <div class="filter-option">
+      <label for="release">Year:</label>
+      <select name="release">
         {% for r in releases %}
-          <option value="{{ r.slug }}"{% if release == r.slug %} selected="selected"{% endif %}>
-              {{ r.name }}
-          </option>
+        <option value="{{ r.slug }}"{% if release == r.slug %} selected="selected"{% endif %}>
+          {{ r.name }}
+        </option>
         {% endfor %}
-    </select>
-</div>
+      </select>
+    </div>
 
-<input type="submit" value="Filter" class="button">
-
-</form>
+    <input type="submit" value="Filter" class="button">
+  </form>
 </div>
 
 {% if layout == "numberbyrepresentative" %}
@@ -89,6 +99,5 @@
 {% elif layout == "section" %}
   {% include "interests_register/index_section.html" %}
 {% endif %}
-
 
 {% endblock %}

--- a/pombola/south_africa/views/interests.py
+++ b/pombola/south_africa/views/interests.py
@@ -321,6 +321,12 @@ class SAMembersInterestsIndex(TemplateView):
     def get_numberbysource_view(self, context):
         release_content_type = ContentType.objects.get_for_model(Release)
 
+        context['categories'] = Category.objects.filter(
+            slug__in=['sponsorships',
+                      'gifts-and-hospitality',
+                      'benefits',
+                      'pensions'])
+
         # numberbysource view - number of declarations by source per category
         context['layout'] = 'numberbysource'
         if context['category'] == 'all' and context['release'] == 'all':


### PR DESCRIPTION
A few improvements to improve user interaction with the filters on the MP assets list page.
https://www.pa.org.za/interests/

Different ways to group the data was separated from the filters to make that fact more obvious.
e.g. Number of declarations per MP. A user now selects the way tp group the results first, and then filters those results.

Only the appropriate categories are returned when viewing the numbers by source.

![image](https://user-images.githubusercontent.com/11753432/62203512-a0233a00-b38b-11e9-9994-31c2db240987.png)
