### PR TITLE
Update version requirement for pdftohtml

### DIFF
--- a/pombola/hansard/kenya_parser.py
+++ b/pombola/hansard/kenya_parser.py
@@ -126,7 +126,7 @@ class KenyaParser():
             shell = False,
             stderr = subprocess.PIPE,
         ).communicate()
-        wanted_version = 'pdftohtml version 0.18.4'
+        wanted_version = 'pdftohtml version 0.48.0'
         if wanted_version not in version_error:
             raise Exception( "Bad pdftohtml version - got '%s' but want '%s'" % (version_error, wanted_version) )
 


### PR DESCRIPTION
This doesn't seem to cause any problems that I can see in the parsing. Closes #2680 