### PR TITLE
Only display ministers without a party, when not filtered by party

### DIFF
--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -990,6 +990,15 @@ class SAMpAttendancePageTest(TestCase):
         self.assertEqual(context['attendance_data'], expected)
 
 
+        # When filtered by party, only display ministers with active memberships
+        url = "%s?year=2000&party=PARTY1" % reverse('mp-attendance')
+        context = self.client.get(url).context
+
+        expected = [
+            {'name': u'3, P', 'pa_url': u'/person/person3/', 'party_name': u'PARTY1', 'position': u'deputy-minister', 'present': 0}]
+        self.assertEqual(context['attendance_data'], expected)
+
+
     def test_divide_2019_attendance_records_pre_and_post_elections(self):
         # Pre election: 01/01/2019 - 30/06/2019
         # Post election: 01/07/2019 - 31/12/2019

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -193,8 +193,12 @@ class SAMpAttendanceView(TemplateView):
             for slug in minister_slugs:
                 minister = ministers[slug][0].person
                 position = ministers[slug][-1].title.slug
-                if ctx_party and minister.parties()[0].slug.upper() != ctx_party:
-                    # Only include ministers belonging to the party selected.
+                if ctx_party and not minister.parties():
+                    # Some previous ministers are not currently a member of a party.
+                    # Don't display them when a party is selected, but do all parties are shown.
+                    continue
+                if ctx_party and minister.parties() and minister.parties()[0].slug.upper() != ctx_party:
+                    # Don't show ministers who aren't currently members of the party selected.
                     continue
                 else:
                     minister_attendance.append(self.build_minister_zero_attendance(minister, position))

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -194,8 +194,8 @@ class SAMpAttendanceView(TemplateView):
                 minister = ministers[slug][0].person
                 position = ministers[slug][-1].title.slug
                 if ctx_party and not minister.parties():
-                    # Some previous ministers are not currently a member of a party.
-                    # Don't display them when a party is selected, but do all parties are shown.
+                    # Some previous ministers are no longer a member of a party.
+                    # Don't display them when a party is selected, but do when all parties are shown.
                     continue
                 if ctx_party and minister.parties() and minister.parties()[0].slug.upper() != ctx_party:
                     # Don't show ministers who aren't currently members of the party selected.


### PR DESCRIPTION
@chrismytton 

Some previous ministers are no longer members of parties. We need to check for this before trying to access an element in the parties list.

We also only display these ministers when the page is not filtered by party.