### PR TITLE
Upgrade sorl-thumbnail and Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 ### General useful bits
 py-bcrypt==0.4
 PyYAML==5.1
-Pillow==3.2.0
+Pillow==6.1.0
 
 ### Database drivers
 psycopg2==2.8.2
@@ -28,7 +28,7 @@ djangorestframework==3.3.2
 django-registration-defaults==0.3
 
 ### Pombola dependencies
-sorl-thumbnail==12.3
+sorl-thumbnail==12.4.1
 django_date_extensions==0.1dev
 django-ajax-selects==1.4.2
 django-autocomplete-light==2.3.3


### PR DESCRIPTION
When we upgraded Pillow before we started seeing errors like the
following:

     IOError: cannot write mode RGBA as JPEG

As a quick workaround we just downgraded Pillow, but that created a
different error:

     IOError: encoder error -2 when writing image file

I've dug into this a bit more and it seems that the first error is fixed
in sorl-thumbnail 12.4.1. I think I tried upgrading to the latest sorl,
but that isn't compatible with Django 1.8, which is the version we're
currently on. So this change upgrades to the latest version of Pillow,
and to the latest compatible version of sorl.

Fixes https://github.com/mysociety/pombola/issues/2649
Fixes https://github.com/mysociety/pombola/issues/2669